### PR TITLE
docs: group sidebar navigation with captioned toctrees and grid cards

### DIFF
--- a/docs/source/explanation/index.md
+++ b/docs/source/explanation/index.md
@@ -1,49 +1,56 @@
 # Explanation
 
-Explanation pages help you understand why PolyzyMD works the way it does, how
+Explanation pages help you understand *why* PolyzyMD works the way it does, how
 to interpret outputs, and what assumptions or tradeoffs matter.
+
+```{tip}
+Looking for step-by-step instructions? Go to {doc}`../how_to/index`.
+Need to look up a setting or option? Go to {doc}`../reference/index`.
+```
+
+::::{grid} 2
+:gutter: 3
+
+:::{grid-item-card} Concepts and Design
+:link: analysis_concepts
+:link-type: doc
+
+How the analysis pipeline, chain conventions, and plugin architecture fit
+together.
+:::
+
+:::{grid-item-card} Interpretation and Best Practices
+:link: analysis_statistics_best_practices
+:link-type: doc
+
+Replication, convergence, multiple testing, and per-plugin best practices.
+:::
+
+:::{grid-item-card} Experimental Analysis Concepts
+:link: polymer_bridging_interpretation
+:link-type: doc
+
+Interpretation guidance for experimental analysis workflows.
+:::
+
+::::
 
 ## Concepts and Design
 
-- [Analysis System Concepts](analysis_concepts.md) — How the analysis pipeline, comparison.yaml, conditions, replicates, and plugins fit together.
-- [Architecture](architecture.md)
-- [Residue Assignment and Chain Conventions](residue_assignment.md)
-- [Colored Logging](colored_logging.md)
-
-## Analysis Interpretation and Best Practices
-
-- [Statistical Best Practices for Analysis](analysis_statistics_best_practices.md)
-- [RMSD Best Practices](analysis_rmsd_best_practices.md)
-- [Establishing Convergence in MD Simulations](convergence_detection.md) — Conceptual guide to convergence detection: what it means, how PolyzyMD's sliding-window heuristic works, and when to tune parameters.
-- [Rg Best Practices](analysis_rg_best_practices.md)
-- [RMSF Best Practices](analysis_rmsf_best_practices.md)
-- [RMSF Reference Selection](analysis_reference_selection.md)
-- [RMSF Verification](analysis_rmsf_verification.md)
-- [Catalytic Triad Best Practices](analysis_triad_best_practices.md)
-
-## Experimental Analysis Concepts
-
-These workflows remain available in PolyzyMD, but their interpretation is still
-evolving and they should be treated as experimental:
-
-- [Binding Preference](../how_to/analysis_binding_preference.md)
-- [Binding Free Energy](../how_to/analysis_binding_free_energy.md)
-- [Polymer Affinity](../how_to/analysis_polymer_affinity.md)
-- [Polymer Bridging Interpretation](polymer_bridging_interpretation.md)
-- [Exposure Dynamics](../how_to/analysis_exposure_dynamics.md)
-
-<!-- IMAGE OPPORTUNITY: Add a chain-convention figure (A/B/C/D+), plus a simple
-stable-vs-experimental analysis map to orient users before they dive into the
-longer conceptual pages. -->
-
 ```{toctree}
-:hidden:
 :maxdepth: 1
 
-Architecture <architecture>
 Analysis System Concepts <analysis_concepts>
+Architecture <architecture>
 Residue Assignment and Chain Conventions <residue_assignment>
 Colored Logging <colored_logging>
+```
+
+## Interpretation and Best Practices
+
+```{toctree}
+:maxdepth: 1
+
 Statistical Best Practices for Analysis <analysis_statistics_best_practices>
 RMSD Best Practices <analysis_rmsd_best_practices>
 Convergence Detection <convergence_detection>
@@ -52,5 +59,19 @@ RMSF Best Practices <analysis_rmsf_best_practices>
 RMSF Reference Selection <analysis_reference_selection>
 RMSF Verification <analysis_rmsf_verification>
 Catalytic Triad Best Practices <analysis_triad_best_practices>
+```
+
+## Experimental Analysis Concepts
+
+These workflows remain available in PolyzyMD, but their interpretation is still
+evolving and they should be treated as experimental. See also the how-to guides
+for {doc}`../how_to/analysis_binding_preference`,
+{doc}`../how_to/analysis_binding_free_energy`,
+{doc}`../how_to/analysis_polymer_affinity`, and
+{doc}`../how_to/analysis_exposure_dynamics`.
+
+```{toctree}
+:maxdepth: 1
+
 Polymer Bridging Interpretation <polymer_bridging_interpretation>
 ```

--- a/docs/source/how_to/index.md
+++ b/docs/source/how_to/index.md
@@ -3,62 +3,50 @@
 How-to guides help you accomplish a specific task. Use this section when you
 already know your goal and need the shortest practical route to it.
 
-## Simulation Setup
-
-- [Add Polymers to a Simulation](polymers.md)
-- [Generate Polymers from SMILES](dynamic_polymers.md)
-- [Add Distance Restraints](restraints.md)
-- [Set Up Equilibration Stages](equilibration.md)
-- [Run GROMACS Simulations on HPC Clusters](gromacs_export.md)
-
-## HPC and Job Submission
-
-- [Run Simulations on SLURM Clusters](hpc_slurm.md)
-- [Submit Analysis Jobs to SLURM](hpc_execution.md)
-
-## Stable Analysis Workflows
-
-These analyses are production-ready with validated statistics:
-
-- [Which Analysis Should I Run?](analysis_chooser.md) -- pick the right plugins
-  for your research question
-- [Compare Simulation Conditions](analysis_compare_conditions.md) -- set up
-  `comparison.yaml` and run cross-condition analysis
-- [Run RMSD Analysis](analysis_rmsd_quickstart.md)
-- [Run Rg Analysis](analysis_rg_quickstart.md)
-- [Run RMSF Analysis](analysis_rmsf_quickstart.md)
-- [Run Distance Analysis](analysis_distances_quickstart.md)
-- [Run Contacts Analysis](analysis_contacts_quickstart.md)
-- [Run SASA Analysis](../tutorials/sasa_analysis.md)
-- [Analyze Hydrogen Bonds](hydrogen_bonds.md)
-- [Run Catalytic Triad Analysis](analysis_triad_quickstart.md)
-
-## Experimental Analysis Workflows
-
-```{warning}
-These analyses are functional but their interpretation guidance is still
-evolving. Results should be treated as exploratory.
+```{tip}
+If you're new to PolyzyMD, start with {doc}`../tutorials/index` instead.
+These guides assume you already have a working installation and know the
+basics.
 ```
 
-- [Analyze Binding Preference](analysis_binding_preference.md)
-- [Analyze Binding Free Energy](analysis_binding_free_energy.md)
-- [Analyze Polymer Affinity](analysis_polymer_affinity.md)
-- [Analyze Polymer Bridging](analysis_polymer_bridging.md)
-- [Analyze Exposure Dynamics](analysis_exposure_dynamics.md)
+::::{grid} 2
+:gutter: 3
 
-## Plot Customization
+:::{grid-item-card} Simulation Setup
+:link: polymers
+:link-type: doc
 
-- [Customizing Plots for Publication](publication_plots.md)
+Add polymers, restraints, equilibration stages, or export to GROMACS.
+:::
 
-## Recipes and Troubleshooting
+:::{grid-item-card} Analysis Workflows
+:link: analysis_chooser
+:link-type: doc
 
-- [Contacts Cookbook](analysis_contacts_cookbook.md) -- advanced selection
-  patterns, custom criteria, and Python API usage
-- [Broken Molecule Debugging](broken_molecules_debugging.md)
-- [Troubleshoot Common Problems](troubleshooting.md)
+Pick the right analysis plugin and get results in a few commands.
+:::
+
+:::{grid-item-card} HPC & Job Submission
+:link: hpc_slurm
+:link-type: doc
+
+Submit simulations or analysis jobs via SLURM.
+:::
+
+:::{grid-item-card} Plots & Troubleshooting
+:link: publication_plots
+:link-type: doc
+
+Adjust themes, colors, and figure sizes for publication-quality output.
+:::
+
+::::
+
+## Simulation Setup
+
+Build and configure your enzyme-polymer conjugate systems.
 
 ```{toctree}
-:hidden:
 :maxdepth: 1
 
 Add Polymers to a Simulation <polymers>
@@ -66,8 +54,27 @@ Generate Polymers from SMILES <dynamic_polymers>
 Add Distance Restraints <restraints>
 Set Up Equilibration Stages <equilibration>
 Run GROMACS Simulations on HPC Clusters <gromacs_export>
+```
+
+## HPC & Job Submission
+
+Run on SLURM clusters — from individual jobs to daisy-chained workflows.
+
+```{toctree}
+:maxdepth: 1
+
 Run Simulations on SLURM Clusters <hpc_slurm>
 Submit Analysis Jobs to SLURM <hpc_execution>
+```
+
+## Stable Analysis Workflows
+
+These analysis plugins are well-tested and recommended for production use.
+See also {doc}`../tutorials/sasa_analysis` for a guided SASA walkthrough.
+
+```{toctree}
+:maxdepth: 1
+
 Which Analysis Should I Run? <analysis_chooser>
 Compare Simulation Conditions <analysis_compare_conditions>
 Run RMSD Analysis <analysis_rmsd_quickstart>
@@ -75,14 +82,34 @@ Run Rg Analysis <analysis_rg_quickstart>
 Run RMSF Analysis <analysis_rmsf_quickstart>
 Run Distance Analysis <analysis_distances_quickstart>
 Run Contacts Analysis <analysis_contacts_quickstart>
-Run SASA Analysis <../tutorials/sasa_analysis>
 Analyze Hydrogen Bonds <hydrogen_bonds>
 Run Catalytic Triad Analysis <analysis_triad_quickstart>
+```
+
+## Experimental Analysis Workflows
+
+```{warning}
+These workflows are available in PolyzyMD but their interpretation is still
+evolving. Treat results as exploratory, not settled science.
+```
+
+```{toctree}
+:maxdepth: 1
+
 Analyze Binding Preference <analysis_binding_preference>
 Analyze Binding Free Energy <analysis_binding_free_energy>
 Analyze Polymer Affinity <analysis_polymer_affinity>
 Analyze Polymer Bridging <analysis_polymer_bridging>
 Analyze Exposure Dynamics <analysis_exposure_dynamics>
+```
+
+## Plots & Troubleshooting
+
+Customize publication-quality figures and debug common issues.
+
+```{toctree}
+:maxdepth: 1
+
 Customizing Plots for Publication <publication_plots>
 Contacts Cookbook <analysis_contacts_cookbook>
 Broken Molecule Debugging <broken_molecules_debugging>

--- a/docs/source/reference/analysis_plugin_settings.md
+++ b/docs/source/reference/analysis_plugin_settings.md
@@ -1,0 +1,225 @@
+# Analysis Plugin Settings Reference
+
+This page is a complete YAML key reference for plugin settings under
+`comparison.yaml`:
+
+```yaml
+plugins:
+  <plugin_name>:
+    ...settings...
+```
+
+Use this as a lookup table for field names, types, defaults, and meanings.
+
+## `rmsf`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `selection` | `str` | `"protein and name CA"` | MDAnalysis selection used for RMSF calculation |
+| `reference_mode` | `str` | `"centroid"` | Reference mode: `centroid`, `average`, `frame`, or `external` |
+| `reference_frame` | `int \| null` | `null` | Frame number used when `reference_mode: frame` (1-indexed) |
+| `reference_file` | `str \| null` | `null` | External PDB path used when `reference_mode: external` |
+| `alignment_selection` | `str` | `"protein and name CA"` | Selection used for trajectory alignment |
+| `centroid_selection` | `str` | `"protein"` | Selection used to find centroid frame |
+
+## `catalytic_triad`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | `"catalytic_triad"` | Name of the triad/active-site definition |
+| `pairs` | `list[TriadPairSettings]` | required | Distance pairs to monitor |
+| `threshold` | `float` | `3.5` | Contact threshold in Å |
+| `description` | `str \| null` | `null` | Optional human-readable description |
+
+`TriadPairSettings` entries in `pairs`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `label` | `str` | required | Human-readable pair name |
+| `selection_a` | `str` | required | First atom/point selection |
+| `selection_b` | `str` | required | Second atom/point selection |
+
+## `distances`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `threshold` | `float \| null` | `3.5` | Global distance threshold (Å) for contact-style state analysis |
+| `pairs` | `list[DistancePairSettings]` | `[]` (must be non-empty) | Distance pairs to monitor |
+| `use_pbc` | `bool` | `true` | Use minimum-image PBC-aware distances |
+| `align_trajectory` | `bool` | `true` | Align trajectory before distance calculations |
+| `alignment_selection` | `str` | `"protein and name CA"` | Selection for alignment |
+| `alignment_mode` | `str` | `"centroid"` | Alignment reference mode: `centroid`, `average`, or `frame` |
+| `alignment_frame` | `int \| null` | `null` | Frame index (1-indexed) when `alignment_mode: frame` |
+| `fdr_alpha` | `float` | `0.05` | Benjamini-Hochberg false-discovery-rate alpha |
+
+`DistancePairSettings` entries in `pairs`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `label` | `str` | required | Human-readable pair name |
+| `selection_a` | `str` | required | First atom/point selection |
+| `selection_b` | `str` | required | Second atom/point selection |
+| `threshold` | `float \| null` | `null` | Per-pair threshold override (falls back to global `threshold`) |
+| `below_label` | `str \| null` | `null` | Display label for below-threshold state |
+| `above_label` | `str \| null` | `null` | Display label for above-threshold state |
+
+## `contacts`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `polymer_selection` | `str` | `"chainID C"` | MDAnalysis selection for polymer atoms |
+| `protein_selection` | `str` | `"protein"` | MDAnalysis selection for protein atoms |
+| `cutoff` | `float` | `4.5` | Contact cutoff distance in Å |
+| `polymer_types` | `list[str] \| null` | `null` | Optional polymer residue-name filter |
+| `grouping` | `str` | `"aa_class"` | Grouping mode: `aa_class`, `secondary_structure`, or `none` |
+| `compute_residence_times` | `bool` | `true` | Compute residence-time statistics |
+| `compute_binding_preference` | `bool` | `false` | Enable binding-preference enrichment sub-analysis |
+| `surface_exposure_threshold` | `float` | `0.2` | Relative SASA threshold for surface-exposed residues |
+| `enzyme_pdb_for_sasa` | `str \| null` | `null` | Optional PDB path for SASA calculations |
+| `include_default_aa_groups` | `bool` | `true` | Include built-in amino-acid class groups |
+| `protein_groups` | `dict[str, list[int]] \| null` | `null` | Custom residue groups, e.g. `{name: [resid, ...]}` |
+| `protein_partitions` | `dict[str, list[str]] \| null` | `null` | Partition definitions over custom `protein_groups` |
+| `polymer_type_selections` | `dict[str, str] \| null` | `null` | Custom polymer-type selections |
+| `polymer_chain` | `str` | `"C"` | Polymer chain ID for auto-detection |
+| `enrichment_normalization` | `str` | `"residue"` | Deprecated compatibility key (ignored at runtime) |
+| `fdr_alpha` | `float` | `0.05` | Benjamini-Hochberg false-discovery-rate alpha |
+| `min_effect_size` | `float` | `0.5` | Minimum Cohen's d highlighted in output |
+| `top_residues` | `int` | `10` | Number of top-contact residues shown in summaries |
+
+## `secondary_structure`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `chain_id` | `str` | `"A"` | Protein chain letter to analyze (PolyzyMD convention: chain A) |
+
+## `sasa`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `runs` | `list[SASARunSettings]` | `[]` (must be non-empty) | SASA runs to compute |
+| `probe_radius_nm` | `float` | `0.14` | Shrake-Rupley probe radius (nm) |
+| `n_sphere_points` | `int` | `960` | Shrake-Rupley sphere point count |
+| `chunk_size` | `int` | `100` | Frames per chunk for SASA computation |
+| `fdr_alpha` | `float` | `0.05` | Benjamini-Hochberg false-discovery-rate alpha |
+
+`SASARunSettings` entries in `runs`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `label` | `str` | required | Human-readable run label |
+| `target_selection` | `str` | required | Selection whose SASA is reported |
+| `context_selection` | `str \| null` | `null` | Environment/context selection for SASA computation (`null` defaults to `target_selection`) |
+| `stride` | `int` | `1` | Frame stride (1 means every frame) |
+
+## `hydrogen_bonds`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `groups` | `dict[str, str]` | `{protein: "chainid A", polymer: "chainid C"}` | Named MDAnalysis selections used by summaries |
+| `summaries` | `list[HydrogenBondSummarySettings]` | `[{name: protein_polymer, between: [protein, polymer]}]` | Summary definitions to compute |
+| `distance_cutoff` | `float` | `3.0` | Donor-acceptor cutoff (Å) |
+| `angle_cutoff` | `float` | `150.0` | D-H...A angle cutoff (degrees) |
+| `update_selections` | `bool` | `true` | Re-evaluate selections each frame |
+| `top_n_pairs` | `int` | `15` | Number of top residue pairs reported |
+| `allow_empty_groups` | `bool` | `true` | Warn/skip empty groups instead of raising |
+| `allow_overlapping_composition` | `bool` | `false` | Allow overlapping composition partitions (otherwise raise) |
+| `composition` | `HydrogenBondCompositionSettings \| null` | `null` | Optional partitioning for composition analysis |
+| `timestep_ps` | `float \| null` | `null` | Optional timestep override (ps) for time-axis plots |
+
+`HydrogenBondSummarySettings` entries in `summaries`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | required | Unique summary name |
+| `between` | `tuple[str, str] \| null` | `null` | Cross-group summary mode |
+| `within` | `str \| null` | `null` | Intra-group summary mode |
+
+Exactly one of `between` or `within` must be set for each summary.
+
+`HydrogenBondCompositionSettings`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `partitions` | `dict[str, str]` | `{}` | Named composition partitions as MDAnalysis selections |
+
+## `exposure`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `protein_selection` | `str` | `"protein"` | Protein selection |
+| `polymer_selection` | `str` | `"chainID C"` | Polymer selection |
+| `exposure_threshold` | `float` | `0.2` | Relative SASA cutoff for exposed vs buried residues |
+| `transient_lower` | `float` | `0.2` | Lower transient bound |
+| `transient_upper` | `float` | `0.8` | Upper transient bound (`> transient_lower`) |
+| `min_event_length` | `int` | `1` | Minimum contiguous exposed-frame length per event |
+| `probe_radius_nm` | `float` | `0.14` | SASA probe radius (nm) |
+| `n_sphere_points` | `int` | `960` | Sphere points for Shrake-Rupley SASA |
+| `protein_chain` | `str` | `"A"` | Protein chain letter |
+| `polymer_resnames` | `list[str] \| null` | `null` | Optional polymer residue-name subset |
+| `fdr_alpha` | `float` | `0.05` | Benjamini-Hochberg false-discovery-rate alpha |
+
+## `binding_free_energy`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `units` | `str` | `"kT"` | Output free-energy units: `kT`, `kcal/mol`, or `kJ/mol` |
+| `compute_binding_preference` | `bool` | `true` | Compute binding preference if cache is missing |
+| `surface_exposure_threshold` | `float` | `0.2` | Relative SASA threshold for surface exposure |
+| `enzyme_pdb_for_sasa` | `str \| null` | `null` | Optional enzyme PDB for SASA |
+| `include_default_aa_groups` | `bool` | `true` | Include built-in amino-acid class groups |
+| `protein_groups` | `dict[str, list[int]] \| null` | `null` | Custom residue groups |
+| `protein_partitions` | `dict[str, list[str]] \| null` | `null` | Custom partitions over `protein_groups` |
+| `polymer_type_selections` | `dict[str, str] \| null` | `null` | Custom polymer-type selections |
+| `polymer_chain` | `str` | `"C"` | Polymer chain ID for auto-detection |
+| `fdr_alpha` | `float` | `0.05` | Benjamini-Hochberg false-discovery-rate alpha |
+
+## `polymer_affinity`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `compute_binding_preference` | `bool` | `true` | Compute binding preference if cache is missing |
+| `surface_exposure_threshold` | `float` | `0.2` | Relative SASA threshold for surface exposure |
+| `enzyme_pdb_for_sasa` | `str \| null` | `null` | Optional enzyme PDB for SASA |
+| `include_default_aa_groups` | `bool` | `true` | Include built-in amino-acid class groups |
+| `protein_groups` | `dict[str, list[int]] \| null` | `null` | Custom residue groups |
+| `protein_partitions` | `dict[str, list[str]] \| null` | `null` | Custom partitions over `protein_groups` |
+| `polymer_type_selections` | `dict[str, str] \| null` | `null` | Custom polymer-type selections |
+| `polymer_chain` | `str` | `"C"` | Polymer chain ID for auto-detection |
+| `fdr_alpha` | `float` | `0.05` | Benjamini-Hochberg false-discovery-rate alpha |
+
+## `rg`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `runs` | `list[RgRunSettings]` | `[]` (must be non-empty) | Named Rg runs to compute |
+| `fdr_alpha` | `float` | `0.05` | Benjamini-Hochberg false-discovery-rate alpha |
+
+`RgRunSettings` entries in `runs`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `label` | `str` | required | Human-readable run label |
+| `selection` | `str` | required | MDAnalysis selection for Rg calculation |
+| `calculation_mode` | `"selection" \| "fragments"` | `"selection"` | Whole-selection vs fragment-reduced Rg mode |
+| `fragment_weighting` | `"equal" \| "mass"` | `"equal"` | Fragment reduction weighting (fragment mode) |
+| `save_fragment_distribution` | `bool` | `true` | Save per-fragment distribution sidecar outputs |
+| `histogram_bins` | `int` | `50` | Histogram bins for fragment distribution summaries |
+
+## `rmsd`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `runs` | `list[RMSDRunSettings]` | `[]` (must be non-empty) | Named RMSD runs to compute |
+| `fdr_alpha` | `float` | `0.05` | Benjamini-Hochberg false-discovery-rate alpha |
+
+`RMSDRunSettings` entries in `runs`:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `label` | `str` | required | Human-readable run label |
+| `selection` | `str` | `"protein and name CA"` | Selection used for RMSD calculation |
+| `alignment_selection` | `str` | `"protein and name CA"` | Selection used for alignment |
+| `reference_mode` | `str` | `"centroid"` | Reference mode: `centroid`, `average`, `frame`, or `external` |
+| `reference_frame` | `int` | `0` | 0-indexed frame index for `reference_mode: frame` |
+| `reference_file` | `str \| null` | `null` | External PDB path for `reference_mode: external` |
+| `centroid_selection` | `str \| null` | `null` | Optional centroid-mode selection (falls back to `alignment_selection`) |

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,52 +1,65 @@
 # Reference
 
 Reference pages are for lookup. Use this section when you need commands,
-configuration fields, API signatures, defaults, or benchmark data.
+configuration fields, plugin settings, API signatures, or benchmark data.
 
-## User-Facing Reference
+```{tip}
+For a guided walkthrough, go to {doc}`../tutorials/index`.
+For a task-oriented solution, go to {doc}`../how_to/index`.
+```
 
-- [Data Requirements & Directory Layout](data_requirements.md)
-- [CLI Reference](cli_reference.md)
-- [Configuration Reference](configuration.md)
-- [Comparison YAML Schema](comparison_yaml.md)
-- [Comparison and Plotting Reference](analysis_comparison_reference.md)
-- [RMSD Plugin Reference](analysis_rmsd_reference.md)
-- [Rg Plugin Reference](analysis_rg_reference.md)
-- [RMSF Plugin Reference](analysis_rmsf_reference.md)
-- [Catalytic Triad Plugin Reference](analysis_triad_reference.md)
-- [Distances Plugin Reference](analysis_distances_reference.md)
-- [Contacts Plugin Reference](analysis_contacts_reference.md)
-- [Post-Hoc Testing Reference](posthoc_testing.md)
-- [Benchmarks](benchmarks.md)
+::::{grid} 2
+:gutter: 3
 
-## API Reference
+:::{grid-item-card} CLI Commands
+:link: cli_reference
+:link-type: doc
 
-- [API Overview](../api/overview.rst)
-- [Configuration API](../api/config.md)
-- [Builders API](../api/builders.md)
-- [Simulation API](../api/simulation.md)
-- [Workflow API](../api/workflow.md)
-- [Core API](../api/core.md)
-- [Analysis API](../api/analysis.md)
-- [Analyses Plugin API](../api/analyses.md)
-- [API Reference Landing Page](../api/index.rst)
+All `polyzymd` commands, flags, and options.
+:::
 
-## When Not to Use This Section
+:::{grid-item-card} Configuration YAML
+:link: configuration
+:link-type: doc
 
-If you need a guided path, go to [Tutorials](../tutorials/index.md).
-If you need a concrete task solution, go to [How-To Guides](../how_to/index.md).
+Every key in `config.yaml` — types, defaults, and constraints.
+:::
 
-<!-- IMAGE OPPORTUNITY: Add a compact module map that groups config, builders,
-simulation, workflow, and analysis as a reference navigation aid. -->
+:::{grid-item-card} Analysis Plugin Reference
+:link: analysis_plugin_settings
+:link-type: doc
+
+Per-plugin settings, comparison YAML schema, and post-hoc testing options.
+:::
+
+:::{grid-item-card} API Documentation
+:link: ../api/index
+:link-type: doc
+
+Module-level Python API for config, builders, simulation, workflow, and
+analysis.
+:::
+
+::::
+
+## CLI, Configuration & Data
 
 ```{toctree}
-:hidden:
 :maxdepth: 1
 
 CLI Reference <cli_reference>
-Data Requirements & Directory Layout <data_requirements>
 Configuration Reference <configuration>
+Data Requirements & Directory Layout <data_requirements>
+Benchmarks <benchmarks>
+```
+
+## Analysis Plugin Reference
+
+```{toctree}
+:maxdepth: 1
+
 Comparison YAML Schema <comparison_yaml>
+Analysis Plugin Settings Reference <analysis_plugin_settings>
 Comparison and Plotting Reference <analysis_comparison_reference>
 RMSD Plugin Reference <analysis_rmsd_reference>
 Rg Plugin Reference <analysis_rg_reference>
@@ -54,16 +67,15 @@ RMSF Plugin Reference <analysis_rmsf_reference>
 Catalytic Triad Plugin Reference <analysis_triad_reference>
 Distances Plugin Reference <analysis_distances_reference>
 Contacts Plugin Reference <analysis_contacts_reference>
-Analysis Plugin Settings Reference <analysis_plugin_settings>
 Post-Hoc Testing Reference <posthoc_testing>
-Benchmarks <benchmarks>
-API Reference Landing Page <../api/index>
-API Overview <../api/overview>
-Configuration API <../api/config>
-Builders API <../api/builders>
-Simulation API <../api/simulation>
-Workflow API <../api/workflow>
-Core API <../api/core>
-Analysis API <../api/analysis>
-Analyses Plugin API <../api/analyses>
+```
+
+## API Reference
+
+Full Python API documentation.
+
+```{toctree}
+:maxdepth: 1
+
+API Reference <../api/index>
 ```


### PR DESCRIPTION
Replace flat toctrees in how_to, reference, and explanation index pages with grouped toctrees that create collapsible sidebar sections in RTD theme.

- how_to/index.md: 26 flat entries → 5 groups (Simulation Setup, HPC, Stable Analysis, Experimental Analysis, Plots & Troubleshooting)
- reference/index.md: 23 flat entries → 3 groups (CLI/Config/Data, Analysis Plugin Reference, API Reference); deduplicate 9 API entries that were duplicated from api/index.rst
- explanation/index.md: 12 flat entries → 3 groups (Concepts & Design, Interpretation & Best Practices, Experimental Concepts)
- Add sphinx-design grid cards to all 3 landing pages matching the Get Started page pattern
- Remove SASA from how_to toctree (owned by tutorials/index.md); keep as body cross-reference
- Include analysis_plugin_settings.md (previously untracked but referenced by reference toctree)