### PR TITLE
fix(rmsf): report pairwise mean deltas

### DIFF
--- a/src/polyzymd/analyses/stats.py
+++ b/src/polyzymd/analyses/stats.py
@@ -753,10 +753,13 @@ def format_scalar_comparison_artifact_payload(
     if pairwise:
         lines.extend(["", "Pairwise comparisons:"])
         for item in pairwise:
+            delta_mean = _payload_pairwise_delta_mean(item, condition_by_label, metric_key)
+            percent_change = _payload_float_or_nan(item.get("percent_change"))
+            p_value = _payload_float_or_nan(item.get("p_value"))
             lines.append(
                 f"  {item.get('condition_a')} vs {item.get('condition_b')}: "
-                f"Δ={float(item.get('effect_size', item.get('mean_difference', 0.0))):.4f}, "
-                f"p={float(item.get('p_value', 1.0)):.4g}"
+                f"Δmean={delta_mean:.4f}{unit_str}, %Δ={format_pct(percent_change)}, "
+                f"p={p_value:.4g}"
             )
     return "\n".join(lines)
 
@@ -792,8 +795,96 @@ def _payload_ranking(payload: dict[str, Any], metric_key: str) -> list[dict[str,
 def _payload_metric(condition: dict[str, Any], metric_key: str, suffix: str) -> float:
     """Return a scalar metric from a payload condition summary."""
 
-    value = condition.get(f"{metric_key}_{suffix}", condition.get(suffix, 0.0))
-    return float(value if value is not None else 0.0)
+    exact_key = f"{metric_key}_{suffix}"
+    if exact_key in condition:
+        return _payload_float_or_nan(condition.get(exact_key))
+    if suffix in condition:
+        return _payload_float_or_nan(condition.get(suffix))
+    return 0.0
+
+
+def _payload_float_or_nan(value: Any) -> float:
+    """Return a float value or ``nan`` for absent and malformed payload values.
+
+    Parameters
+    ----------
+    value : Any
+        Payload value to coerce.
+
+    Returns
+    -------
+    float
+        Float-converted value, or ``nan`` when conversion is not possible.
+    """
+
+    if value is None:
+        return float("nan")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _payload_required_metric(condition: dict[str, Any], metric_key: str, suffix: str) -> float:
+    """Return an exact selected metric value from a payload condition summary.
+
+    Parameters
+    ----------
+    condition : dict[str, Any]
+        Payload condition summary.
+    metric_key : str
+        Selected metric key.
+    suffix : str
+        Metric suffix, such as ``"mean"`` or ``"sem"``.
+
+    Returns
+    -------
+    float
+        Float-converted value for ``f"{metric_key}_{suffix}"``, or ``nan``
+        when the exact selected key is absent or malformed.
+    """
+
+    exact_key = f"{metric_key}_{suffix}"
+    if exact_key not in condition:
+        return float("nan")
+    return _payload_float_or_nan(condition.get(exact_key))
+
+
+def _payload_pairwise_delta_mean(
+    pairwise_item: dict[str, Any],
+    condition_by_label: dict[str, dict[str, Any]],
+    metric_key: str,
+) -> float:
+    """Return signed pairwise mean difference from payload condition summaries.
+
+    Parameters
+    ----------
+    pairwise_item : dict[str, Any]
+        Pairwise comparison payload entry with ``condition_a`` and ``condition_b`` labels.
+    condition_by_label : dict[str, dict[str, Any]]
+        Mapping from condition label to condition summary payload.
+    metric_key : str
+        Metric key whose condition means should be compared.
+
+    Returns
+    -------
+    float
+        Signed ``mean(condition_b) - mean(condition_a)`` in metric units. Missing labels or
+        non-numeric means return ``nan`` so CLI formatting does not fail.
+    """
+
+    label_a = str(pairwise_item.get("condition_a", ""))
+    label_b = str(pairwise_item.get("condition_b", ""))
+    condition_a = condition_by_label.get(label_a)
+    condition_b = condition_by_label.get(label_b)
+    if condition_a is None or condition_b is None:
+        return float("nan")
+
+    mean_a = _payload_required_metric(condition_a, metric_key, "mean")
+    mean_b = _payload_required_metric(condition_b, metric_key, "mean")
+    if math.isnan(mean_a) or math.isnan(mean_b):
+        return float("nan")
+    return mean_b - mean_a
 
 
 def _payload_direction_label(higher_is_better: bool | None) -> str:

--- a/tests/analyses/test_stats.py
+++ b/tests/analyses/test_stats.py
@@ -20,6 +20,7 @@ from polyzymd.analyses.stats import (
     anova_test,
     default_scalar_comparison,
     format_scalar_comparison,
+    format_scalar_comparison_artifact_payload,
     pairwise_comparisons,
     rank_conditions,
 )
@@ -374,6 +375,331 @@ def test_format_scalar_comparison_includes_adjusted_pvalues_in_text_and_markdown
     assert "p (adj)" in markdown_output
     assert "0.0300" in markdown_output
     assert "0.0400" in markdown_output
+
+
+def test_format_scalar_comparison_artifact_payload_computes_pairwise_delta_mean() -> None:
+    """Artifact payload formatter should show mean differences, not Cohen's d."""
+    payload = {
+        "condition_summaries": [
+            {
+                "label": "Control",
+                "n_replicates": 3,
+                "mean_rmsf_mean": 1.2000,
+                "mean_rmsf_sem": 0.0100,
+            },
+            {
+                "label": "PEG",
+                "n_replicates": 3,
+                "mean_rmsf_mean": 0.9892,
+                "mean_rmsf_sem": 0.0200,
+            },
+        ],
+        "pairwise_comparisons": [
+            {
+                "condition_a": "Control",
+                "condition_b": "PEG",
+                "metric": "mean_rmsf",
+                "p_value": 0.02717,
+                "p_value_adjusted": 0.02717,
+                "posthoc_method": "ttest_bh",
+                "cohens_d": -1.25,
+                "effect_size_interpretation": "large",
+                "direction": "decreased",
+                "significant": True,
+                "percent_change": -17.6,
+                "testable": True,
+                "note": None,
+            }
+        ],
+        "ranking": ["PEG", "Control"],
+        "rankings_by_metric": {"mean_rmsf": ["PEG", "Control"]},
+        "statistical_parameters": {"project_name": "RMSF beta", "equilibration": "10ns"},
+    }
+
+    text_output = format_scalar_comparison_artifact_payload(
+        payload,
+        title="RMSF Comparison",
+        metric_label="Mean RMSF",
+        metric_unit="A",
+        metric_key="mean_rmsf",
+        output_format="text",
+        higher_is_better=False,
+    )
+    json_output = format_scalar_comparison_artifact_payload(
+        payload,
+        metric_key="mean_rmsf",
+        output_format="json",
+    )
+
+    assert "Control vs PEG: Δmean=-0.2108 A" in text_output
+    assert "%Δ=-17.6%" in text_output
+    assert "p=0.02717" in text_output
+    assert "Δ=0.0000" not in text_output
+    assert json.loads(json_output) == payload
+
+
+def test_format_scalar_comparison_artifact_payload_requires_selected_mean_for_delta() -> None:
+    """Pairwise delta should not fall back to generic condition means."""
+    payload = {
+        "condition_summaries": [
+            {
+                "label": "Control",
+                "n_replicates": 3,
+                "mean": 1.2000,
+                "mean_rmsf_sem": 0.0100,
+            },
+            {
+                "label": "PEG",
+                "n_replicates": 3,
+                "mean": 0.9892,
+                "mean_rmsf_sem": 0.0200,
+            },
+        ],
+        "pairwise_comparisons": [
+            {
+                "condition_a": "Control",
+                "condition_b": "PEG",
+                "metric": "mean_rmsf",
+                "p_value": 0.02717,
+                "p_value_adjusted": 0.02717,
+                "posthoc_method": "ttest_bh",
+                "cohens_d": -1.25,
+                "effect_size_interpretation": "large",
+                "direction": "decreased",
+                "significant": True,
+                "percent_change": -17.6,
+                "testable": True,
+                "note": None,
+            }
+        ],
+        "ranking": ["PEG", "Control"],
+        "rankings_by_metric": {"mean_rmsf": ["PEG", "Control"]},
+        "statistical_parameters": {"project_name": "RMSF beta", "equilibration": "10ns"},
+    }
+
+    text_output = format_scalar_comparison_artifact_payload(
+        payload,
+        title="RMSF Comparison",
+        metric_label="Mean RMSF",
+        metric_unit="A",
+        metric_key="mean_rmsf",
+        output_format="text",
+        higher_is_better=False,
+    )
+
+    assert "Control vs PEG: Δmean=nan A" in text_output
+    assert "Δmean=-0.2108 A" not in text_output
+    assert "Δmean=0.0000 A" not in text_output
+
+
+def test_format_scalar_comparison_artifact_payload_handles_missing_pairwise_stats() -> None:
+    """Missing pairwise percent and p-values should format without crashing."""
+    payload = {
+        "condition_summaries": [
+            {
+                "label": "Control",
+                "n_replicates": 3,
+                "mean_rmsf_mean": 1.2000,
+                "mean_rmsf_sem": 0.0100,
+            },
+            {
+                "label": "PEG",
+                "n_replicates": 3,
+                "mean_rmsf_mean": 0.9892,
+                "mean_rmsf_sem": 0.0200,
+            },
+        ],
+        "pairwise_comparisons": [
+            {
+                "condition_a": "Control",
+                "condition_b": "PEG",
+                "metric": "mean_rmsf",
+                "p_value": None,
+                "p_value_adjusted": None,
+                "posthoc_method": "ttest_bh",
+                "cohens_d": -1.25,
+                "effect_size_interpretation": "large",
+                "direction": "decreased",
+                "significant": False,
+                "percent_change": None,
+                "testable": False,
+                "note": None,
+            }
+        ],
+        "ranking": ["PEG", "Control"],
+        "rankings_by_metric": {"mean_rmsf": ["PEG", "Control"]},
+        "statistical_parameters": {"project_name": "RMSF beta", "equilibration": "10ns"},
+    }
+
+    text_output = format_scalar_comparison_artifact_payload(
+        payload,
+        title="RMSF Comparison",
+        metric_label="Mean RMSF",
+        metric_unit="A",
+        metric_key="mean_rmsf",
+        output_format="text",
+        higher_is_better=False,
+    )
+
+    assert "Control vs PEG: Δmean=-0.2108 A" in text_output
+    assert "%Δ=undefined" in text_output
+    assert "p=nan" in text_output
+
+
+def test_format_scalar_comparison_artifact_payload_handles_malformed_ranking_values() -> None:
+    """Malformed selected condition means and SEMs should render as nan."""
+    payload = {
+        "condition_summaries": [
+            {
+                "label": "Control",
+                "n_replicates": 3,
+                "mean_rmsf_mean": "bad",
+                "mean_rmsf_sem": ["bad"],
+            },
+            {
+                "label": "PEG",
+                "n_replicates": 3,
+                "mean_rmsf_mean": {},
+                "mean_rmsf_sem": "bad",
+            },
+        ],
+        "pairwise_comparisons": [],
+        "ranking": ["PEG", "Control"],
+        "rankings_by_metric": {"mean_rmsf": ["PEG", "Control"]},
+        "statistical_parameters": {"project_name": "RMSF beta", "equilibration": "10ns"},
+    }
+
+    text_output = format_scalar_comparison_artifact_payload(
+        payload,
+        title="RMSF Comparison",
+        metric_label="Mean RMSF",
+        metric_unit="A",
+        metric_key="mean_rmsf",
+        output_format="text",
+        higher_is_better=False,
+    )
+    markdown_output = format_scalar_comparison_artifact_payload(
+        payload,
+        title="RMSF Comparison",
+        metric_label="Mean RMSF",
+        metric_unit="A",
+        metric_key="mean_rmsf",
+        output_format="markdown",
+        higher_is_better=False,
+    )
+
+    assert "1. PEG: nan A ± nan A" in text_output
+    assert "2. Control: nan A ± nan A" in text_output
+    assert "| 1 | PEG | nan A | nan A |" in markdown_output
+    assert "| 2 | Control | nan A | nan A |" in markdown_output
+
+
+def test_format_scalar_comparison_artifact_payload_handles_malformed_delta_mean() -> None:
+    """Malformed selected means should render a nan pairwise delta."""
+    payload = {
+        "condition_summaries": [
+            {
+                "label": "Control",
+                "n_replicates": 3,
+                "mean_rmsf_mean": "bad",
+                "mean_rmsf_sem": 0.0100,
+            },
+            {
+                "label": "PEG",
+                "n_replicates": 3,
+                "mean_rmsf_mean": ["bad"],
+                "mean_rmsf_sem": 0.0200,
+            },
+        ],
+        "pairwise_comparisons": [
+            {
+                "condition_a": "Control",
+                "condition_b": "PEG",
+                "metric": "mean_rmsf",
+                "p_value": 0.02717,
+                "p_value_adjusted": 0.02717,
+                "posthoc_method": "ttest_bh",
+                "cohens_d": -1.25,
+                "effect_size_interpretation": "large",
+                "direction": "decreased",
+                "significant": True,
+                "percent_change": -17.6,
+                "testable": True,
+                "note": None,
+            }
+        ],
+        "ranking": ["PEG", "Control"],
+        "rankings_by_metric": {"mean_rmsf": ["PEG", "Control"]},
+        "statistical_parameters": {"project_name": "RMSF beta", "equilibration": "10ns"},
+    }
+
+    text_output = format_scalar_comparison_artifact_payload(
+        payload,
+        title="RMSF Comparison",
+        metric_label="Mean RMSF",
+        metric_unit="A",
+        metric_key="mean_rmsf",
+        output_format="text",
+        higher_is_better=False,
+    )
+
+    assert "Control vs PEG: Δmean=nan A" in text_output
+
+
+@pytest.mark.parametrize("malformed_value", ["bad", ["bad"], {"bad": "value"}])
+def test_format_scalar_comparison_artifact_payload_handles_malformed_pairwise_stats(
+    malformed_value: object,
+) -> None:
+    """Malformed pairwise percent and p-values should format without crashing."""
+    payload = {
+        "condition_summaries": [
+            {
+                "label": "Control",
+                "n_replicates": 3,
+                "mean_rmsf_mean": 1.2000,
+                "mean_rmsf_sem": 0.0100,
+            },
+            {
+                "label": "PEG",
+                "n_replicates": 3,
+                "mean_rmsf_mean": 0.9892,
+                "mean_rmsf_sem": 0.0200,
+            },
+        ],
+        "pairwise_comparisons": [
+            {
+                "condition_a": "Control",
+                "condition_b": "PEG",
+                "metric": "mean_rmsf",
+                "p_value": malformed_value,
+                "p_value_adjusted": malformed_value,
+                "posthoc_method": "ttest_bh",
+                "cohens_d": -1.25,
+                "effect_size_interpretation": "large",
+                "direction": "decreased",
+                "significant": False,
+                "percent_change": malformed_value,
+                "testable": False,
+                "note": None,
+            }
+        ],
+        "ranking": ["PEG", "Control"],
+        "rankings_by_metric": {"mean_rmsf": ["PEG", "Control"]},
+        "statistical_parameters": {"project_name": "RMSF beta", "equilibration": "10ns"},
+    }
+
+    text_output = format_scalar_comparison_artifact_payload(
+        payload,
+        title="RMSF Comparison",
+        metric_label="Mean RMSF",
+        metric_unit="A",
+        metric_key="mean_rmsf",
+        output_format="text",
+        higher_is_better=False,
+    )
+
+    assert "%Δ=undefined" in text_output
+    assert "p=nan" in text_output
 
 
 def test_comparison_result_rejects_missing_adjusted_pvalues() -> None:


### PR DESCRIPTION
## Summary
- compute artifact pairwise Δmean from selected condition means instead of missing payload fields
- include %Δ from existing pairwise percent_change while preserving JSON output
- harden artifact text formatting against malformed scalar payload values

## Tests
- pixi run -e cuda-12-6 pytest tests/analyses/test_stats.py -v
- pixi run -e cuda-12-6 pytest tests/analyses/plugins/test_rmsf.py -v -k "format"
- pixi run -e cuda-12-6 ruff check src/polyzymd/analyses/stats.py tests/analyses/test_stats.py tests/analyses/plugins/test_rmsf.py
- pixi run -e cuda-12-6 black --check src/polyzymd/analyses/stats.py tests/analyses/test_stats.py tests/analyses/plugins/test_rmsf.py

Reviewer verdict: APPROVED