### PR TITLE
release: v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-04-01
+
+### Fixed
+
+- **`resid` restraint selections now match PDB residue numbers correctly.**
+  The restraint atom selection parser (`_parse_selection`) used OpenMM's
+  sequential 0-based `Residue.index` and assumed a simple `resid - 1`
+  conversion, which only worked when PDB numbering started at 1 with no gaps.
+  For structures with non-standard starting residue numbers (e.g., PDB 4TGL
+  starting at residue 5), the offset was wrong and selections like
+  `resid 144 and name OG` would silently target the wrong residue or fail
+  with "No atoms match selection". Now uses `Residue.id` (the PDB `resSeq`
+  number) for direct matching without any offset arithmetic.
+  (`core/restraints.py`)
+
 ## [1.2.0] - 2026-03-24
 
 ### Added

--- a/pixi.lock
+++ b/pixi.lock
@@ -8069,8 +8069,8 @@ packages:
   requires_python: ~=3.11
 - pypi: ./
   name: polyzymd
-  version: 1.2.0
-  sha256: 36b864b491a0c7fd7ba3d84f2b8786a9d35631c358521d40450da8242bcf3302
+  version: 1.2.1
+  sha256: 5632037f68f78d0eb6fb98e1d8036b58a49226f7c2ecb1847f4909f98fbce36f
   requires_dist:
   - pydantic>=2.0.0
   - pyyaml>=6.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -43,7 +43,7 @@
 
 [workspace]
 name        = "polyzymd"
-version     = "1.2.0"
+version     = "1.2.1"
 description = "MD simulations for enzyme-polymer systems"
 channels    = ["conda-forge"]
 platforms   = ["linux-64", "osx-arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "polyzymd"
-version = "1.2.0"
+version = "1.2.1"
 description = "Molecular dynamics simulation toolkit for enzyme-polymer systems"
 readme = "README.md"
 license = "MIT"

--- a/src/polyzymd/__init__.py
+++ b/src/polyzymd/__init__.py
@@ -26,7 +26,7 @@ Note:
     modules require a full pixi environment with OpenMM and OpenFF installed.
 """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __author__ = "Joseph R. Laforet Jr."
 __email__ = "jola3134@colorado.edu"
 

--- a/src/polyzymd/analysis/cli.py
+++ b/src/polyzymd/analysis/cli.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 import click
 
+from polyzymd.cli.colors import echo_logo
 from polyzymd.core.branding import SHORT_CREDIT_LINE
 from polyzymd.core.experimental import echo_experimental_warning
 
@@ -24,8 +25,8 @@ LOGGER = logging.getLogger("polyzymd.analysis")
 
 
 def _echo_branding() -> None:
-    """Print short PolyzyMD branding for top-level analysis commands."""
-    click.echo(SHORT_CREDIT_LINE)
+    """Print the PolyzyMD ASCII logo for top-level analysis commands."""
+    echo_logo()
 
 
 # =============================================================================

--- a/src/polyzymd/cli/colors.py
+++ b/src/polyzymd/cli/colors.py
@@ -440,3 +440,56 @@ def render_progress_bar(
     filled = int(fraction * width)
     bar = _FILLED_CHAR * filled + _EMPTY_CHAR * (width - filled)
     return _colorize(bar, status)
+
+
+# ---------------------------------------------------------------------------
+# ASCII logo rendering
+# ---------------------------------------------------------------------------
+
+# Logo color definitions: (RGB, xterm-256 index, basic ANSI code)
+_LOGO_GOLD = ((215, 185, 120), 179, "\033[33m")  # warm gold for "Polyzy"
+_LOGO_GREEN = ((80, 180, 120), 78, "\033[32m")  # forest green for "MD"
+_LOGO_DIM = ((145, 140, 120), 144, "\033[37m")  # muted tone for credit line
+
+
+def _logo_escape(color: tuple[tuple[int, int, int], int, str]) -> str:
+    """Return the ANSI open escape for a logo color tuple."""
+    support = get_color_support()
+    if support is TerminalColorSupport.NONE:
+        return ""
+    rgb, xterm, basic = color
+    if support is TerminalColorSupport.TRUECOLOR:
+        r, g, b = rgb
+        return f"\033[38;2;{r};{g};{b}m"
+    if support is TerminalColorSupport.EXTENDED:
+        return f"\033[38;5;{xterm}m"
+    return basic
+
+
+def echo_logo() -> None:
+    """Print the two-tone PolyzyMD ASCII logo to stdout.
+
+    "Polyzy" is rendered in warm gold and "MD" in forest green,
+    matching the project's visual branding.  Color output respects
+    the current ``TerminalColorSupport`` level (including ``NO_COLOR``).
+    """
+    from polyzymd.core.branding import (
+        CREDIT_LINE,
+        LOGO_GAP,
+        LOGO_MD_LINES,
+        LOGO_POLYZY_LINES,
+    )
+
+    gold = _logo_escape(_LOGO_GOLD)
+    green = _logo_escape(_LOGO_GREEN)
+    dim = _logo_escape(_LOGO_DIM)
+    reset = "\033[0m" if get_color_support() is not TerminalColorSupport.NONE else ""
+
+    indent = "  "
+    for left, right in zip(LOGO_POLYZY_LINES, LOGO_MD_LINES):
+        click.echo(f"{indent}{gold}{left}{reset}{LOGO_GAP}{green}{right}{reset}")
+
+    # Blank line then centered credit
+    click.echo()
+    logo_width = len(LOGO_POLYZY_LINES[0]) + len(LOGO_GAP) + len(LOGO_MD_LINES[0])
+    click.echo(f"{indent}{dim}{CREDIT_LINE:^{logo_width}}{reset}")

--- a/src/polyzymd/cli/colors.py
+++ b/src/polyzymd/cli/colors.py
@@ -485,6 +485,10 @@ def echo_logo() -> None:
     dim = _logo_escape(_LOGO_DIM)
     reset = "\033[0m" if get_color_support() is not TerminalColorSupport.NONE else ""
 
+    # Two blank lines before the logo for vertical breathing room
+    click.echo()
+    click.echo()
+
     indent = "  "
     for left, right in zip(LOGO_POLYZY_LINES, LOGO_MD_LINES):
         click.echo(f"{indent}{gold}{left}{reset}{LOGO_GAP}{green}{right}{reset}")

--- a/src/polyzymd/cli/colors.py
+++ b/src/polyzymd/cli/colors.py
@@ -496,3 +496,4 @@ def echo_logo() -> None:
     click.echo()
     logo_width = len(LOGO_POLYZY_LINES[0]) + len(LOGO_GAP) + len(LOGO_MD_LINES[0])
     click.echo(f"{indent}{dim}{CREDIT_LINE:^{logo_width}}{reset}")
+    click.echo()

--- a/src/polyzymd/cli/colors.py
+++ b/src/polyzymd/cli/colors.py
@@ -485,8 +485,7 @@ def echo_logo() -> None:
     dim = _logo_escape(_LOGO_DIM)
     reset = "\033[0m" if get_color_support() is not TerminalColorSupport.NONE else ""
 
-    # Two blank lines before the logo for vertical breathing room
-    click.echo()
+    # Blank line before the logo for vertical breathing room
     click.echo()
 
     indent = "  "

--- a/src/polyzymd/cli/main.py
+++ b/src/polyzymd/cli/main.py
@@ -21,7 +21,7 @@ from typing import Optional
 
 import click
 
-from polyzymd.cli.colors import colored_echo, setup_colored_logging
+from polyzymd.cli.colors import colored_echo, echo_logo, setup_colored_logging
 from polyzymd.core.branding import SHORT_CREDIT_LINE, prepend_file_header
 
 # Bootstrap a minimal root handler so suppress_openff_logs() works at import
@@ -34,8 +34,8 @@ LOGGER = logging.getLogger("polyzymd")
 
 
 def _echo_branding(phase: str = "cli") -> None:
-    """Print short PolyzyMD branding for top-level user-facing commands."""
-    colored_echo(SHORT_CREDIT_LINE, phase=phase)
+    """Print the PolyzyMD ASCII logo for top-level user-facing commands."""
+    echo_logo()
 
 
 def suppress_openff_logs() -> None:

--- a/src/polyzymd/compare/cli.py
+++ b/src/polyzymd/compare/cli.py
@@ -14,6 +14,7 @@ from typing import Optional
 import click
 import yaml
 
+from polyzymd.cli.colors import echo_logo
 from polyzymd.compare.cli_utils import (
     common_compare_options,
     load_comparison_config,
@@ -47,8 +48,8 @@ LOGGER = logging.getLogger("polyzymd.compare.cli")
 
 
 def _echo_branding() -> None:
-    """Print short PolyzyMD branding for top-level comparison commands."""
-    click.echo(SHORT_CREDIT_LINE)
+    """Print the PolyzyMD ASCII logo for top-level comparison commands."""
+    echo_logo()
 
 
 # ---------------------------------------------------------------------------

--- a/src/polyzymd/core/branding.py
+++ b/src/polyzymd/core/branding.py
@@ -6,7 +6,28 @@ from collections.abc import Sequence
 
 FULL_CREDIT_LINE = "PolyzyMD: Created by Joseph R. Laforet Jr."
 SHORT_CREDIT_LINE = "PolyzyMD by Joseph R. Laforet Jr."
+CREDIT_LINE = "Created by Joseph R. Laforet Jr."
 PLOT_WATERMARK = "Made by PolyzyMD"
+
+# ---------------------------------------------------------------------------
+# ASCII art logo (block-character style)
+# ---------------------------------------------------------------------------
+# Split into "Polyzy" (left) and "MD" (right) for two-tone CLI coloring.
+# Each list has 3 rows; all entries in a list are the same character width.
+
+LOGO_POLYZY_LINES: list[str] = [
+    "█▀▀▄ █▀▀█ █   █   █ ▀▀▀█ █   █",
+    "█▄▄▀ █  █ █    ▀█▀   ▄▀   ▀█▀ ",
+    "█    █▄▄█ █▄▄▄  █   █▄▄▄   █  ",
+]
+
+LOGO_MD_LINES: list[str] = [
+    "█▄ ▄█ █▀▀▄",
+    "█ █ █ █  █",
+    "█   █ █▄▄▀",
+]
+
+LOGO_GAP = "  "  # gap between "Polyzy" and "MD" halves
 
 
 def file_header_lines(comment_prefix: str = "#", *, width: int = 76) -> list[str]:

--- a/src/polyzymd/core/restraints.py
+++ b/src/polyzymd/core/restraints.py
@@ -104,7 +104,7 @@ def _parse_selection(selection: str, topology: OpenMMTopology) -> List[int]:
                 "index": atom.index,
                 "name": atom.name.lower() if atom.name else "",
                 "resname": atom.residue.name.lower() if atom.residue else "",
-                "resid": atom.residue.index,  # 0-indexed internally
+                "resid": int(atom.residue.id),  # PDB residue number (resSeq)
                 "chain": atom.residue.chain.id if atom.residue and atom.residue.chain else "",
             }
         )
@@ -131,8 +131,8 @@ def _parse_selection(selection: str, topology: OpenMMTopology) -> List[int]:
         matching = set()
 
         if keyword == "resid":
-            # resid is 1-indexed in selection (matches PDB), 0-indexed internally
-            target_resid = int(value) - 1
+            # resid matches PDB residue number (resSeq) directly
+            target_resid = int(value)
             for atom in atoms_data:
                 if atom["resid"] == target_resid:
                     matching.add(atom["index"])


### PR DESCRIPTION
## Summary

Patch release v1.2.1 with a targeted bugfix and cosmetic CLI improvements.

### Fixed
- **`resid` restraint selections now match PDB residue numbers correctly.** The restraint atom selection parser used OpenMM's sequential 0-based `Residue.index` with a simple `resid - 1` conversion, which broke for structures with non-standard starting residue numbers (e.g., PDB 4TGL starting at residue 5). Now uses `Residue.id` (the PDB `resSeq` number) for direct matching. (`core/restraints.py`)

### Changed
- Added two-tone ASCII art logo banner to CLI entry points with adjusted vertical spacing.
- Version bumped to 1.2.1 in `pyproject.toml`, `src/polyzymd/__init__.py`, and `pixi.toml`.

### Note
The analysis OCP-compliance refactor (`refactor/analysis-ocp-compliance`) will ship separately as v1.3.0.