### PR TITLE
fix(solvent): support cosolvent mole fractions

### DIFF
--- a/docs/source/contributor_guide/contributing.md
+++ b/docs/source/contributor_guide/contributing.md
@@ -82,7 +82,7 @@ solvent:
     model: "tip3p"
   co_solvents:
     - name: "formamide"
-      volume_fraction: 0.10
+      mole_fraction: 0.05
 ```
 
 Then verify the build path:

--- a/docs/source/how_to/dynamic_polymers.md
+++ b/docs/source/how_to/dynamic_polymers.md
@@ -231,7 +231,7 @@ solvent:
     model: "tip3p"
   co_solvents:
     - name: "dmso"
-      volume_fraction: 0.30
+      mole_fraction: 0.10
       residue_name: "DMS"
   ions:
     neutralize: true

--- a/docs/source/how_to/troubleshooting.md
+++ b/docs/source/how_to/troubleshooting.md
@@ -101,9 +101,9 @@ yaml.scanner.ScannerError: mapping values are not allowed here
 ```
 Build failed: 3 validation errors for SimulationConfig
 solvent.co_solvents.0
-  Value error, Co-solvent 'dmso': Must specify either 'volume_fraction' or 'concentration'
+  Value error, Co-solvent 'dmso': Must specify either 'mole_fraction' or 'concentration'
 solvent.co_solvents.1.name
-  Field required [type=missing, input_value={'volume_fraction': 0.5}, input_type=dict]
+  Field required [type=missing, input_value={'mole_fraction': 0.1}, input_type=dict]
 solvent.co_solvents.2.name
   Field required [type=missing, input_value={'residue_name': 'DMS'}, input_type=dict]
 ```
@@ -114,7 +114,7 @@ solvent.co_solvents.2.name
 ```yaml
 co_solvents:
   - name: "dmso"
-  - volume_fraction: 0.5
+  - mole_fraction: 0.1
   - residue_name: "DMS"
 ```
 
@@ -122,7 +122,7 @@ co_solvents:
 ```yaml
 co_solvents:
   - name: "dmso"
-    volume_fraction: 0.5
+    mole_fraction: 0.1
     residue_name: "DMS"
 ```
 

--- a/docs/source/reference/cli_reference.md
+++ b/docs/source/reference/cli_reference.md
@@ -131,7 +131,7 @@ polyzymd validate -c <path>
 - Referenced files (PDB, SDF) exist
 - Monomer probabilities sum to 1.0
 - Valid enum values (water model, ensemble, etc.)
-- Co-solvent specification (volume_fraction XOR concentration)
+- Co-solvent specification (mole_fraction XOR concentration)
 
 ### Example
 

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -225,43 +225,44 @@ solvent:
 
 ### Co-solvents
 
-PolyzyMD supports adding co-solvents to your simulation system. You can specify co-solvents using either **volume fraction** (v/v) or **molar concentration**.
+PolyzyMD supports adding co-solvents to your simulation system. You can specify co-solvents using either **mole fraction** or **molar concentration**.
 
 #### Specification Methods
 
 | Method | Field | Description | Effect on Water |
 |--------|-------|-------------|-----------------|
-| Volume Fraction | `volume_fraction` | Fraction of box volume (0-1) | Reduces water proportionally |
+| Mole Fraction | `mole_fraction` | Fraction of neutral solvent molecules (0-1) | Replaces water in the neutral solvent mixture |
 | Concentration | `concentration` | Molar concentration (mol/L) | Additive (water unchanged) |
 
-**Important:** Use exactly ONE method per co-solvent. Do not specify both `volume_fraction` and `concentration` for the same co-solvent.
+**Important:** Use exactly ONE method per co-solvent. Do not specify both `mole_fraction` and `concentration` for the same co-solvent. The previous `volume_fraction` key has been removed and is rejected instead of converted automatically.
 
-#### Volume Fraction Method
+#### Mole Fraction Method
 
-Use this when you want a specific percentage of the solvent to be the co-solvent (e.g., "30% DMSO").
+Use this when you want a specific molecule fraction of the neutral solvent mixture to be the co-solvent (e.g., "10 mol% DMSO").
 
 ```yaml
 co_solvents:
   - name: "dmso"
-    volume_fraction: 0.30    # 30% v/v DMSO
+    mole_fraction: 0.10      # 10 mol% DMSO
 ```
 
 **Formula:**
 
 ```
-n = (V_box × phi × rho) / M
+x_water = 1 - sum(x_i)
+M_avg   = x_water × M_water + sum(x_i × M_i)
+N_total = neutral_solvent_mass / M_avg
+n_i     = x_i × N_total
+n_water = N_total - sum(n_i)
 
 Where:
-  n     = number of co-solvent molecules
-  V_box = simulation box volume (L)
-  phi   = volume fraction (e.g., 0.30 for 30%)
-  rho   = co-solvent density (g/mL)
-  M     = molar mass (g/mol)
+  x_i   = mole fraction for co-solvent i
+  M_i   = molecular mass for co-solvent i
 ```
 
-**Source:** [`src/polyzymd/builders/solvent.py:267-287`](https://github.com/joelaforet/polyzymd/blob/main/src/polyzymd/builders/solvent.py#L267-L287)
+**Source:** [`src/polyzymd/builders/solvent.py`](https://github.com/joelaforet/polyzymd/blob/main/src/polyzymd/builders/solvent.py)
 
-The water count is reduced proportionally: if you specify 30% DMSO, water fills the remaining 70% of the box.
+Mole-fraction co-solvents replace water in the neutral solvent mass budget. If you specify 10 mol% DMSO, DMSO molecules account for about 10% of neutral solvent molecules after rounding.
 
 #### Concentration Method
 
@@ -282,16 +283,16 @@ Where:
   n     = number of co-solvent molecules
   C     = concentration (mol/L)
   V_box = simulation box volume (L)
-  N_A   = Avogadro's number (implicit in OpenMM)
+  N_A   = Avogadro's number
 ```
 
-**Source:** [`src/polyzymd/builders/solvent.py:295-312`](https://github.com/joelaforet/polyzymd/blob/main/src/polyzymd/builders/solvent.py#L295-L312)
+**Source:** [`src/polyzymd/builders/solvent.py`](https://github.com/joelaforet/polyzymd/blob/main/src/polyzymd/builders/solvent.py)
 
 The water count is NOT reduced when using concentration. The co-solvent molecules are added to the existing water, which may slightly increase the effective density.
 
 #### Built-in Co-solvent Library
 
-PolyzyMD includes a library of common co-solvents with pre-defined SMILES and densities. Density values are sourced from [PubChem](https://pubchem.ncbi.nlm.nih.gov/), a public database of chemical compounds. Each compound has a unique Compound Identification Number (CID) that can be used to look up detailed information including density, structure, and safety data.
+PolyzyMD includes a library of common co-solvents with pre-defined SMILES and densities. Density values are retained as metadata and are sourced from [PubChem](https://pubchem.ncbi.nlm.nih.gov/), a public database of chemical compounds. Each compound has a unique Compound Identification Number (CID) that can be used to look up detailed information including density, structure, and safety data.
 
 | Name | SMILES | Density (g/mL) | Reference |
 |------|--------|----------------|-----------|
@@ -308,25 +309,24 @@ PolyzyMD includes a library of common co-solvents with pre-defined SMILES and de
 | `dioxane` | `C1COCCO1` | 1.033 | [CID 31275](https://pubchem.ncbi.nlm.nih.gov/compound/31275) |
 | `ethylene_glycol` | `C(CO)O` | 1.114 | [CID 174](https://pubchem.ncbi.nlm.nih.gov/compound/174) |
 
-For library co-solvents, you only need to specify the `name` and either `volume_fraction` or `concentration`:
+For library co-solvents, you only need to specify the `name` and either `mole_fraction` or `concentration`:
 
 ```yaml
 co_solvents:
   - name: "dmso"
-    volume_fraction: 0.10    # 10% v/v DMSO - smiles and density auto-populated
+    mole_fraction: 0.10      # 10 mol% DMSO - smiles auto-populated
 ```
 
 #### Custom Co-solvents
 
-For molecules not in the library, you must provide the SMILES string. Density is required only when using `volume_fraction`:
+For molecules not in the library, you must provide the SMILES string:
 
 ```yaml
 co_solvents:
-  # Custom co-solvent with volume fraction (density required)
+  # Custom co-solvent with mole fraction
   - name: "ethyl_acetate"
     smiles: "CCOC(=O)C"
-    density: 0.902           # g/mL - required for volume_fraction
-    volume_fraction: 0.15
+    mole_fraction: 0.05
 
   # Custom co-solvent with concentration (density not needed)
   - name: "my_additive"
@@ -341,12 +341,12 @@ You can combine multiple co-solvents. Each can use either specification method i
 ```yaml
 co_solvents:
   - name: "dmso"
-    volume_fraction: 0.20    # 20% v/v DMSO
+    mole_fraction: 0.10      # 10 mol% DMSO
   - name: "urea"
     concentration: 1.0       # Plus 1 M urea
 ```
 
-**Warning:** When using multiple co-solvents with `volume_fraction`, ensure the total does not exceed 1.0 (100%). The remaining fraction is filled with water.
+**Warning:** When using multiple co-solvents with `mole_fraction`, ensure the total is less than 1.0 (100%). The remaining mole fraction is filled with water.
 
 ```{warning}
 **YAML List Syntax**
@@ -357,7 +357,7 @@ A common mistake is placing each field on a separate line with its own `-`, whic
 ~~~yaml
 co_solvents:
   - name: "dmso"
-  - volume_fraction: 0.30
+  - mole_fraction: 0.10
   - residue_name: "DMS"
 ~~~
 
@@ -365,7 +365,7 @@ co_solvents:
 ~~~yaml
 co_solvents:
   - name: "dmso"
-    volume_fraction: 0.30
+    mole_fraction: 0.10
     residue_name: "DMS"
 ~~~
 
@@ -374,7 +374,7 @@ The `-` character starts a **new list item**. All fields belonging to the same i
 
 #### Assumptions and Limitations
 
-- **Ideal mixing:** Volume fractions assume ideal mixing (volumes are additive). Real solutions may deviate.
+- **Ideal composition:** Mole fractions are converted to molecule counts by a weighted average molar mass. Real solutions may deviate from ideal density behavior.
 - **Room temperature densities:** Library densities are approximate values at ~25C.
 - **PACKMOL placement:** Co-solvent molecules are placed randomly by PACKMOL and may require equilibration to achieve uniform distribution.
 

--- a/src/polyzymd/builders/solvent.py
+++ b/src/polyzymd/builders/solvent.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from polyzymd.config.schema import SolventConfig
 
 LOGGER = logging.getLogger(__name__)
+AVOGADRO_CONSTANT = 6.02214076e23
 
 # Water model type
 WaterModelType = Literal["tip3p", "spce", "tip4p", "tip4pew", "opc"]
@@ -51,8 +52,9 @@ class CoSolvent:
     """Specification for a co-solvent component.
 
     Supports two specification methods:
-    - volume_fraction: Specify as fraction (0-1), e.g., 0.30 for 30% v/v
-    - concentration: Specify as molarity (mol/L)
+
+    - ``mole_fraction``: Specify as molecule fraction (0-1)
+    - ``concentration``: Specify as molarity (mol/L)
 
     Note: The molecule is NOT created in __post_init__ to avoid running
     charge calculations prematurely. Instead, molecules are loaded via
@@ -62,20 +64,20 @@ class CoSolvent:
     Attributes:
         name: Identifier for the co-solvent.
         smiles: SMILES string for the molecule.
-        volume_fraction: Volume fraction (0-1), mutually exclusive with concentration.
-        concentration: Molar concentration (mol/L), mutually exclusive with volume_fraction.
-        density: Density in g/mL (required for volume_fraction calculation).
+        mole_fraction: Mole fraction (0-1), mutually exclusive with concentration.
+        concentration: Molar concentration (mol/L), mutually exclusive with mole_fraction.
+        density: Optional density in g/mL for metadata.
         residue_name: 3-letter residue name.
         molecule: OpenFF Molecule (assigned later with cached charges).
     """
 
     name: str
     smiles: str
-    volume_fraction: Optional[float] = None
-    concentration: Optional[float] = None
-    density: Optional[float] = None  # g/mL
+    mole_fraction: float | None = None
+    concentration: float | None = None
+    density: float | None = None  # g/mL
     residue_name: str = "COS"
-    molecule: Optional[Molecule] = field(default=None, repr=False)
+    molecule: Molecule | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         """Validate co-solvent specification.
@@ -88,21 +90,19 @@ class CoSolvent:
         if len(self.residue_name) > 3:
             self.residue_name = self.residue_name[:3].upper()
 
-        # Validate that exactly one specification method is used
-        if self.volume_fraction is None and self.concentration is None:
+        # Validate that exactly one composition method is used
+        if self.mole_fraction is None and self.concentration is None:
             raise ValueError(
-                f"CoSolvent '{self.name}': Must specify either volume_fraction or concentration"
+                f"CoSolvent '{self.name}': Must specify either mole_fraction or concentration"
             )
-        if self.volume_fraction is not None and self.concentration is not None:
+        if self.mole_fraction is not None and self.concentration is not None:
             raise ValueError(
-                f"CoSolvent '{self.name}': Cannot specify both volume_fraction and concentration"
+                f"CoSolvent '{self.name}': Cannot specify both mole_fraction and concentration"
             )
-
-        # Density is required for volume_fraction
-        if self.volume_fraction is not None and self.density is None:
-            raise ValueError(
-                f"CoSolvent '{self.name}': density (g/mL) is required for volume_fraction calculation"
-            )
+        if self.mole_fraction is not None and not 0.0 < self.mole_fraction < 1.0:
+            raise ValueError(f"CoSolvent '{self.name}': mole_fraction must be between 0 and 1")
+        if self.concentration is not None and self.concentration <= 0.0:
+            raise ValueError(f"CoSolvent '{self.name}': concentration must be greater than 0")
 
 
 @dataclass
@@ -155,15 +155,23 @@ class SolventComposition:
     mgcl2_concentration: float = 0.0
     neutralize: bool = True
 
-    @property
-    def water_volume_fraction(self) -> float:
-        """Get the water volume fraction (1 - sum of co-solvent fractions).
+    def __post_init__(self) -> None:
+        """Validate co-solvent mole fractions."""
+        total_cosolvent = sum(
+            cs.mole_fraction for cs in self.co_solvents if cs.mole_fraction is not None
+        )
+        if total_cosolvent >= 1.0:
+            raise ValueError(f"Total co-solvent mole fraction must be < 1.0, got {total_cosolvent}")
 
-        Note: Only counts co-solvents specified by volume_fraction.
-        Co-solvents specified by concentration don't reduce water volume.
+    @property
+    def water_mole_fraction(self) -> float:
+        """Get the water mole fraction in the neutral solvent mixture.
+
+        Note: Only counts co-solvents specified by mole_fraction.
+        Co-solvents specified by concentration don't reduce water count.
         """
         total_cosolvent = sum(
-            cs.volume_fraction for cs in self.co_solvents if cs.volume_fraction is not None
+            cs.mole_fraction for cs in self.co_solvents if cs.mole_fraction is not None
         )
         return 1.0 - total_cosolvent
 
@@ -174,7 +182,7 @@ class SolventBuilder:
     This class handles:
     - Water solvation with different water models
     - Ion addition for neutralization and ionic strength
-    - Co-solvent addition with specified volume fractions
+    - Co-solvent addition with specified mole fractions or concentrations
     - Box shape and padding configuration
 
     Example:
@@ -182,7 +190,7 @@ class SolventBuilder:
         >>> composition = SolventComposition(
         ...     water_model="tip3p",
         ...     nacl_concentration=0.15,
-        ...     co_solvents=[CoSolvent("dmso", "CS(=O)C", 0.1)]
+        ...     co_solvents=[CoSolvent("dmso", "CS(=O)C", mole_fraction=0.1)]
         ... )
         >>> solvated = builder.solvate(
         ...     topology=solute_topology,
@@ -299,15 +307,6 @@ class SolventBuilder:
         nacl_mass_to_add = solvent_mass * nacl_mass_fraction
         nacl_to_add = (nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
 
-        # Calculate water to add
-        water_mass_to_add = solvent_mass - nacl_mass_to_add
-        water_to_add = (water_mass_to_add / water_mass).m_as("dimensionless").round()
-
-        # Adjust for co-solvents (reduce water proportionally)
-        if composition.co_solvents:
-            water_fraction = composition.water_volume_fraction
-            water_to_add = int(water_to_add * water_fraction)
-
         # Neutralize system
         solute_charge = sum(mol.total_charge for mol in topology.molecules)
         if composition.neutralize:
@@ -316,6 +315,40 @@ class SolventBuilder:
         else:
             na_to_add = int(nacl_to_add)
             cl_to_add = int(nacl_to_add)
+
+        # Load co-solvents before count calculations so molar masses are known
+        cosolvent_masses: list[tuple[str, float, Any]] = []
+        for cosolvent in composition.co_solvents:
+            if cosolvent.molecule is None:
+                # Load molecule with pre-computed charges to ensure all copies
+                # of the same co-solvent have identical parameters
+                cosolvent.molecule = get_solvent_molecule(
+                    name=cosolvent.name,
+                    smiles=cosolvent.smiles,
+                    residue_name=cosolvent.residue_name,
+                )
+
+            cosolvent_molar_mass = sum(atom.mass for atom in cosolvent.molecule.atoms)
+            if cosolvent.mole_fraction is not None:
+                cosolvent_masses.append(
+                    (cosolvent.name, cosolvent.mole_fraction, cosolvent_molar_mass)
+                )
+            elif cosolvent.concentration is None:
+                # Should not reach here due to validation in CoSolvent.__post_init__
+                raise ValueError(
+                    f"CoSolvent '{cosolvent.name}' has neither mole_fraction nor concentration"
+                )
+
+        neutral_solvent_mass = solvent_mass - nacl_mass_to_add
+        if cosolvent_masses:
+            water_to_add, mole_fraction_counts = self._calculate_mole_fraction_counts(
+                neutral_solvent_mass=neutral_solvent_mass,
+                water_mass=water_mass,
+                cosolvent_mole_fractions=cosolvent_masses,
+            )
+        else:
+            water_to_add = self._round_dimensionless_to_int(neutral_solvent_mass / water_mass)
+            mole_fraction_counts = []
 
         LOGGER.info(f"Adding {int(water_to_add)} water, {na_to_add} Na+, {cl_to_add} Cl-")
 
@@ -327,45 +360,15 @@ class SolventBuilder:
         cosolvent_counts_list: List[Tuple[str, int]] = []
 
         # Add co-solvents (using cached charges for consistency)
+        mole_fraction_count_index = 0
         for cosolvent in composition.co_solvents:
-            if cosolvent.molecule is None:
-                # Load molecule with pre-computed charges to ensure all copies
-                # of the same co-solvent have identical parameters
-                cosolvent.molecule = get_solvent_molecule(
-                    name=cosolvent.name,
-                    smiles=cosolvent.smiles,
-                    residue_name=cosolvent.residue_name,
-                )
-
-            # Get molar mass of co-solvent
-            cosolvent_molar_mass = sum(atom.mass for atom in cosolvent.molecule.atoms)
-
-            if cosolvent.volume_fraction is not None:
-                # =============================================================
-                # VOLUME FRACTION METHOD
-                # =============================================================
-                # Formula: n = (V_box × φ × ρ) / M
-                # Where:
-                #   V_box = simulation box volume
-                #   φ     = volume fraction (e.g., 0.30 for 30%)
-                #   ρ     = co-solvent density (g/mL)
-                #   M     = molar mass (g/mol)
-                #
-                # This assumes ideal mixing (volumes are additive).
-                # =============================================================
-                cosolvent_density = Quantity(cosolvent.density, "gram / milliliter")
-                # Volume of co-solvent = box_volume × volume_fraction
-                cosolvent_volume = box_vol * cosolvent.volume_fraction
-                # Mass of co-solvent = volume × density
-                cosolvent_mass_to_add = cosolvent_volume * cosolvent_density
-                # Number of molecules = mass / molar_mass
-                n_cosolvent = int(
-                    (cosolvent_mass_to_add / cosolvent_molar_mass).m_as("dimensionless").round()
-                )
+            if cosolvent.mole_fraction is not None:
+                _, n_cosolvent = mole_fraction_counts[mole_fraction_count_index]
+                mole_fraction_count_index += 1
 
                 LOGGER.info(
                     f"Adding {n_cosolvent} {cosolvent.name} molecules "
-                    f"({cosolvent.volume_fraction * 100:.1f}% v/v, ρ={cosolvent.density} g/mL)"
+                    f"({cosolvent.mole_fraction * 100:.1f} mol%)"
                 )
 
             elif cosolvent.concentration is not None:
@@ -376,13 +379,15 @@ class SolventBuilder:
                 # Where:
                 #   C   = concentration (mol/L)
                 #   V   = box volume (L)
-                #   N_A = Avogadro's number (implicit in unit conversion)
+                #   N_A = Avogadro's number
                 #
-                # This directly gives the number of moles, then molecules.
+                # Convert volume to liters explicitly before applying N_A
                 # =============================================================
-                conc = Quantity(cosolvent.concentration, "mole / liter")
-                n_moles = conc * box_vol
-                n_cosolvent = int(n_moles.m_as("dimensionless").round())
+                box_volume_liters = self._box_volume_liters(box_vol)
+                n_cosolvent = self._count_concentration_molecules(
+                    concentration_molar=cosolvent.concentration,
+                    box_volume_liters=box_volume_liters,
+                )
 
                 LOGGER.info(
                     f"Adding {n_cosolvent} {cosolvent.name} molecules ({cosolvent.concentration} M)"
@@ -391,7 +396,7 @@ class SolventBuilder:
             else:
                 # Should not reach here due to validation in CoSolvent.__post_init__
                 raise ValueError(
-                    f"CoSolvent '{cosolvent.name}' has neither volume_fraction nor concentration"
+                    f"CoSolvent '{cosolvent.name}' has neither mole_fraction nor concentration"
                 )
 
             solvent_molecules.append(cosolvent.molecule)
@@ -447,7 +452,7 @@ class SolventBuilder:
             CoSolvent(
                 name=cs.name,
                 smiles=cs.smiles,  # type: ignore[arg-type]  # Validated in schema
-                volume_fraction=cs.volume_fraction,
+                mole_fraction=cs.mole_fraction,
                 concentration=cs.concentration,
                 density=cs.density,
                 residue_name=cs.residue_name or cs.name[:3].upper(),
@@ -472,6 +477,107 @@ class SolventBuilder:
             target_density=config.box.target_density,
             tolerance=config.box.tolerance,
         )
+
+    @staticmethod
+    def _round_dimensionless_to_int(value: Any) -> int:
+        """Round a dimensionless value to an integer molecule count.
+
+        Parameters
+        ----------
+        value : Any
+            Dimensionless scalar or quantity-like object with ``m_as``.
+
+        Returns
+        -------
+        int
+            Rounded integer count.
+        """
+        if hasattr(value, "m_as"):
+            value = value.m_as("dimensionless")
+        return int(round(float(value)))
+
+    @staticmethod
+    def _box_volume_liters(box_volume: Any) -> float:
+        """Convert a box volume to liters.
+
+        Parameters
+        ----------
+        box_volume : Any
+            Volume as an OpenFF quantity-like object or a numeric value already
+            expressed in liters.
+
+        Returns
+        -------
+        float
+            Box volume in liters.
+        """
+        if hasattr(box_volume, "m_as"):
+            return float(box_volume.m_as("liter"))
+        return float(box_volume)
+
+    @staticmethod
+    def _count_concentration_molecules(concentration_molar: float, box_volume_liters: float) -> int:
+        """Count additive co-solvent molecules from concentration.
+
+        Parameters
+        ----------
+        concentration_molar : float
+            Co-solvent concentration in mol/L.
+        box_volume_liters : float
+            Simulation box volume in liters.
+
+        Returns
+        -------
+        int
+            Number of co-solvent molecules to add.
+        """
+        return int(round(concentration_molar * box_volume_liters * AVOGADRO_CONSTANT))
+
+    @classmethod
+    def _calculate_mole_fraction_counts(
+        cls,
+        neutral_solvent_mass: Any,
+        water_mass: Any,
+        cosolvent_mole_fractions: Sequence[tuple[str, float, Any]],
+    ) -> tuple[int, list[tuple[str, int]]]:
+        """Count water and mole-fraction co-solvents from a mass budget.
+
+        Parameters
+        ----------
+        neutral_solvent_mass : Any
+            Mass allocated to water plus mole-fraction co-solvents.
+        water_mass : Any
+            Molecular mass of one water molecule.
+        cosolvent_mole_fractions : Sequence[tuple[str, float, Any]]
+            Tuples of co-solvent name, mole fraction, and molecular mass.
+
+        Returns
+        -------
+        water_count : int
+            Number of water molecules in the neutral solvent mixture.
+        cosolvent_counts : list[tuple[str, int]]
+            Number of molecules for each mole-fraction co-solvent.
+        """
+        total_mole_fraction = sum(mole_fraction for _, mole_fraction, _ in cosolvent_mole_fractions)
+        if total_mole_fraction >= 1.0:
+            raise ValueError(
+                f"Total co-solvent mole fraction must be < 1.0, got {total_mole_fraction}"
+            )
+
+        water_mole_fraction = 1.0 - total_mole_fraction
+        average_mass = water_mass * water_mole_fraction
+        for _, mole_fraction, cosolvent_mass in cosolvent_mole_fractions:
+            average_mass += cosolvent_mass * mole_fraction
+
+        total_neutral_molecules = cls._round_dimensionless_to_int(
+            neutral_solvent_mass / average_mass
+        )
+        cosolvent_counts = [
+            (name, int(round(mole_fraction * total_neutral_molecules)))
+            for name, mole_fraction, _ in cosolvent_mole_fractions
+        ]
+        water_count = total_neutral_molecules - sum(count for _, count in cosolvent_counts)
+        return water_count, cosolvent_counts
 
     def _get_box_shape_matrix(self, shape: BoxShapeType) -> NDArray:
         """Get the transformation matrix for the box shape.

--- a/src/polyzymd/config/schema.py
+++ b/src/polyzymd/config/schema.py
@@ -412,22 +412,14 @@ class PolymerConfig(BaseModel):
 class CoSolventSpec(BaseModel):
     """Specification for a co-solvent component.
 
-    You must specify EITHER volume_fraction OR concentration, not both.
+    You must specify either ``mole_fraction`` or ``concentration``, not both.
 
     For co-solvents in the built-in library (dmso, dmf, urea, ethanol, etc.),
     you can omit the smiles and density fields - they will be looked up
     automatically.
 
-    Attributes:
-        name: Identifier for the co-solvent (e.g., "dmso")
-        smiles: SMILES string (optional if co-solvent is in library)
-        volume_fraction: Volume fraction (0-1), e.g., 0.30 for 30% v/v
-        concentration: Molar concentration (mol/L)
-        density: Density in g/mL (required for volume_fraction with custom molecules)
-        residue_name: 3-letter residue name (default: first 3 chars of name)
-
-    Example (library co-solvent with volume fraction):
-        >>> CoSolventSpec(name="dmso", volume_fraction=0.30)
+    Example (library co-solvent with mole fraction):
+        >>> CoSolventSpec(name="dmso", mole_fraction=0.10)
 
     Example (library co-solvent with concentration):
         >>> CoSolventSpec(name="urea", concentration=2.0)
@@ -436,51 +428,62 @@ class CoSolventSpec(BaseModel):
         >>> CoSolventSpec(
         ...     name="my_solvent",
         ...     smiles="CCOC(=O)C",
-        ...     density=0.902,
-        ...     volume_fraction=0.15
+        ...     mole_fraction=0.05
         ... )
     """
 
     name: str = Field(..., description="Co-solvent identifier")
     smiles: str | None = Field(None, description="SMILES string (optional if in library)")
 
-    # Specification method 1: Volume fraction
-    volume_fraction: float | None = Field(
+    # Specification method 1: Mole fraction
+    mole_fraction: float | None = Field(
         None,
         gt=0.0,
         lt=1.0,
-        description="Volume fraction (0-1), e.g., 0.30 for 30% v/v",
+        description="Mole fraction (0-1), e.g., 0.10 for 10 mol%",
     )
 
     # Specification method 2: Molar concentration
     concentration: float | None = Field(None, gt=0.0, description="Molar concentration (mol/L)")
 
-    # Physical property for volume fraction calculation
+    # Optional physical property for library metadata
     density: float | None = Field(
         None,
         gt=0.0,
-        description="Density in g/mL (required for volume_fraction with custom molecules)",
+        description="Optional density in g/mL for co-solvent metadata",
     )
 
     residue_name: str | None = Field(None, max_length=3, description="Residue name")
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_volume_fraction(cls, data: Any) -> Any:
+        """Reject removed volume-fraction configuration keys."""
+        if isinstance(data, dict) and "volume_fraction" in data:
+            raise ValueError(
+                "Co-solvent 'volume_fraction' has been removed. Use 'mole_fraction' "
+                "for solvent mole fractions or 'concentration' for molarity; values are "
+                "not converted automatically."
+            )
+        return data
 
     @model_validator(mode="after")
     def validate_and_populate(self) -> "CoSolventSpec":
         """Validate specification and populate missing fields from library."""
         from polyzymd.data.cosolvent_library import get_cosolvent
 
-        # Check that exactly one of volume_fraction or concentration is specified
-        has_vf = self.volume_fraction is not None
+        # Check that exactly one composition method is specified
+        has_mole_fraction = self.mole_fraction is not None
         has_conc = self.concentration is not None
 
-        if not has_vf and not has_conc:
+        if not has_mole_fraction and not has_conc:
             raise ValueError(
-                f"Co-solvent '{self.name}': Must specify either 'volume_fraction' "
+                f"Co-solvent '{self.name}': Must specify either 'mole_fraction' "
                 f"or 'concentration'"
             )
-        if has_vf and has_conc:
+        if has_mole_fraction and has_conc:
             raise ValueError(
-                f"Co-solvent '{self.name}': Cannot specify both 'volume_fraction' "
+                f"Co-solvent '{self.name}': Cannot specify both 'mole_fraction' "
                 f"and 'concentration' - choose one"
             )
 
@@ -496,15 +499,9 @@ class CoSolventSpec(BaseModel):
                     f"Co-solvent '{self.name}' not in library. Please provide 'smiles' field."
                 )
 
-        # For volume_fraction, we need density
-        if has_vf and self.density is None:
-            if library_data:
-                object.__setattr__(self, "density", library_data.density)
-            else:
-                raise ValueError(
-                    f"Co-solvent '{self.name}' not in library. "
-                    f"Please provide 'density' field (g/mL) for volume_fraction calculation."
-                )
+        # Preserve library density as metadata when available
+        if self.density is None and library_data:
+            object.__setattr__(self, "density", library_data.density)
 
         # Set default residue name
         if self.residue_name is None:
@@ -558,14 +555,7 @@ class BoxConfig(BaseModel):
 
 
 class SolventConfig(BaseModel):
-    """Complete solvent configuration.
-
-    Attributes:
-        primary: Primary solvent settings
-        co_solvents: List of co-solvent specifications
-        ions: Ion configuration
-        box: Box geometry settings
-    """
+    """Complete solvent configuration."""
 
     primary: PrimarySolventConfig = Field(
         default_factory=PrimarySolventConfig, description="Primary solvent"
@@ -575,11 +565,11 @@ class SolventConfig(BaseModel):
     box: BoxConfig = Field(default_factory=BoxConfig, description="Box settings")
 
     @model_validator(mode="after")
-    def validate_volume_fractions(self) -> "SolventConfig":
-        """Ensure co-solvent volume fractions don't exceed 1.0."""
-        total = sum(cs.volume_fraction for cs in self.co_solvents if cs.volume_fraction is not None)
+    def validate_mole_fractions(self) -> "SolventConfig":
+        """Ensure co-solvent mole fractions leave room for water."""
+        total = sum(cs.mole_fraction for cs in self.co_solvents if cs.mole_fraction is not None)
         if total >= 1.0:
-            raise ValueError(f"Total co-solvent volume fraction must be < 1.0, got {total}")
+            raise ValueError(f"Total co-solvent mole fraction must be < 1.0, got {total}")
         return self
 
 
@@ -1482,8 +1472,8 @@ class SimulationConfig(BaseModel):
 
         # Include co-solvent info
         for cosolvent in self.solvent.co_solvents:
-            if cosolvent.volume_fraction is not None:
-                statepoint[f"cosolvent_{cosolvent.name}_fraction"] = cosolvent.volume_fraction
+            if cosolvent.mole_fraction is not None:
+                statepoint[f"cosolvent_{cosolvent.name}_mole_fraction"] = cosolvent.mole_fraction
             elif cosolvent.concentration is not None:
                 statepoint[f"cosolvent_{cosolvent.name}_molarity"] = cosolvent.concentration
 

--- a/src/polyzymd/templates/examples/enzyme_cosolvent.yaml
+++ b/src/polyzymd/templates/examples/enzyme_cosolvent.yaml
@@ -5,9 +5,9 @@
 # Useful for studying solvent effects on enzyme activity
 # ============================================================================
 
-name: "LipA_ResorufinButyrate_DMSO10"
+name: "LipA_ResorufinButyrate_DMSO10mol"
 engine: "openmm"
-description: "LipA enzyme with Resorufin-Butyrate in 10% DMSO co-solvent"
+description: "LipA enzyme with Resorufin-Butyrate in 10 mol% DMSO co-solvent"
 
 # ============================================================================
 # Enzyme Configuration
@@ -44,7 +44,7 @@ solvent:
   co_solvents:
     - name: "dmso"
       smiles: "CS(=O)C"  # DMSO SMILES
-      volume_fraction: 0.10  # 10% v/v DMSO
+      mole_fraction: 0.10  # 10 mol% DMSO
       residue_name: "DMS"
   
   ions:

--- a/src/polyzymd/templates/templates/config_template.yaml
+++ b/src/polyzymd/templates/templates/config_template.yaml
@@ -185,18 +185,18 @@ description: "Description of your simulation system"
 #   co_solvents: []
 #   
 #   # Co-solvent specification options:
-#   #   - volume_fraction: Specify as v/v fraction (e.g., 0.30 for 30%)
-#   #   - concentration:   Specify as molar (e.g., 2.0 for 2 M)
+#   #   - mole_fraction: Specify as solvent mole fraction (e.g., 0.10 for 10 mol%)
+#   #   - concentration:  Specify as molar (e.g., 2.0 for 2 M)
 #   #   NOTE: Use ONE method per co-solvent, not both.
 #   #
 #   # Built-in co-solvents (auto-populated smiles & density):
 #   #   dmso, dmf, acetonitrile, urea, ethanol, methanol, glycerol,
 #   #   isopropanol, acetone, thf, dioxane, ethylene_glycol
 #   
-#   # Example: 30% v/v DMSO (reduces water proportionally)
+#   # Example: 10 mol% DMSO (replaces water in neutral solvent mixture)
 #   # co_solvents:
 #   #   - name: "dmso"
-#   #     volume_fraction: 0.30             # 30% v/v
+#   #     mole_fraction: 0.10              # Mole fraction
 #   
 #   # Example: 2 M urea (additive, doesn't reduce water)
 #   # co_solvents:
@@ -207,8 +207,7 @@ description: "Description of your simulation system"
 #   # co_solvents:
 #   #   - name: "my_solvent"
 #   #     smiles: "CCOC(=O)C"               # SMILES required for custom
-#   #     density: 0.902                    # g/mL, required for volume_fraction
-#   #     volume_fraction: 0.15
+#   #     mole_fraction: 0.05              # Mole fraction
 #   
 #   ions:
 #     neutralize: true                    # Add counter-ions to neutralize

--- a/tests/builders/test_solvent.py
+++ b/tests/builders/test_solvent.py
@@ -1,0 +1,57 @@
+"""Tests for solvent composition counting helpers."""
+
+from polyzymd.builders.solvent import AVOGADRO_CONSTANT, SolventBuilder
+from polyzymd.config.schema import CoSolventSpec, SolventConfig
+
+
+def test_concentration_count_uses_liters_and_avogadro() -> None:
+    """Concentration counts should use volume in liters and Avogadro's constant."""
+    count = SolventBuilder._count_concentration_molecules(
+        concentration_molar=2.0,
+        box_volume_liters=1.0e-22,
+    )
+
+    assert count == round(2.0 * 1.0e-22 * AVOGADRO_CONSTANT)
+
+
+def test_mole_fraction_counts_replace_water_from_mass_budget() -> None:
+    """Mole-fraction co-solvents should share the neutral solvent mass budget."""
+    water_count, cosolvent_counts = SolventBuilder._calculate_mole_fraction_counts(
+        neutral_solvent_mass=2400.0,
+        water_mass=18.0,
+        cosolvent_mole_fractions=[("dmso", 0.10, 78.0)],
+    )
+
+    assert cosolvent_counts == [("dmso", 10)]
+    assert water_count == 90
+
+
+def test_config_translation_uses_mole_fraction(monkeypatch) -> None:
+    """solvate_from_config should pass mole_fraction into builder composition."""
+    captured = {}
+
+    def fake_solvate(self, *, topology, composition, **kwargs):
+        """Capture the composition without running the heavy build path."""
+        captured["topology"] = topology
+        captured["composition"] = composition
+        captured["kwargs"] = kwargs
+        return topology
+
+    monkeypatch.setattr(SolventBuilder, "solvate", fake_solvate)
+
+    config = SolventConfig(
+        co_solvents=[
+            CoSolventSpec(name="dmso", mole_fraction=0.10),
+            CoSolventSpec(name="urea", concentration=2.0),
+        ]
+    )
+    topology = object()
+
+    result = SolventBuilder().solvate_from_config(topology, config)
+
+    assert result is topology
+    co_solvents = captured["composition"].co_solvents
+    assert co_solvents[0].mole_fraction == 0.10
+    assert co_solvents[0].concentration is None
+    assert co_solvents[1].mole_fraction is None
+    assert co_solvents[1].concentration == 2.0

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -157,57 +157,70 @@ class TestConfigValidation:
         assert config.nacl_concentration == 0.0
 
 
-class TestCoSolventVolumeValidation:
-    """Test co-solvent volume fraction / concentration validation."""
+class TestCoSolventCompositionValidation:
+    """Test co-solvent mole fraction and concentration validation."""
 
     def test_concentration_cosolvent_does_not_crash_validator(self):
-        """Concentration-based co-solvents must not crash validate_volume_fractions.
-
-        Regression: sum() over volume_fraction raised TypeError when any
-        co-solvent used concentration (volume_fraction=None).
-        """
+        """Concentration-based co-solvents should validate without mole fractions."""
         from polyzymd.config.schema import CoSolventSpec, SolventConfig
 
         config = SolventConfig(co_solvents=[CoSolventSpec(name="urea", concentration=2.0)])
         assert len(config.co_solvents) == 1
 
-    def test_mixed_volume_fraction_and_concentration_cosolvents(self):
-        """Mixed volume_fraction + concentration co-solvents should validate."""
+    def test_mixed_mole_fraction_and_concentration_cosolvents(self):
+        """Mixed mole_fraction and concentration co-solvents should validate."""
         from polyzymd.config.schema import CoSolventSpec, SolventConfig
 
         config = SolventConfig(
             co_solvents=[
-                CoSolventSpec(name="dmso", volume_fraction=0.3),
+                CoSolventSpec(name="dmso", mole_fraction=0.3),
                 CoSolventSpec(name="urea", concentration=2.0),
             ]
         )
         assert len(config.co_solvents) == 2
 
-    def test_volume_fractions_exceeding_one_rejected(self):
-        """Total volume fractions >= 1.0 should still be rejected."""
+    def test_mole_fractions_exceeding_one_rejected(self):
+        """Total mole fractions >= 1.0 should be rejected."""
         from pydantic import ValidationError
 
         from polyzymd.config.schema import CoSolventSpec, SolventConfig
 
-        with pytest.raises(ValidationError, match="volume fraction must be < 1.0"):
+        with pytest.raises(ValidationError, match="mole fraction must be < 1.0"):
             SolventConfig(
                 co_solvents=[
-                    CoSolventSpec(name="dmso", volume_fraction=0.6),
-                    CoSolventSpec(name="ethanol", volume_fraction=0.5),
+                    CoSolventSpec(name="dmso", mole_fraction=0.6),
+                    CoSolventSpec(name="ethanol", mole_fraction=0.5),
                 ]
             )
 
-    def test_volume_fractions_below_one_accepted(self):
-        """Total volume fractions < 1.0 should pass validation."""
+    def test_mole_fractions_below_one_accepted(self):
+        """Total mole fractions < 1.0 should pass validation."""
         from polyzymd.config.schema import CoSolventSpec, SolventConfig
 
         config = SolventConfig(
             co_solvents=[
-                CoSolventSpec(name="dmso", volume_fraction=0.3),
-                CoSolventSpec(name="ethanol", volume_fraction=0.2),
+                CoSolventSpec(name="dmso", mole_fraction=0.3),
+                CoSolventSpec(name="ethanol", mole_fraction=0.2),
             ]
         )
         assert len(config.co_solvents) == 2
+
+    def test_volume_fraction_key_rejected_with_migration_error(self):
+        """Removed volume_fraction keys should fail with a migration message."""
+        from polyzymd.config.schema import CoSolventSpec
+
+        with pytest.raises(ValidationError, match="volume_fraction.*removed"):
+            CoSolventSpec(name="dmso", volume_fraction=0.3)
+
+    def test_exactly_one_composition_method_required(self):
+        """Each co-solvent should have exactly one composition method."""
+        from polyzymd.config.schema import CoSolventSpec
+
+        with pytest.raises(ValidationError, match="Must specify either 'mole_fraction'"):
+            CoSolventSpec(name="dmso")
+
+        with pytest.raises(ValidationError, match="Cannot specify both 'mole_fraction'"):
+            CoSolventSpec(name="dmso", mole_fraction=0.1, concentration=1.0)
 
 
 class TestSimulationPhasesConfig:
@@ -282,9 +295,9 @@ class TestSimulationPhasesConfig:
 
 class TestStatepointCoSolventExport:
     """to_statepoint must not crash when co-solvents use concentration instead
-    of volume_fraction."""
+    of mole_fraction."""
 
-    def _make_config(self, *, volume_fraction=None, concentration=None):
+    def _make_config(self, *, mole_fraction=None, concentration=None):
         """Build a minimal SimulationConfig with one co-solvent."""
         from unittest.mock import MagicMock
 
@@ -296,19 +309,19 @@ class TestStatepointCoSolventExport:
 
         cs = MagicMock()
         cs.name = "urea"
-        cs.volume_fraction = volume_fraction
+        cs.mole_fraction = mole_fraction
         cs.concentration = concentration
         config.solvent.co_solvents = [cs]
         return config
 
-    def test_volume_fraction_exported_as_fraction_key(self):
-        """volume_fraction co-solvent produces a _fraction key."""
+    def test_mole_fraction_exported_as_mole_fraction_key(self):
+        """mole_fraction co-solvent produces a _mole_fraction key."""
         from polyzymd.config.schema import SimulationConfig
 
         _to_statepoint = SimulationConfig.__dict__["to_signac_statepoint"]
-        cfg = self._make_config(volume_fraction=0.3)
+        cfg = self._make_config(mole_fraction=0.3)
         sp = _to_statepoint(cfg)
-        assert sp["cosolvent_urea_fraction"] == 0.3
+        assert sp["cosolvent_urea_mole_fraction"] == 0.3
         assert "cosolvent_urea_molarity" not in sp
 
     def test_concentration_exported_as_molarity_key(self):
@@ -319,10 +332,10 @@ class TestStatepointCoSolventExport:
         cfg = self._make_config(concentration=2.0)
         sp = _to_statepoint(cfg)
         assert sp["cosolvent_urea_molarity"] == 2.0
-        assert "cosolvent_urea_fraction" not in sp
+        assert "cosolvent_urea_mole_fraction" not in sp
 
-    def test_no_crash_with_none_volume_fraction(self):
-        """Previously crashed with TypeError when volume_fraction was None."""
+    def test_no_crash_with_none_mole_fraction(self):
+        """Concentration statepoints should allow no mole_fraction."""
         from polyzymd.config.schema import SimulationConfig
 
         _to_statepoint = SimulationConfig.__dict__["to_signac_statepoint"]


### PR DESCRIPTION
Changes how co-solvents are added, now users must specify additional component via mole fraction, with the remainder of the box being filled with water. Also patched specifying `concentration` for a co-solvent.