### PR TITLE
fix(secondary-structure): support explicit selection

### DIFF
--- a/docs/source/reference/analysis_plugin_settings.md
+++ b/docs/source/reference/analysis_plugin_settings.md
@@ -88,6 +88,14 @@ below.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `chain_id` | `str` | `"A"` | Protein chain letter to analyze (PolyzyMD convention: chain A) |
+| `selection` | `str \| null` | `null` | Explicit MDAnalysis protein-residue selection. Overrides `chain_id` when set |
+
+The default is `protein and chainid A` for PDB/PolyzyMD chain-convention
+compatibility. GROMACS `.gro` topologies may not preserve chain IDs; use
+`selection: "protein"`, `selection: "protein and resid 1:269"`, or
+`selection: "protein and resindex 0:268"` when chain IDs are unavailable.
+DSSP requires complete residues; do not use CA-only selections such as
+`protein and name CA`.
 
 ## `sasa`
 

--- a/docs/source/reference/analysis_secondary_structure_reference.md
+++ b/docs/source/reference/analysis_secondary_structure_reference.md
@@ -10,10 +10,41 @@ Top-level plugin key: `plugins.secondary_structure`.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `chain_id` | `str` | `"A"` | Protein chain letter passed to DSSP. Chain A is the PolyzyMD protein convention. |
+| `selection` | `str \| null` | `null` | Explicit MDAnalysis selection for the protein residues. When set, this overrides `chain_id`. |
 
 The plugin computes simplified DSSP classes with MDTraj, aggregates helix,
 strand, and coil persistence across replicates, and uses default scalar
 comparison on `helix_fraction`.
+
+By default, PolyzyMD selects `protein and chainid A`. This matches the PDB and
+PolyzyMD chain convention where chain A is the protein. GROMACS `.gro`
+topologies may not preserve chain IDs, so `chainid` selections can fail in
+MDAnalysis. For `.gro` inputs, set `selection` explicitly, for example:
+
+```yaml
+plugins:
+  secondary_structure:
+    selection: "protein"
+```
+
+Use MDAnalysis residue syntax to restrict the protein region:
+
+```yaml
+plugins:
+  secondary_structure:
+    selection: "protein and resid 1:269"
+```
+
+or zero-based residue indices:
+
+```yaml
+plugins:
+  secondary_structure:
+    selection: "protein and resindex 0:268"
+```
+
+DSSP requires complete, backbone-compatible protein residues. Do not use
+CA-only selections such as `protein and name CA` for this plugin.
 
 ## Output files
 

--- a/docs/source/reference/comparison_yaml.md
+++ b/docs/source/reference/comparison_yaml.md
@@ -163,6 +163,14 @@ defaults.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `chain_id` | string | `"A"` | Chain letter for the protein to analyze via DSSP |
+| `selection` | string | `null` | Explicit MDAnalysis protein-residue selection. Overrides `chain_id` when provided. |
+
+The default secondary-structure selection is `protein and chainid A`, preserving
+the PolyzyMD/PDB convention that chain A is the protein. GROMACS `.gro`
+topologies may not preserve chain IDs, so use `selection` for those files, for
+example `selection: "protein"`, `selection: "protein and resid 1:269"`, or
+`selection: "protein and resindex 0:268"`. DSSP needs complete residues; do not
+use CA-only selections such as `protein and name CA`.
 
 ### `plugins.sasa`
 

--- a/src/polyzymd/analyses/secondary_structure/__init__.py
+++ b/src/polyzymd/analyses/secondary_structure/__init__.py
@@ -8,11 +8,12 @@ comparison path.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Sequence
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from polyzymd.analyses._framework.cache_identity import settings_fingerprint
 from polyzymd.analyses.base import (
@@ -48,17 +49,84 @@ if TYPE_CHECKING:
     from polyzymd.analyses.mda import MDAAnalysisJob, MDAReplicateJobContext
 
 
+def _legacy_secondary_structure_fingerprint(chain_id: str) -> str:
+    """Return the legacy settings fingerprint for chain-only settings.
+
+    Parameters
+    ----------
+    chain_id : str
+        Effective protein chain ID.
+
+    Returns
+    -------
+    str
+        First eight hexadecimal characters of the SHA-256 digest.
+    """
+
+    serialized = json.dumps({"chain_id": chain_id}, sort_keys=True)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:8]
+
+
 class SecondaryStructureSettings(BaseModel):
     """Settings for secondary structure analysis.
 
     Chain ``A`` is the default protein chain under the PolyzyMD chain
-    convention.
+    convention. Set ``selection`` to an explicit MDAnalysis selection when
+    topology files do not preserve chain IDs.
     """
 
     chain_id: str = Field(
         default="A",
         description="Chain letter for the protein chain",
     )
+    selection: str | None = Field(
+        default=None,
+        description="Explicit MDAnalysis protein selection. Overrides chain_id when provided.",
+    )
+
+    @field_validator("chain_id")
+    @classmethod
+    def _validate_chain_id(cls, value: str) -> str:
+        """Validate and normalize the protein chain ID.
+
+        Parameters
+        ----------
+        value : str
+            User-provided protein chain ID.
+
+        Returns
+        -------
+        str
+            Stripped chain ID.
+        """
+
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Secondary-structure chain_id must not be empty")
+        return stripped
+
+    @field_validator("selection")
+    @classmethod
+    def _validate_selection(cls, value: str | None) -> str | None:
+        """Validate and normalize an explicit protein selection.
+
+        Parameters
+        ----------
+        value : str or None
+            Optional MDAnalysis selection string.
+
+        Returns
+        -------
+        str or None
+            Stripped selection string, or ``None`` when not configured.
+        """
+
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Secondary-structure selection must not be empty when provided")
+        return stripped
 
 
 class SecondaryStructureAnalysis(Analysis):
@@ -88,6 +156,8 @@ class SecondaryStructureAnalysis(Analysis):
             Stable settings fingerprint.
         """
 
+        if isinstance(settings, SecondaryStructureSettings) and settings.selection is None:
+            return _legacy_secondary_structure_fingerprint(settings.chain_id)
         return settings_fingerprint(settings)
 
     def aggregate_settings_fingerprint(self, settings: BaseModel | None) -> str | None:

--- a/src/polyzymd/analyses/secondary_structure/_mda.py
+++ b/src/polyzymd/analyses/secondary_structure/_mda.py
@@ -62,13 +62,13 @@ def build_secondary_structure_jobs(
         One job backed by an AnalysisBase-compatible DSSP adapter.
     """
 
-    selection = _protein_chain_selection(settings.chain_id)
+    selection = _effective_protein_selection(settings)
     return [
         MDAAnalysisJob(
             name="dssp",
             analysis=build_dssp_analysis(
                 universe=ctx.universe,
-                chain_id=settings.chain_id,
+                selection=selection,
                 timestep_ps=ctx.frame_selection.timestep_ps,
             ),
             frame_selection=ctx.frame_selection,
@@ -87,7 +87,7 @@ def build_secondary_structure_jobs(
     ]
 
 
-def build_dssp_analysis(*, universe: Any, chain_id: str, timestep_ps: float | None) -> Any:
+def build_dssp_analysis(*, universe: Any, selection: str, timestep_ps: float | None) -> Any:
     """Build an AnalysisBase-compatible DSSP adapter.
 
     The adapter lets MDAnalysis own frame iteration, including explicit frame
@@ -97,8 +97,8 @@ def build_dssp_analysis(*, universe: Any, chain_id: str, timestep_ps: float | No
     ----------
     universe : Any
         MDAnalysis universe for one replicate.
-    chain_id : str
-        Protein chain ID following the PolyzyMD chain convention.
+    selection : str
+        Effective MDAnalysis selection for complete protein residues.
     timestep_ps : float or None
         Trajectory timestep in picoseconds when available.
 
@@ -110,18 +110,27 @@ def build_dssp_analysis(*, universe: Any, chain_id: str, timestep_ps: float | No
 
     from MDAnalysis.analysis.base import AnalysisBase
 
-    selection = _protein_chain_selection(chain_id)
-
     class DSSPAnalysis(AnalysisBase):
         """Collect protein-chain coordinates and compute DSSP states."""
 
         def __init__(self) -> None:
-            atom_group = universe.select_atoms(selection)
+            try:
+                atom_group = universe.select_atoms(selection)
+            except AttributeError as exc:
+                if "chainid" in selection:
+                    raise ValueError(
+                        "Secondary-structure selection failed while using chain IDs. GROMACS "
+                        ".gro topologies may not preserve chain IDs for MDAnalysis selections. "
+                        "Set plugins.secondary_structure.selection to an explicit protein "
+                        "selection such as 'protein' or 'protein and resid START:STOP'."
+                    ) from exc
+                raise
             if len(atom_group) == 0:
                 raise ValueError(
                     f"Secondary-structure selection matched no atoms: {selection!r}. "
-                    "Check the configured chain_id."
+                    "Check plugins.secondary_structure.selection or chain_id."
                 )
+            _validate_complete_residue_selection(atom_group, selection)
             super().__init__(universe.trajectory)
             self._atom_group = atom_group
             self._raw_timestep_ps = float(timestep_ps) if timestep_ps is not None else None
@@ -468,6 +477,51 @@ def _protein_chain_selection(chain_id: str) -> str:
     """Return the MDAnalysis selection for a protein chain."""
 
     return f"protein and chainid {chain_id}"
+
+
+def _effective_protein_selection(settings: SecondaryStructureSettings) -> str:
+    """Return the configured secondary-structure atom selection.
+
+    Parameters
+    ----------
+    settings : SecondaryStructureSettings
+        User-facing secondary-structure settings.
+
+    Returns
+    -------
+    str
+        Explicit selection when configured, otherwise the chain-based default.
+    """
+
+    if settings.selection is not None:
+        return settings.selection
+    return _protein_chain_selection(settings.chain_id)
+
+
+def _validate_complete_residue_selection(atom_group: Any, selection: str) -> None:
+    """Reject selections that include only part of one or more residues.
+
+    Parameters
+    ----------
+    atom_group : Any
+        MDAnalysis atom group returned by the effective selection.
+    selection : str
+        Effective MDAnalysis selection string.
+
+    Raises
+    ------
+    ValueError
+        If selected atoms do not cover complete residues.
+    """
+
+    selected_atom_count = len(atom_group)
+    residue_atom_count = sum(len(residue.atoms) for residue in atom_group.residues)
+    if residue_atom_count != selected_atom_count:
+        raise ValueError(
+            f"Secondary-structure selection {selection!r} does not select complete residues. "
+            "DSSP requires complete, backbone-compatible protein residues; use a selection such "
+            "as 'protein' or 'protein and resid START:STOP' instead of CA-only selections."
+        )
 
 
 def _build_mdtraj_topology(atom_group: Any) -> tuple[Any, dict[str, list[Any]]]:

--- a/tests/analyses/plugins/test_secondary_structure.py
+++ b/tests/analyses/plugins/test_secondary_structure.py
@@ -40,7 +40,9 @@ from polyzymd.analyses.secondary_structure._mda import (
     DSSP_MATRIX_SIDECAR,
     SecondaryStructureArtifactCollector,
     _compute_dssp_state_matrix,
+    _effective_protein_selection,
     aggregate_secondary_structure_artifacts,
+    build_dssp_analysis,
     build_secondary_structure_jobs,
     encode_dssp_matrix,
     load_replicate_matrix,
@@ -71,6 +73,7 @@ def test_plugin_attributes(settings: SecondaryStructureSettings) -> None:
     """Plugin attributes should describe the MDA artifact lifecycle."""
 
     assert settings.chain_id == "A"
+    assert settings.selection is None
     assert SecondaryStructureAnalysis.name == "secondary_structure"
     assert SecondaryStructureAnalysis.AggregatedResultClass is None
     assert SecondaryStructureAnalysis.ReplicateResultClass is None
@@ -78,6 +81,55 @@ def test_plugin_attributes(settings: SecondaryStructureSettings) -> None:
         get_analysis("ss")
     assert SecondaryStructureAnalysis.slurm_resource_hint == SlurmResourceHint(mem="16G")
     assert "run_replicate" not in SecondaryStructureAnalysis.__dict__
+
+
+def test_secondary_structure_effective_default_selection() -> None:
+    """Default settings should preserve the legacy chain-based selection."""
+
+    settings = SecondaryStructureSettings()
+
+    assert _effective_protein_selection(settings) == "protein and chainid A"
+
+
+def test_secondary_structure_explicit_selection_overrides_chain_id() -> None:
+    """Explicit selection should override chain_id and avoid chainid syntax."""
+
+    settings = SecondaryStructureSettings(chain_id="B", selection=" protein ")
+
+    assert settings.selection == "protein"
+    assert _effective_protein_selection(settings) == "protein"
+
+
+def test_secondary_structure_settings_reject_empty_values() -> None:
+    """Settings validation should reject empty chain IDs and selections."""
+
+    with pytest.raises(ValueError, match="chain_id"):
+        SecondaryStructureSettings(chain_id=" ")
+    with pytest.raises(ValueError, match="selection"):
+        SecondaryStructureSettings(selection=" ")
+
+
+def test_secondary_structure_default_fingerprint_preserves_legacy_payload() -> None:
+    """Default cache identity should match the pre-selection chain-only payload."""
+
+    class LegacySecondaryStructureSettings(SecondaryStructureSettings):
+        selection: None = None
+
+        def model_dump(self, *args, **kwargs):
+            del args, kwargs
+            return {"chain_id": self.chain_id}
+
+    analysis = SecondaryStructureAnalysis()
+    default_settings = SecondaryStructureSettings()
+    explicit_settings = SecondaryStructureSettings(selection="protein")
+    legacy_settings = LegacySecondaryStructureSettings()
+
+    assert analysis.aggregate_settings_fingerprint(default_settings) == settings_fingerprint(
+        legacy_settings
+    )
+    assert analysis.aggregate_settings_fingerprint(explicit_settings) != settings_fingerprint(
+        legacy_settings
+    )
 
 
 def test_dssp_encoding() -> None:
@@ -123,6 +175,63 @@ def test_dssp_trajectory_uses_mdtraj_topology_keyword(monkeypatch) -> None:
     assert encoded.tolist() == [[1, 0]]
 
 
+def test_dssp_chainid_attribute_error_mentions_gromacs(monkeypatch) -> None:
+    """Chain-ID selection failures should give actionable GROMACS guidance."""
+
+    _install_fake_analysis_base(monkeypatch)
+
+    class FakeUniverse:
+        trajectory = []
+
+        def select_atoms(self, selection):
+            raise AttributeError("'Topology' object has no attribute 'chainIDs'")
+
+    with pytest.raises(ValueError, match="GROMACS.*selection.*protein"):
+        build_dssp_analysis(
+            universe=FakeUniverse(),
+            selection="protein and chainid A",
+            timestep_ps=None,
+        )
+
+
+def test_dssp_partial_residue_selection_is_rejected(monkeypatch) -> None:
+    """CA-only selections should be rejected before DSSP topology construction."""
+
+    _install_fake_analysis_base(monkeypatch)
+
+    residue = SimpleNamespace(atoms=[object(), object(), object(), object()])
+    atom_group = _FakeAtomGroup(atoms=[object()], residues=[residue])
+
+    class FakeUniverse:
+        trajectory = []
+
+        def select_atoms(self, selection):
+            return atom_group
+
+    with pytest.raises(ValueError, match="complete residues.*CA-only"):
+        build_dssp_analysis(
+            universe=FakeUniverse(),
+            selection="protein and name CA",
+            timestep_ps=None,
+        )
+
+
+def test_dssp_zero_atom_selection_mentions_selection_or_chain_id(monkeypatch) -> None:
+    """Empty selections should point users to both selection and chain_id settings."""
+
+    _install_fake_analysis_base(monkeypatch)
+    atom_group = _FakeAtomGroup(atoms=[], residues=[])
+
+    class FakeUniverse:
+        trajectory = []
+
+        def select_atoms(self, selection):
+            return atom_group
+
+    with pytest.raises(ValueError, match="selection or chain_id"):
+        build_dssp_analysis(universe=FakeUniverse(), selection="protein", timestep_ps=None)
+
+
 def test_build_mda_jobs_uses_frame_selection(monkeypatch, tmp_path, condition, settings) -> None:
     """Job construction should return an MDA job with the original frame selection."""
 
@@ -155,6 +264,50 @@ def test_build_mda_jobs_uses_frame_selection(monkeypatch, tmp_path, condition, s
     assert jobs[0].name == "dssp"
     assert jobs[0].frame_selection is frame_selection
     assert jobs[0].frame_selection.run_kwargs()["frames"] == [0, 3, 7]
+    assert jobs[0].universe_policy.metadata["secondary_structure_selection"] == (
+        "protein and chainid A"
+    )
+
+
+def test_build_mda_jobs_records_explicit_selection(monkeypatch, tmp_path, condition) -> None:
+    """Job metadata should record the effective explicit selection."""
+
+    import polyzymd.analyses.secondary_structure._mda as mda_mod
+
+    captured: dict[str, object] = {}
+    fake_analysis = SimpleNamespace(run=lambda **kwargs: None, results={})
+
+    def fake_build_dssp_analysis(**kwargs):
+        captured.update(kwargs)
+        return fake_analysis
+
+    monkeypatch.setattr(mda_mod, "build_dssp_analysis", fake_build_dssp_analysis)
+    settings = SecondaryStructureSettings(chain_id="A", selection="protein and resid 1:269")
+    replicate_ctx = ReplicateContext(
+        condition=condition,
+        replicate=1,
+        sim_config=condition.sim_config,
+        output_dir=tmp_path / "run_1",
+        equilibration="0ns",
+        recompute=True,
+        settings=settings,
+        result_path=tmp_path / "run_1" / "result.json",
+    )
+    frame_selection = FrameSelection(frames=np.asarray([0]), n_frames_total=1)
+    ctx = MDAReplicateJobContext(
+        replicate_context=replicate_ctx,
+        universe=MagicMock(),
+        frame_selection=frame_selection,
+        universe_policy=MDAUniversePolicy(condition_label="Control", replicate=1),
+        artifact_store=ArtifactStore(tmp_path / "run_1"),
+    )
+
+    jobs = build_secondary_structure_jobs(ctx, settings)
+
+    assert captured["selection"] == "protein and resid 1:269"
+    assert jobs[0].universe_policy.metadata["secondary_structure_selection"] == (
+        "protein and resid 1:269"
+    )
 
 
 def test_collector_writes_sidecar_artifact(tmp_path, condition, settings) -> None:
@@ -223,7 +376,7 @@ def test_aggregate_computes_occupancy_without_writing_condition_artifact(
         equilibration="0ns",
         output_dir=output_dir,
         artifacts=[artifact_1, artifact_2],
-        settings_fingerprint=settings_fingerprint(settings),
+        settings_fingerprint=_secondary_structure_settings_fingerprint(settings),
     )
 
     assert isinstance(artifact, ConditionArtifact)
@@ -261,7 +414,7 @@ def test_aggregate_rejects_residue_identity_mismatch(tmp_path, condition, settin
             equilibration="0ns",
             output_dir=tmp_path / "aggregated",
             artifacts=[artifact_1, artifact_2],
-            settings_fingerprint=settings_fingerprint(settings),
+            settings_fingerprint=_secondary_structure_settings_fingerprint(settings),
         )
 
 
@@ -513,7 +666,7 @@ def _collect_artifact(
         frame_selection=frame_selection,
         universe_policy=MDAUniversePolicy(condition_label=condition.label, replicate=replicate),
         artifact_store=ArtifactStore(run_dir),
-        settings_fingerprint=settings_fingerprint(settings),
+        settings_fingerprint=_secondary_structure_settings_fingerprint(settings),
     )
     job_result = MDAJobResult(
         name="dssp",
@@ -549,6 +702,42 @@ def _write_replicate_artifact(
     )
     ArtifactStore(run_dir).write_replicate_result(artifact, "result.json")
     return artifact
+
+
+class _FakeAtomGroup:
+    """Minimal atom-group fake for DSSP selection validation tests."""
+
+    def __init__(self, *, atoms: list[object], residues: list[object]) -> None:
+        self.atoms = atoms
+        self.residues = residues
+
+    def __len__(self) -> int:
+        """Return the number of selected atoms."""
+
+        return len(self.atoms)
+
+
+def _install_fake_analysis_base(monkeypatch) -> None:
+    """Install a minimal MDAnalysis AnalysisBase replacement."""
+
+    class FakeAnalysisBase:
+        def __init__(self, trajectory) -> None:
+            self._trajectory = trajectory
+            self.results = SimpleNamespace()
+
+    monkeypatch.setitem(sys.modules, "MDAnalysis", SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "MDAnalysis.analysis", SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "MDAnalysis.analysis.base",
+        SimpleNamespace(AnalysisBase=FakeAnalysisBase),
+    )
+
+
+def _secondary_structure_settings_fingerprint(settings: SecondaryStructureSettings) -> str:
+    """Return the plugin-specific secondary-structure settings fingerprint."""
+
+    return SecondaryStructureAnalysis._make_settings_cache_tag(settings)
 
 
 def _plot_condition_artifact(label: str, helix_fraction: float) -> ConditionArtifact:
@@ -608,5 +797,5 @@ def _condition_artifact(
                 }
             },
         },
-        metadata={"settings_fingerprint": settings_fingerprint(settings)},
+        metadata={"settings_fingerprint": _secondary_structure_settings_fingerprint(settings)},
     )


### PR DESCRIPTION
## Summary
- add optional plugins.secondary_structure.selection override for GROMACS/GRO topologies without chain IDs
- preserve legacy chain_id default behavior and cache fingerprints when no selection is configured
- improve chain-ID error guidance and reject partial-residue DSSP selections
- document GROMACS .gro selection examples and complete-residue requirement

## Tests
- MPLBACKEND=Agg pixi run -e cuda-12-6 pytest tests/analyses/plugins/test_secondary_structure.py -v
- pixi run -e cuda-12-6 ruff check src/polyzymd/analyses/secondary_structure tests/analyses/plugins/test_secondary_structure.py
- pixi run -e cuda-12-6 black --check src/polyzymd/analyses/secondary_structure tests/analyses/plugins/test_secondary_structure.py
- pixi run -e cuda-12-6 make -C docs clean html

Reviewer verdict: APPROVED