### PR TITLE
Add blanca-chbe-rdi SLURM preset

### DIFF
--- a/src/polyzymd/cli/main.py
+++ b/src/polyzymd/cli/main.py
@@ -1161,7 +1161,7 @@ def _print_gromacs_dry_run_details(
 )
 @click.option(
     "--preset",
-    type=click.Choice(["aa100", "al40", "blanca-shirts", "bridges2", "testing"]),
+    type=click.Choice(["aa100", "al40", "blanca-shirts", "blanca-chbe-rdi", "bridges2", "testing"]),
     default="aa100",
     help="SLURM partition preset (default: aa100)",
 )
@@ -2561,7 +2561,7 @@ def clean_pdb(input_path: str, output_path: str | None, ph: float) -> None:
 )
 @click.option(
     "--preset",
-    type=click.Choice(["aa100", "al40", "blanca-shirts", "bridges2", "testing"]),
+    type=click.Choice(["aa100", "al40", "blanca-shirts", "blanca-chbe-rdi", "bridges2", "testing"]),
     default="aa100",
     help="SLURM partition preset (default: aa100)",
 )

--- a/src/polyzymd/workflow/slurm.py
+++ b/src/polyzymd/workflow/slurm.py
@@ -28,7 +28,7 @@ from polyzymd.utils.templates import render_package_template
 LOGGER = logging.getLogger(__name__)
 
 # Preset types
-PresetType = Literal["aa100", "al40", "blanca-shirts", "bridges2", "testing"]
+PresetType = Literal["aa100", "al40", "blanca-shirts", "blanca-chbe-rdi", "bridges2", "testing"]
 
 # Valid GPU types for Bridges2 (PSC).  Adding a new type is a one-line change here.
 BRIDGES2_GPU_TYPES: List[str] = ["v100-16", "v100-32", "l40s-48", "h100-80"]
@@ -40,6 +40,7 @@ PRESET_DEFAULT_PIXI_ENV: Dict[str, str] = {
     "aa100": "cuda-12-4",
     "al40": "cuda-12-4",
     "blanca-shirts": "cuda-12-4",
+    "blanca-chbe-rdi": "cuda-12-4",
     "bridges2": "cuda-12-6",
     "testing": "cuda-12-4",
 }
@@ -335,6 +336,13 @@ class SlurmConfig:
                 "partition": "blanca,blanca-shirts",
                 "qos": "preemptable",
                 "account": "blanca-shirts",
+                "time_limit": "23:59:59",
+                "exclude": "bgpu-bortz1",
+            },
+            "blanca-chbe-rdi": {
+                "partition": "blanca,blanca-chbe-rdi",
+                "qos": "preemptable",
+                "account": "blanca-chbe-rdi",
                 "time_limit": "23:59:59",
                 "exclude": "bgpu-bortz1",
             },


### PR DESCRIPTION
Adds a SLURM preset for the blanca-chbe-rdi account on CURC Blanca cluster. Tested with albumin simulations and confirmed ability to run as expected. 