### PR TITLE
fix(hydrogen-bonds): support GRO topologies without elements

### DIFF
--- a/docs/source/how_to/hydrogen_bonds.md
+++ b/docs/source/how_to/hydrogen_bonds.md
@@ -90,12 +90,16 @@ hydrogen). The angle is measured at the hydrogen: D–H···A.
 :class: important
 
 The plugin passes your configured group union to MDAnalysis as the donor and
-acceptor selection, and uses `(<group union>) and element H` for hydrogens. This
-means your topology must contain explicit hydrogen atoms and usable element
-metadata for hydrogen selection. Topologies without hydrogens, with missing or
-incorrect element records, or with coarse-grained beads will undercount or
-return no H-bonds. The current public settings do not expose separate donor,
-hydrogen, and acceptor selection strings.
+acceptor selection. Your topology must contain explicit hydrogen atoms; systems
+without hydrogens or with coarse-grained beads will undercount or return no
+H-bonds.
+
+PolyzyMD prefers `(<group union>) and (element H)` for hydrogen selection. For
+GRO-like topologies with missing MDAnalysis `elements`, PolyzyMD tries to infer
+elements safely from atom types or atom names. If elements remain unavailable,
+`hydrogen_bonds` falls back to the conservative name pattern
+`(<group union>) and (name H* or name [123]H*)`. Use `hydrogens_selection` only
+for unusual explicit-hydrogen names.
 :::
 
 ### Groups
@@ -183,6 +187,7 @@ overlap, the plugin raises an error by default. Set
 | `top_n_pairs` | int | `15` | Number of top residue pairs to report per summary |
 | `allow_empty_groups` | bool | `true` | If `true` (default), warn and skip summaries when a referenced group selection matches no atoms. Set `false` for strict validation (raise `ValueError`). |
 | `allow_overlapping_composition` | bool | `false` | If `false`, overlapping composition partitions raise an error. Set `true` to allow overlap with warnings. |
+| `hydrogens_selection` | string or null | `null` | Advanced explicit-hydrogen selection override for unusual atom names. The default uses element metadata, with GRO-safe inference/name fallback when needed. |
 | `timestep_ps` | float or null | `null` | Manual frame spacing in ps for time-axis plots. If null, read from trajectory metadata. |
 
 If you want composition partitions to mirror group selections, define them

--- a/docs/source/reference/analysis_hydrogen_bonds_reference.md
+++ b/docs/source/reference/analysis_hydrogen_bonds_reference.md
@@ -17,15 +17,20 @@ Top-level plugin key and CLI name: `hydrogen_bonds`.
 | `allow_empty_groups` | `bool` | `true` | Warn and skip summaries with empty groups instead of raising |
 | `allow_overlapping_composition` | `bool` | `false` | Permit overlapping composition partitions |
 | `composition` | mapping or `null` | `null` | Optional donor/acceptor partition analysis |
+| `hydrogens_selection` | `str \| null` | `null` | Advanced explicit-hydrogen selection override for unusual atom names |
 | `timestep_ps` | `float \| null` | `null` | Optional uniform frame spacing for time-axis plots |
 
 Each summary defines exactly one of `between: [group_a, group_b]` or
 `within: group_name`. Mapping-form summaries use the mapping key as the summary
 name.
 
-Hydrogen detection uses MDAnalysis `HydrogenBondAnalysis` with hydrogens
-selected as `(<group union>) and element H`; topologies need explicit hydrogens
-and reliable element metadata.
+Hydrogen detection uses MDAnalysis `HydrogenBondAnalysis` and requires explicit
+hydrogen atoms in the topology. PolyzyMD prefers `(<group union>) and (element H)`
+for hydrogen selection. For GRO-like topologies that do not provide MDAnalysis
+`elements`, PolyzyMD first tries to infer missing elements safely from atom types
+or atom names. If element metadata remains unavailable, `hydrogen_bonds` falls
+back to `(<group union>) and (name H* or name [123]H*)`. Set
+`hydrogens_selection` only for unusual explicit-hydrogen naming schemes.
 
 ## Comparison mode
 

--- a/docs/source/reference/analysis_plugin_settings.md
+++ b/docs/source/reference/analysis_plugin_settings.md
@@ -128,6 +128,7 @@ DSSP requires complete residues; do not use CA-only selections such as
 | `allow_empty_groups` | `bool` | `true` | Warn/skip empty groups instead of raising |
 | `allow_overlapping_composition` | `bool` | `false` | Allow overlapping composition partitions (otherwise raise) |
 | `composition` | `HydrogenBondCompositionSettings \| null` | `null` | Optional partitioning for composition analysis |
+| `hydrogens_selection` | `str \| null` | `null` | Advanced explicit-hydrogen selection override for unusual atom names |
 | `timestep_ps` | `float \| null` | `null` | Optional timestep override (ps) for time-axis plots |
 
 Time-axis plots assume uniformly saved frames. PolyzyMD maps frame index to time
@@ -144,9 +145,12 @@ not supported.
 
 Exactly one of `between` or `within` must be set for each summary.
 
-Hydrogen detection uses MDAnalysis `HydrogenBondAnalysis` with hydrogens
-selected as `(<group union>) and element H`; explicit hydrogens and reliable
-element metadata are required for meaningful counts.
+Hydrogen detection uses MDAnalysis `HydrogenBondAnalysis` and requires explicit
+hydrogens. PolyzyMD prefers `(<group union>) and (element H)` and infers missing
+elements for GRO-like topologies when atom types or atom names are conservative
+enough. If elements remain unavailable, the plugin falls back to
+`(<group union>) and (name H* or name [123]H*)`. Set `hydrogens_selection` only
+for unusual explicit-hydrogen naming schemes.
 
 `HydrogenBondCompositionSettings`:
 

--- a/docs/source/reference/comparison_yaml.md
+++ b/docs/source/reference/comparison_yaml.md
@@ -298,6 +298,7 @@ Each entry in `runs`:
 | `allow_empty_groups` | bool | `true` | Allow empty group selections: `true` = warn and skip summaries when a group matches no atoms; `false` = raise error |
 | `allow_overlapping_composition` | bool | `false` | Whether overlapping composition partitions are allowed |
 | `composition` | mapping | `null` | Composition analysis settings |
+| `hydrogens_selection` | string | `null` | Advanced explicit-hydrogen selection override for unusual atom names |
 | `timestep_ps` | float | `null` | Override trajectory timestep in picoseconds for time-axis plots |
 
 Time-axis plots assume uniformly saved frames. PolyzyMD converts frame index to
@@ -314,9 +315,12 @@ Each summary entry in `summaries` has:
 
 For mapping-form input, keys are treated as `name` values.
 
-Hydrogen detection uses MDAnalysis `HydrogenBondAnalysis` with hydrogens
-selected as `(<group union>) and element H`; topologies need explicit hydrogens
-and usable element metadata.
+Hydrogen detection uses MDAnalysis `HydrogenBondAnalysis` and requires explicit
+hydrogens. PolyzyMD prefers `(<group union>) and (element H)`. For GRO-like
+topologies without MDAnalysis `elements`, PolyzyMD tries safe element inference
+from atom types or atom names; if elements remain unavailable, the plugin falls
+back to `(<group union>) and (name H* or name [123]H*)`. Set
+`hydrogens_selection` only for unusual explicit-hydrogen naming schemes.
 
 `composition` sub-fields:
 

--- a/src/polyzymd/analyses/hydrogen_bonds/__init__.py
+++ b/src/polyzymd/analyses/hydrogen_bonds/__init__.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Sequence
 
 import numpy as np
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 from polyzymd.analyses._framework.cache_identity import settings_fingerprint
 from polyzymd.analyses.base import (
@@ -337,6 +337,10 @@ class HydrogenBondSettings(BaseModel):
         If False, raise when composition partitions overlap.
     composition : HydrogenBondCompositionSettings | None
         Optional composition-partition settings.
+    hydrogens_selection : str | None
+        Advanced override for selecting explicit hydrogens. When omitted,
+        element metadata is preferred and atom-name fallback is used only when
+        elements are unavailable.
     """
 
     groups: dict[str, str] = Field(default_factory=lambda: dict(DEFAULT_GROUPS))
@@ -377,6 +381,14 @@ class HydrogenBondSettings(BaseModel):
         ),
     )
     composition: HydrogenBondCompositionSettings | None = None
+    hydrogens_selection: str | None = Field(
+        default=None,
+        description=(
+            "Advanced MDAnalysis selection for explicit hydrogens. If omitted, "
+            "hydrogen_bonds uses element H when element metadata are available and "
+            "falls back to hydrogen atom-name patterns otherwise."
+        ),
+    )
     timestep_ps: float | None = Field(
         default=None,
         gt=0,
@@ -438,6 +450,34 @@ class HydrogenBondSettings(BaseModel):
         new_data = dict(data)
         new_data["summaries"] = normalized
         return new_data
+
+    @field_validator("hydrogens_selection")
+    @classmethod
+    def validate_hydrogens_selection(cls, value: str | None) -> str | None:
+        """Validate the optional explicit-hydrogen selection override.
+
+        Parameters
+        ----------
+        value : str or None
+            User-provided MDAnalysis selection for hydrogens.
+
+        Returns
+        -------
+        str or None
+            Stripped selection text, or ``None`` when no override is provided.
+
+        Raises
+        ------
+        ValueError
+            Raised when the override is an empty string.
+        """
+
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("hydrogens_selection must not be empty when provided")
+        return stripped
 
     @model_validator(mode="after")
     def validate_summary_references(self) -> HydrogenBondSettings:

--- a/src/polyzymd/analyses/hydrogen_bonds/_mda.py
+++ b/src/polyzymd/analyses/hydrogen_bonds/_mda.py
@@ -62,6 +62,8 @@ class HydrogenBondMDAPlan:
     """Selection and summary state prepared for one hydrogen-bond replicate."""
 
     selection_string: str
+    hydrogens_selection_string: str
+    hydrogens_selection_source: str
     frame_indices: list[int]
     n_frames: int
     timestep_ps: float
@@ -157,7 +159,7 @@ class HydrogenBondMDAAnalysis:
         hbonds = HydrogenBondAnalysis(
             universe=self.universe,
             donors_sel=self.plan.selection_string,
-            hydrogens_sel=f"({self.plan.selection_string}) and element H",
+            hydrogens_sel=self.plan.hydrogens_selection_string,
             acceptors_sel=self.plan.selection_string,
             d_a_cutoff=self.settings.distance_cutoff,
             d_h_a_angle_cutoff=self.settings.angle_cutoff,
@@ -203,6 +205,7 @@ def build_hydrogen_bond_jobs(ctx: MDAReplicateJobContext) -> list[MDAAnalysisJob
             "angle_cutoff": settings.angle_cutoff,
             "update_selections": settings.update_selections,
             "allow_empty_groups": settings.allow_empty_groups,
+            "hydrogens_selection": settings.hydrogens_selection,
             "dynamic_selection_policy": dynamic_selection_policy_payload(settings),
         },
     )
@@ -292,6 +295,13 @@ class HydrogenBondArtifactCollector:
                 "dynamic_selection_policy": dynamic_selection_policy_payload(analysis.settings),
                 "composition_warnings": composition_warnings,
                 "update_selections": analysis.settings.update_selections,
+                "hydrogens_selection_policy": {
+                    "selection": analysis.plan.hydrogens_selection_string,
+                    "source": analysis.plan.hydrogens_selection_source,
+                    "element_enrichment": getattr(
+                        analysis.universe, "_polyzymd_element_enrichment", None
+                    ),
+                },
             },
             metadata={
                 "result_kind": "hydrogen_bonds_mda_replicate",
@@ -302,6 +312,8 @@ class HydrogenBondArtifactCollector:
                 "equilibration_time": eq_value,
                 "equilibration_unit": eq_unit,
                 "selection_string": analysis.plan.selection_string,
+                "hydrogens_selection_string": analysis.plan.hydrogens_selection_string,
+                "hydrogens_selection_source": analysis.plan.hydrogens_selection_source,
                 "timestep_ps": analysis.plan.timestep_ps,
                 "raw_timestep_ps": analysis.plan.raw_timestep_ps,
                 "frame_stride": analysis.plan.frame_stride,
@@ -425,6 +437,9 @@ def aggregate_hydrogen_bond_artifacts(
         provenance={
             "source": "hydrogen_bonds_replicate_artifact_aggregation",
             "frame_selection": ordered_artifacts[0].provenance.get("frame_selection"),
+            "hydrogens_selection_policy": ordered_artifacts[0].provenance.get(
+                "hydrogens_selection_policy"
+            ),
         },
         metadata={
             "result_kind": "hydrogen_bonds_mda_condition",
@@ -434,6 +449,12 @@ def aggregate_hydrogen_bond_artifacts(
             "equilibration_time": condition_model.equilibration_time,
             "equilibration_unit": condition_model.equilibration_unit,
             "selection_string": condition_model.selection_string,
+            "hydrogens_selection_string": ordered_artifacts[0].metadata.get(
+                "hydrogens_selection_string"
+            ),
+            "hydrogens_selection_source": ordered_artifacts[0].metadata.get(
+                "hydrogens_selection_source"
+            ),
             "timestep_ps": condition_model.timestep_ps,
             "raw_timestep_ps": condition_model.raw_timestep_ps,
             "frame_stride": condition_model.frame_stride,
@@ -829,6 +850,8 @@ def _prepare_hydrogen_bond_plan(
             summary_results_by_name[summary_spec.name] = summary_result
 
     union_sel = _build_union_selection(active_summary_specs, settings, resolved_groups)
+    hydrogens_selection_string = ""
+    hydrogens_selection_source = "none"
     if not union_sel:
         message = "No atoms selected for any summary — returning empty result"
         LOGGER.warning(message)
@@ -838,9 +861,24 @@ def _prepare_hydrogen_bond_plan(
                 summary_spec.name,
                 _build_zero_summary(summary_spec, n_frames=n_frames),
             )
+    else:
+        (
+            hydrogens_selection_string,
+            hydrogens_selection_source,
+            hydrogens_selection_warning,
+        ) = _resolve_hydrogens_selection(
+            universe=universe,
+            settings=settings,
+            group_union_selection=union_sel,
+        )
+        if hydrogens_selection_warning is not None:
+            LOGGER.warning(hydrogens_selection_warning)
+            warnings.append(hydrogens_selection_warning)
 
     return HydrogenBondMDAPlan(
         selection_string=union_sel,
+        hydrogens_selection_string=hydrogens_selection_string,
+        hydrogens_selection_source=hydrogens_selection_source,
         frame_indices=frame_indices,
         n_frames=n_frames,
         timestep_ps=effective_timestep_ps,
@@ -851,6 +889,68 @@ def _prepare_hydrogen_bond_plan(
         summary_results_by_name=summary_results_by_name,
         warnings=warnings,
     )
+
+
+def _universe_has_element_metadata(universe: Any) -> bool:
+    """Return whether a universe exposes complete element metadata.
+
+    Parameters
+    ----------
+    universe : Any
+        MDAnalysis universe or compatible test double.
+
+    Returns
+    -------
+    bool
+        ``True`` when elements are readable for all atoms.
+    """
+
+    try:
+        elements = list(universe.atoms.elements)
+        n_atoms = len(universe.atoms)
+    except (AttributeError, TypeError):
+        return False
+    return len(elements) == n_atoms
+
+
+def _resolve_hydrogens_selection(
+    *,
+    universe: Any,
+    settings: HydrogenBondSettings,
+    group_union_selection: str,
+) -> tuple[str, str, str | None]:
+    """Resolve the hydrogen selection used by MDAnalysis H-bond detection.
+
+    Parameters
+    ----------
+    universe : Any
+        MDAnalysis universe or compatible test double.
+    settings : HydrogenBondSettings
+        User-facing hydrogen-bond settings.
+    group_union_selection : str
+        Union of all active summary groups.
+
+    Returns
+    -------
+    tuple[str, str, str or None]
+        Selection string, source label, and optional warning.
+    """
+
+    if settings.hydrogens_selection is not None:
+        return f"({group_union_selection}) and ({settings.hydrogens_selection})", "user", None
+
+    if _universe_has_element_metadata(universe):
+        return f"({group_union_selection}) and (element H)", "element", None
+
+    enrichment = getattr(universe, "_polyzymd_element_enrichment", None)
+    enrichment_text = f" Element enrichment metadata: {enrichment}." if enrichment else ""
+    warning = (
+        "hydrogen_bonds could not read element metadata; falling back to hydrogen atom-name "
+        "patterns 'name H* or name [123]H*'. Explicit hydrogens are required. For unusual "
+        "hydrogen naming, set hydrogen_bonds.hydrogens_selection."
+        f"{enrichment_text}"
+    )
+    return f"({group_union_selection}) and (name H* or name [123]H*)", "name_fallback", warning
 
 
 def _warn_on_group_overlap(resolved_groups: dict[str, Any]) -> None:
@@ -1178,6 +1278,8 @@ def _write_event_sidecar(
             "shape": [int(dim) for dim in events.shape],
             "n_events": int(events.shape[0]),
             "selection_string": plan.selection_string,
+            "hydrogens_selection_string": plan.hydrogens_selection_string,
+            "hydrogens_selection_source": plan.hydrogens_selection_source,
             "distance_cutoff": settings.distance_cutoff,
             "angle_cutoff": settings.angle_cutoff,
             "update_selections": settings.update_selections,

--- a/src/polyzymd/analyses/shared/loader.py
+++ b/src/polyzymd/analyses/shared/loader.py
@@ -160,8 +160,31 @@ def _canonical_element_symbol(value: object) -> str | None:
     return None
 
 
+def _context_allows_type_element(symbol: str, name: object, resname: object | None) -> bool:
+    """Return whether atom context supports an element inferred from type.
+
+    Parameters
+    ----------
+    symbol : str
+        Element symbol inferred from the atom type.
+    name : object
+        Atom name from the topology.
+    resname : object or None
+        Residue name used to reject ambiguous ion aliases.
+
+    Returns
+    -------
+    bool
+        ``True`` when the atom name and residue context support the type-derived
+        element.
+    """
+
+    name_symbol = _infer_element_from_atom_name(name, resname)
+    return name_symbol == symbol
+
+
 def _infer_elements_from_atom_types(universe: Any) -> tuple[list[str] | None, str]:
-    """Infer topology elements from atom types when every type is element-like.
+    """Infer topology elements from atom types when context agrees.
 
     Parameters
     ----------
@@ -172,21 +195,40 @@ def _infer_elements_from_atom_types(universe: Any) -> tuple[list[str] | None, st
     -------
     tuple[list[str] | None, str]
         Inferred element symbols and a diagnostic message. The element list is
-        ``None`` when any atom type is missing or ambiguous.
+        ``None`` when any atom type is missing, ambiguous, or conflicts with
+        atom name and residue context.
     """
 
     try:
         atom_types = list(universe.atoms.types)
     except (AttributeError, TypeError):
         return None, "atom types are unavailable"
+    try:
+        names = list(universe.atoms.names)
+    except (AttributeError, TypeError):
+        return None, "atom names are unavailable for type validation"
+    try:
+        resnames = list(universe.atoms.resnames)
+    except (AttributeError, TypeError):
+        resnames = [None] * len(names)
+
+    if len(atom_types) != len(names) or len(atom_types) != len(resnames):
+        return None, "atom type, name, and residue metadata lengths differ"
 
     inferred: list[str] = []
-    for atom_type in atom_types:
+    for index, (atom_type, name, resname) in enumerate(
+        zip(atom_types, names, resnames, strict=True)
+    ):
         symbol = _canonical_element_symbol(atom_type)
         if symbol is None:
             return None, f"atom type {atom_type!r} is not element-like"
+        if not _context_allows_type_element(symbol, name, resname):
+            return None, (
+                f"atom type {atom_type!r} at index {index} conflicts with "
+                f"atom name {name!r} and residue {resname!r}"
+            )
         inferred.append(symbol)
-    return inferred, "all atom types are element-like"
+    return inferred, "all atom types are element-like and context-safe"
 
 
 def _infer_element_from_atom_name(name: object, resname: object | None = None) -> str | None:

--- a/src/polyzymd/analyses/shared/loader.py
+++ b/src/polyzymd/analyses/shared/loader.py
@@ -212,9 +212,13 @@ def _infer_element_from_atom_name(name: object, resname: object | None = None) -
     if not token:
         return None
 
-    residue = str(resname).strip().upper() if resname is not None else ""
-    if token in _COMMON_ION_ELEMENTS and residue in {token, f"{token}+", f"{token}-"}:
-        return _COMMON_ION_ELEMENTS[token]
+    residue = str(resname).strip().upper().rstrip("+-") if resname is not None else ""
+    residue_element = _COMMON_ION_ELEMENTS.get(residue)
+    if residue_element is not None:
+        name_element = _COMMON_ION_ELEMENTS.get(token)
+        if name_element == residue_element:
+            return name_element
+        return None
     if token in _COMMON_ION_ELEMENTS and token != "CA" and not residue:
         return _COMMON_ION_ELEMENTS[token]
     if token.startswith("H"):

--- a/src/polyzymd/analyses/shared/loader.py
+++ b/src/polyzymd/analyses/shared/loader.py
@@ -215,6 +215,17 @@ def _context_allows_type_element(symbol: str, name: object, resname: object | No
         element.
     """
 
+    name_token = str(name).strip().upper()
+    name_symbol = _canonical_element_symbol(name_token)
+    residue = str(resname).strip().upper().rstrip("+-") if resname is not None else ""
+    if (
+        len(name_token) == 2
+        and name_symbol == symbol
+        and residue not in _STANDARD_BIOMOLECULAR_RESIDUES
+        and residue not in _COMMON_ION_ELEMENTS
+    ):
+        return True
+
     name_symbol = _infer_element_from_atom_name(name, resname)
     return name_symbol == symbol
 
@@ -301,6 +312,13 @@ def _infer_element_from_atom_name(name: object, resname: object | None = None) -
         return None
     if base_token in {"CL", "BR"}:
         return _canonical_element_symbol(base_token)
+    if (
+        len(base_token) == 2
+        and base_token == token
+        and residue not in _STANDARD_BIOMOLECULAR_RESIDUES
+        and _canonical_element_symbol(base_token)
+    ):
+        return None
     if (
         has_numeric_suffix
         and len(base_token) == 2

--- a/src/polyzymd/analyses/shared/loader.py
+++ b/src/polyzymd/analyses/shared/loader.py
@@ -36,6 +36,60 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 _WARNED_GRO_TOPOLOGY_PATHS: set[Path] = set()
+_WARNED_ELEMENT_ENRICHMENT_KEYS: set[str] = set()
+
+_ELEMENT_SYMBOLS = frozenset(
+    {
+        "H",
+        "He",
+        "Li",
+        "Be",
+        "B",
+        "C",
+        "N",
+        "O",
+        "F",
+        "Ne",
+        "Na",
+        "Mg",
+        "Al",
+        "Si",
+        "P",
+        "S",
+        "Cl",
+        "Ar",
+        "K",
+        "Ca",
+        "Sc",
+        "Ti",
+        "V",
+        "Cr",
+        "Mn",
+        "Fe",
+        "Co",
+        "Ni",
+        "Cu",
+        "Zn",
+        "Br",
+        "I",
+    }
+)
+_COMMON_ION_ELEMENTS = {
+    "NA": "Na",
+    "SOD": "Na",
+    "CL": "Cl",
+    "CLA": "Cl",
+    "MG": "Mg",
+    "CA": "Ca",
+    "CAL": "Ca",
+    "ZN": "Zn",
+    "K": "K",
+    "POT": "K",
+    "FE": "Fe",
+    "CU": "Cu",
+    "MN": "Mn",
+}
+_BIOMOLECULAR_NAME_PREFIX_ELEMENTS = {"C", "N", "O", "S", "P", "F", "I"}
 
 
 def _normalized_warning_path(path: Path) -> Path:
@@ -80,6 +134,206 @@ def _require_matplotlib(feature_name: str = "plotting") -> None:
             "Ensure matplotlib is available in the PolyzyMD pixi environment "
             '(for example: pixi run -e build python -c "import matplotlib")'
         ) from None
+
+
+def _canonical_element_symbol(value: object) -> str | None:
+    """Return a canonical element symbol for an unambiguous token.
+
+    Parameters
+    ----------
+    value : object
+        Candidate atom type or atom name token.
+
+    Returns
+    -------
+    str or None
+        Canonical element symbol, or ``None`` when the token is not a plain
+        element symbol.
+    """
+
+    token = str(value).strip()
+    if not token or not token.isalpha() or len(token) > 2:
+        return None
+    symbol = token[0].upper() + token[1:].lower()
+    if symbol in _ELEMENT_SYMBOLS:
+        return symbol
+    return None
+
+
+def _infer_elements_from_atom_types(universe: Any) -> tuple[list[str] | None, str]:
+    """Infer topology elements from atom types when every type is element-like.
+
+    Parameters
+    ----------
+    universe : Any
+        MDAnalysis universe or compatible test double.
+
+    Returns
+    -------
+    tuple[list[str] | None, str]
+        Inferred element symbols and a diagnostic message. The element list is
+        ``None`` when any atom type is missing or ambiguous.
+    """
+
+    try:
+        atom_types = list(universe.atoms.types)
+    except (AttributeError, TypeError):
+        return None, "atom types are unavailable"
+
+    inferred: list[str] = []
+    for atom_type in atom_types:
+        symbol = _canonical_element_symbol(atom_type)
+        if symbol is None:
+            return None, f"atom type {atom_type!r} is not element-like"
+        inferred.append(symbol)
+    return inferred, "all atom types are element-like"
+
+
+def _infer_element_from_atom_name(name: object, resname: object | None = None) -> str | None:
+    """Infer an element from a conservative atom-name heuristic.
+
+    Parameters
+    ----------
+    name : object
+        Atom name from the topology.
+    resname : object or None, optional
+        Residue name used to distinguish ions such as calcium from protein
+        alpha carbons named ``CA``.
+
+    Returns
+    -------
+    str or None
+        Inferred element symbol, or ``None`` when no conservative inference is
+        possible.
+    """
+
+    raw_name = str(name).strip()
+    token = re.sub(r"^\d+", "", raw_name).upper()
+    if not token:
+        return None
+
+    residue = str(resname).strip().upper() if resname is not None else ""
+    if token in _COMMON_ION_ELEMENTS and residue in {token, f"{token}+", f"{token}-"}:
+        return _COMMON_ION_ELEMENTS[token]
+    if token in _COMMON_ION_ELEMENTS and token != "CA" and not residue:
+        return _COMMON_ION_ELEMENTS[token]
+    if token.startswith("H"):
+        return "H"
+    first_letter = token[0]
+    if first_letter in _BIOMOLECULAR_NAME_PREFIX_ELEMENTS:
+        return first_letter
+    return None
+
+
+def _infer_elements_from_atom_names(universe: Any) -> tuple[list[str] | None, str]:
+    """Infer topology elements from atom names when all atoms are recognized.
+
+    Parameters
+    ----------
+    universe : Any
+        MDAnalysis universe or compatible test double.
+
+    Returns
+    -------
+    tuple[list[str] | None, str]
+        Inferred element symbols and a diagnostic message. The element list is
+        ``None`` when any atom cannot be inferred conservatively.
+    """
+
+    try:
+        names = list(universe.atoms.names)
+    except (AttributeError, TypeError):
+        return None, "atom names are unavailable"
+    try:
+        resnames = list(universe.atoms.resnames)
+    except (AttributeError, TypeError):
+        resnames = [None] * len(names)
+
+    inferred: list[str] = []
+    for index, (name, resname) in enumerate(zip(names, resnames, strict=True)):
+        symbol = _infer_element_from_atom_name(name, resname)
+        if symbol is None:
+            return None, f"atom name {name!r} at index {index} is not safely inferable"
+        inferred.append(symbol)
+    return inferred, "all atom names matched conservative element rules"
+
+
+def _universe_has_elements(universe: Any) -> bool:
+    """Return whether a universe exposes complete element metadata.
+
+    Parameters
+    ----------
+    universe : Any
+        MDAnalysis universe or compatible test double.
+
+    Returns
+    -------
+    bool
+        ``True`` when element metadata can be read for all atoms.
+    """
+
+    try:
+        elements = list(universe.atoms.elements)
+    except (AttributeError, TypeError):
+        return False
+    return len(elements) == len(universe.atoms)
+
+
+def enrich_universe_elements(
+    universe: Any, *, topology_key: str | Path | None = None
+) -> dict[str, Any]:
+    """Add missing MDAnalysis element metadata when it can be inferred safely.
+
+    Parameters
+    ----------
+    universe : Any
+        MDAnalysis universe to enrich in place.
+    topology_key : str or Path or None, optional
+        Stable key for one-time logging, usually the topology path.
+
+    Returns
+    -------
+    dict[str, Any]
+        Lightweight enrichment metadata with ``applied``, ``source``, and
+        diagnostic ``message`` or ``reason`` fields.
+    """
+
+    if _universe_has_elements(universe):
+        metadata = {"applied": False, "source": "existing", "message": "elements already present"}
+        universe._polyzymd_element_enrichment = metadata
+        return metadata
+
+    elements, type_reason = _infer_elements_from_atom_types(universe)
+    source = "types"
+    if elements is None:
+        elements, name_reason = _infer_elements_from_atom_names(universe)
+        source = "names"
+        reason = f"type inference skipped: {type_reason}; name inference skipped: {name_reason}"
+    else:
+        reason = type_reason
+
+    if elements is None:
+        metadata = {"applied": False, "source": None, "reason": reason}
+        universe._polyzymd_element_enrichment = metadata
+        return metadata
+
+    universe.add_TopologyAttr("elements", elements)
+    metadata = {
+        "applied": True,
+        "source": source,
+        "message": f"elements inferred from atom {source}",
+    }
+    universe._polyzymd_element_enrichment = metadata
+
+    warning_key = str(topology_key or id(universe))
+    if warning_key not in _WARNED_ELEMENT_ENRICHMENT_KEYS:
+        _WARNED_ELEMENT_ENRICHMENT_KEYS.add(warning_key)
+        LOGGER.info(
+            "Inferred missing topology elements from atom %s for %s",
+            source,
+            topology_key or "MDAnalysis universe",
+        )
+    return metadata
 
 
 def _trajectory_frame_index(trajectory: Any) -> int | None:
@@ -654,6 +908,7 @@ class TrajectoryLoader:
                 str(info.topology_file),
                 [str(f) for f in info.trajectory_files],
             )
+        enrich_universe_elements(u, topology_key=info.topology_file)
         u.trajectory = _wrap_timestamp_preserving_trajectory(u.trajectory)
 
         if cache:

--- a/src/polyzymd/analyses/shared/loader.py
+++ b/src/polyzymd/analyses/shared/loader.py
@@ -90,6 +90,42 @@ _COMMON_ION_ELEMENTS = {
     "MN": "Mn",
 }
 _BIOMOLECULAR_NAME_PREFIX_ELEMENTS = {"C", "N", "O", "S", "P", "F", "I"}
+_STANDARD_BIOMOLECULAR_RESIDUES = {
+    "ALA",
+    "ARG",
+    "ASN",
+    "ASP",
+    "CYS",
+    "CYX",
+    "GLN",
+    "GLU",
+    "GLY",
+    "HID",
+    "HIE",
+    "HIP",
+    "HIS",
+    "ILE",
+    "LEU",
+    "LYS",
+    "MET",
+    "PHE",
+    "PRO",
+    "SER",
+    "THR",
+    "TRP",
+    "TYR",
+    "VAL",
+    "A",
+    "C",
+    "G",
+    "T",
+    "U",
+    "DA",
+    "DC",
+    "DG",
+    "DT",
+    "DU",
+}
 
 
 def _normalized_warning_path(path: Path) -> Path:
@@ -253,13 +289,24 @@ def _infer_element_from_atom_name(name: object, resname: object | None = None) -
     token = re.sub(r"^\d+", "", raw_name).upper()
     if not token:
         return None
+    base_token = re.sub(r"\d+$", "", token)
+    has_numeric_suffix = base_token != token
 
     residue = str(resname).strip().upper().rstrip("+-") if resname is not None else ""
     residue_element = _COMMON_ION_ELEMENTS.get(residue)
     if residue_element is not None:
-        name_element = _COMMON_ION_ELEMENTS.get(token)
+        name_element = _COMMON_ION_ELEMENTS.get(base_token)
         if name_element == residue_element:
             return name_element
+        return None
+    if base_token in {"CL", "BR"}:
+        return _canonical_element_symbol(base_token)
+    if (
+        has_numeric_suffix
+        and len(base_token) == 2
+        and residue not in _STANDARD_BIOMOLECULAR_RESIDUES
+        and _canonical_element_symbol(base_token)
+    ):
         return None
     if token in _COMMON_ION_ELEMENTS and token != "CA" and not residue:
         return _COMMON_ION_ELEMENTS[token]

--- a/tests/analyses/plugins/test_hydrogen_bonds.py
+++ b/tests/analyses/plugins/test_hydrogen_bonds.py
@@ -76,11 +76,26 @@ class _MockAtom:
 
 
 class _MockAtomCollection:
-    def __init__(self, atoms_by_index: dict[int, _MockAtom]) -> None:
+    """Minimal atom collection with optional element metadata."""
+
+    def __init__(
+        self, atoms_by_index: dict[int, _MockAtom], elements: list[str] | None = None
+    ) -> None:
+        """Store atoms and optional element topology metadata."""
+
         self._atoms_by_index = atoms_by_index
+        if elements is not None:
+            self.elements = elements
 
     def __getitem__(self, item: int) -> _MockAtom:
+        """Return one atom by topology index."""
+
         return self._atoms_by_index[item]
+
+    def __len__(self) -> int:
+        """Return the number of stored atoms."""
+
+        return len(self._atoms_by_index)
 
 
 class _MockAtomGroup:
@@ -246,6 +261,7 @@ def test_settings_defaults() -> None:
     assert settings.summaries[0].name == "protein_polymer"
     assert settings.summaries[0].between == ("protein", "polymer")
     assert settings.allow_empty_groups is True
+    assert settings.hydrogens_selection is None
 
 
 def test_settings_custom() -> None:
@@ -259,6 +275,13 @@ def test_settings_custom() -> None:
     )
     assert set(settings.groups) == {"enzyme", "ligand", "polymer"}
     assert [summary.name for summary in settings.summaries] == ["enzyme_polymer", "ligand_internal"]
+
+
+def test_empty_hydrogens_selection_is_rejected() -> None:
+    """Blank hydrogen selection overrides should fail validation."""
+
+    with pytest.raises(ValidationError, match="hydrogens_selection must not be empty"):
+        HydrogenBondSettings(hydrogens_selection="   ")
 
 
 def test_settings_accepts_mapping_summaries_form() -> None:
@@ -450,6 +473,137 @@ def test_mda_analysis_records_effective_timestep_metadata() -> None:
     assert analysis.plan.timestep_ps == pytest.approx(30.0)
     assert analysis.plan.raw_timestep_ps == pytest.approx(10.0)
     assert analysis.plan.frame_stride == 3
+
+
+def test_mda_analysis_uses_element_h_when_elements_available() -> None:
+    """Element metadata should drive the default hydrogen selection."""
+
+    instances: list[MockHydrogenBondAnalysis] = []
+
+    class MockHydrogenBondAnalysis:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+            self.results = types.SimpleNamespace(hbonds=np.empty((0, 6), dtype=float))
+            instances.append(self)
+
+        def run(self, start: int, stop: int | None, step: int, verbose: bool) -> None:
+            del start, stop, step, verbose
+
+    universe = MagicMock()
+    universe.trajectory = [object()] * 3
+    universe.atoms = _MockAtomCollection(
+        {
+            0: _MockAtom(0, "A", 10, "SER", 0),
+            1: _MockAtom(1, "C", 100, "OEG", 1),
+        },
+        elements=["C", "O"],
+    )
+    universe.select_atoms.side_effect = lambda selection, updating: {
+        "chainid A": _MockAtomGroup([0]),
+        "chainid C": _MockAtomGroup([1]),
+    }[selection]
+    analysis = HydrogenBondMDAAnalysis(
+        universe=universe,
+        settings=HydrogenBondSettings(),
+        condition_label="test",
+        replicate=1,
+        raw_timestep_ps=10.0,
+    )
+
+    with patch.dict(sys.modules, _make_mdanalysis_module(MockHydrogenBondAnalysis)):
+        analysis.run(start=0, stop=3, step=1)
+
+    assert analysis.plan is not None
+    assert analysis.plan.hydrogens_selection_source == "element"
+    assert instances[0].kwargs["hydrogens_sel"] == "((chainid A) or (chainid C)) and (element H)"
+
+
+def test_mda_analysis_uses_name_fallback_without_elements() -> None:
+    """Missing element metadata should fall back to explicit hydrogen names."""
+
+    instances: list[MockHydrogenBondAnalysis] = []
+
+    class MockHydrogenBondAnalysis:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+            self.results = types.SimpleNamespace(hbonds=np.empty((0, 6), dtype=float))
+            instances.append(self)
+
+        def run(self, start: int, stop: int | None, step: int, verbose: bool) -> None:
+            del start, stop, step, verbose
+
+    universe = MagicMock()
+    universe.trajectory = [object()] * 3
+    universe.atoms = _MockAtomCollection(
+        {
+            0: _MockAtom(0, "A", 10, "SER", 0),
+            1: _MockAtom(1, "C", 100, "OEG", 1),
+        }
+    )
+    universe._polyzymd_element_enrichment = {"applied": False, "reason": "test"}
+    universe.select_atoms.side_effect = lambda selection, updating: {
+        "chainid A": _MockAtomGroup([0]),
+        "chainid C": _MockAtomGroup([1]),
+    }[selection]
+    analysis = HydrogenBondMDAAnalysis(
+        universe=universe,
+        settings=HydrogenBondSettings(),
+        condition_label="test",
+        replicate=1,
+        raw_timestep_ps=10.0,
+    )
+
+    with patch.dict(sys.modules, _make_mdanalysis_module(MockHydrogenBondAnalysis)):
+        analysis.run(start=0, stop=3, step=1)
+
+    assert analysis.plan is not None
+    assert analysis.plan.hydrogens_selection_source == "name_fallback"
+    assert instances[0].kwargs["hydrogens_sel"] == (
+        "((chainid A) or (chainid C)) and (name H* or name [123]H*)"
+    )
+    assert any("hydrogens_selection" in warning for warning in analysis.plan.warnings)
+
+
+def test_mda_analysis_wraps_user_hydrogens_selection() -> None:
+    """User hydrogen selection overrides should still be limited to active groups."""
+
+    instances: list[MockHydrogenBondAnalysis] = []
+
+    class MockHydrogenBondAnalysis:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+            self.results = types.SimpleNamespace(hbonds=np.empty((0, 6), dtype=float))
+            instances.append(self)
+
+        def run(self, start: int, stop: int | None, step: int, verbose: bool) -> None:
+            del start, stop, step, verbose
+
+    universe = MagicMock()
+    universe.trajectory = [object()] * 3
+    universe.atoms = _MockAtomCollection(
+        {
+            0: _MockAtom(0, "A", 10, "SER", 0),
+            1: _MockAtom(1, "C", 100, "OEG", 1),
+        }
+    )
+    universe.select_atoms.side_effect = lambda selection, updating: {
+        "chainid A": _MockAtomGroup([0]),
+        "chainid C": _MockAtomGroup([1]),
+    }[selection]
+    analysis = HydrogenBondMDAAnalysis(
+        universe=universe,
+        settings=HydrogenBondSettings(hydrogens_selection="name HW*"),
+        condition_label="test",
+        replicate=1,
+        raw_timestep_ps=10.0,
+    )
+
+    with patch.dict(sys.modules, _make_mdanalysis_module(MockHydrogenBondAnalysis)):
+        analysis.run(start=0, stop=3, step=1)
+
+    assert analysis.plan is not None
+    assert analysis.plan.hydrogens_selection_source == "user"
+    assert instances[0].kwargs["hydrogens_sel"] == "((chainid A) or (chainid C)) and (name HW*)"
 
 
 def test_replicate_artifact_preserves_timing_metadata(tmp_path: Path) -> None:
@@ -777,6 +931,15 @@ def test_compute_stage_basic(tmp_path: Path) -> None:
     assert len(instances) == 1
     assert instances[0].kwargs["d_a_cutoff"] == pytest.approx(settings.distance_cutoff)
     assert instances[0].kwargs["d_h_a_angle_cutoff"] == pytest.approx(settings.angle_cutoff)
+    assert instances[0].kwargs["hydrogens_sel"] == (
+        "((chainid A) or (chainid C)) and (name H* or name [123]H*)"
+    )
+    assert artifact.metadata["hydrogens_selection_source"] == "name_fallback"
+    assert artifact.metadata["hydrogens_selection_string"] == (
+        "((chainid A) or (chainid C)) and (name H* or name [123]H*)"
+    )
+    assert artifact.provenance["hydrogens_selection_policy"]["source"] == "name_fallback"
+    assert any("hydrogens_selection" in warning for warning in artifact.warnings)
     assert instances[0].run_args is not None
     assert instances[0].run_args["start"] == 0
 
@@ -4727,7 +4890,7 @@ def test_compute_stage_hydrogens_sel_explicit(tmp_path: Path) -> None:
     }
     universe = MagicMock()
     universe.trajectory = [object(), object(), object()]
-    universe.atoms = _MockAtomCollection(atoms)
+    universe.atoms = _MockAtomCollection(atoms, elements=["C", "O"])
     selections = {
         "chainid A": _MockAtomGroup([0]),
         "chainid C": _MockAtomGroup([1]),
@@ -4770,7 +4933,7 @@ def test_compute_stage_hydrogens_sel_explicit(tmp_path: Path) -> None:
     hydrogens_sel = captured_kwargs[0]["hydrogens_sel"]
     assert hydrogens_sel is not None, "hydrogens_sel must not be None (causes NoDataError on PDB)"
     assert "element H" in hydrogens_sel
-    expected = "((chainid A) or (chainid C)) and element H"
+    expected = "((chainid A) or (chainid C)) and (element H)"
     assert hydrogens_sel == expected
 
 

--- a/tests/analyses/shared/test_loader.py
+++ b/tests/analyses/shared/test_loader.py
@@ -23,6 +23,8 @@ import pytest
 
 from polyzymd.analyses.shared.loader import TrajectoryLoader, enrich_universe_elements
 
+TEST_DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -269,7 +271,11 @@ class TestUniverseElementEnrichment:
         """Element-like GROMACS atom types should be copied as elements."""
 
         universe = _ElementFakeUniverse(
-            _ElementFakeAtoms(names=["CA", "H1", "NA", "CL"], types=["C", "H", "NA", "CL"])
+            _ElementFakeAtoms(
+                names=["CA", "H1", "NA", "CL"],
+                types=["C", "H", "NA", "CL"],
+                resnames=["ALA", "ALA", "SOD", "CLA"],
+            )
         )
 
         metadata = enrich_universe_elements(universe, topology_key="safe-types.gro")
@@ -280,6 +286,59 @@ class TestUniverseElementEnrichment:
             "message": "elements inferred from atom types",
         }
         assert universe.atoms.elements == ["C", "H", "Na", "Cl"]
+
+    @pytest.mark.parametrize(
+        ("name", "atom_type", "resname", "expected"),
+        [
+            ("CA", "CA", "ALA", "C"),
+            ("NA", "NA", "SOD", "Na"),
+            ("CL", "CL", "CLA", "Cl"),
+            ("CA", "CA", "CAL", "Ca"),
+        ],
+    )
+    def test_atom_types_are_validated_against_name_and_residue_context(
+        self,
+        name: str,
+        atom_type: str,
+        resname: str,
+        expected: str,
+    ) -> None:
+        """Type inference should accept only context-safe element assignments."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=[name], types=[atom_type], resnames=[resname])
+        )
+
+        metadata = enrich_universe_elements(
+            universe, topology_key=f"type-context-{name}-{atom_type}-{resname}.gro"
+        )
+
+        assert metadata["applied"] is True
+        assert universe.atoms.elements == [expected]
+
+    @pytest.mark.parametrize(
+        ("name", "atom_type", "resname"),
+        [("NA", "NA", "CLA"), ("CAX", "CA", "CAL")],
+    )
+    def test_conflicting_ion_like_atom_types_skip_enrichment(
+        self,
+        name: str,
+        atom_type: str,
+        resname: str,
+    ) -> None:
+        """Conflicting ion aliases should not be enriched from atom types."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=[name], types=[atom_type], resnames=[resname])
+        )
+
+        metadata = enrich_universe_elements(
+            universe, topology_key=f"type-conflict-{name}-{atom_type}-{resname}.gro"
+        )
+
+        assert metadata["applied"] is False
+        assert metadata["source"] is None
+        assert not hasattr(universe.atoms, "elements")
 
     def test_unsafe_atom_types_fall_back_to_names(self) -> None:
         """Force-field-like atom types should use conservative atom names."""
@@ -297,6 +356,19 @@ class TestUniverseElementEnrichment:
         assert metadata["applied"] is True
         assert metadata["source"] == "names"
         assert universe.atoms.elements == ["C", "H", "O", "H"]
+
+    def test_ambiguous_type_path_falls_back_to_names_for_protein_alpha_carbon(self) -> None:
+        """Protein alpha carbons typed as ``CA`` should not become calcium."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=["CA", "H"], types=["CA", "H"], resnames=["ALA", "ALA"])
+        )
+
+        metadata = enrich_universe_elements(universe, topology_key="ala-ca-type.gro")
+
+        assert metadata["applied"] is True
+        assert metadata["source"] == "names"
+        assert universe.atoms.elements == ["C", "H"]
 
     @pytest.mark.parametrize(
         ("name", "resname", "expected"),
@@ -356,6 +428,24 @@ class TestUniverseElementEnrichment:
         assert metadata["applied"] is False
         assert metadata["source"] is None
         assert not hasattr(universe.atoms, "elements")
+
+    def test_committed_gro_fixture_enables_element_h_selection(self) -> None:
+        """Committed GRO fixture should exercise portable element enrichment."""
+
+        import MDAnalysis as mda
+
+        gro_path = TEST_DATA_DIR / "gromacs" / "hbonds_element_fallback.gro"
+        universe = mda.Universe(str(gro_path))
+
+        metadata = enrich_universe_elements(universe, topology_key=gro_path)
+
+        assert metadata["applied"] is True
+        assert metadata["source"] == "names"
+        assert list(universe.atoms.elements) == ["N", "C", "H", "Na", "Cl", "Ca"]
+        assert universe.select_atoms("resname ALA and name CA").elements.tolist() == ["C"]
+        assert universe.select_atoms("resname SOD and name NA").elements.tolist() == ["Na"]
+        assert universe.select_atoms("resname CLA and name CL").elements.tolist() == ["Cl"]
+        assert len(universe.select_atoms("element H")) == 1
 
     @pytest.mark.skipif(
         not Path("/home/joelaforet/Shirts-Lab-Linux/polyzymd_debugging/fn-d10.gro").exists(),

--- a/tests/analyses/shared/test_loader.py
+++ b/tests/analyses/shared/test_loader.py
@@ -316,6 +316,67 @@ class TestUniverseElementEnrichment:
         assert metadata["applied"] is True
         assert universe.atoms.elements == [expected]
 
+    @pytest.mark.parametrize(
+        ("name", "atom_type", "resname", "expected", "first_letter"),
+        [
+            ("FE", "FE", "HEM", "Fe", "F"),
+            ("CU", "CU", "LIG", "Cu", "C"),
+            ("NI", "NI", "LIG", "Ni", "N"),
+        ],
+    )
+    def test_exact_type_name_nonstandard_metals_use_types(
+        self,
+        name: str,
+        atom_type: str,
+        resname: str,
+        expected: str,
+        first_letter: str,
+    ) -> None:
+        """Exact type/name metal tokens in nonstandard residues should use types."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=[name], types=[atom_type], resnames=[resname])
+        )
+
+        metadata = enrich_universe_elements(
+            universe, topology_key=f"metal-type-{name}-{atom_type}-{resname}.gro"
+        )
+
+        assert metadata["applied"] is True
+        assert metadata["source"] == "types"
+        assert universe.atoms.elements == [expected]
+        assert universe.atoms.elements != [first_letter]
+
+    @pytest.mark.parametrize(
+        ("name", "atom_type", "resname", "first_letter"),
+        [
+            ("FE", "XX", "HEM", "F"),
+            ("CU", "XX", "LIG", "C"),
+            ("NI", "XX", "LIG", "N"),
+        ],
+    )
+    def test_exact_name_only_nonstandard_metals_skip_enrichment(
+        self,
+        name: str,
+        atom_type: str,
+        resname: str,
+        first_letter: str,
+    ) -> None:
+        """Name-only metal tokens should not fall back to first letters."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=[name], types=[atom_type], resnames=[resname])
+        )
+
+        metadata = enrich_universe_elements(
+            universe, topology_key=f"metal-name-{name}-{atom_type}-{resname}.gro"
+        )
+
+        assert metadata["applied"] is False
+        assert metadata["source"] is None
+        assert not hasattr(universe.atoms, "elements")
+        assert getattr(universe.atoms, "elements", [None]) != [first_letter]
+
     def test_suffixed_chlorine_ligand_name_uses_halogen_context(self) -> None:
         """Suffixed chlorine names should not fall back to carbon."""
 

--- a/tests/analyses/shared/test_loader.py
+++ b/tests/analyses/shared/test_loader.py
@@ -316,6 +316,45 @@ class TestUniverseElementEnrichment:
         assert metadata["applied"] is True
         assert universe.atoms.elements == [expected]
 
+    def test_suffixed_chlorine_ligand_name_uses_halogen_context(self) -> None:
+        """Suffixed chlorine names should not fall back to carbon."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=["CL1"], types=["CL"], resnames=["LIG"])
+        )
+
+        metadata = enrich_universe_elements(universe, topology_key="ligand-cl1.gro")
+
+        assert metadata == {
+            "applied": True,
+            "source": "types",
+            "message": "elements inferred from atom types",
+        }
+        assert universe.atoms.elements == ["Cl"]
+
+    @pytest.mark.parametrize(
+        ("name", "atom_type"),
+        [("CA1", "CA"), ("NA1", "NA"), ("MG1", "MG"), ("ZN1", "ZN")],
+    )
+    def test_ambiguous_numeric_two_letter_ligand_names_skip_enrichment(
+        self,
+        name: str,
+        atom_type: str,
+    ) -> None:
+        """Ambiguous suffixed metal-like ligand names should not use first letters."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=[name], types=[atom_type], resnames=["LIG"])
+        )
+
+        metadata = enrich_universe_elements(
+            universe, topology_key=f"ambiguous-ligand-{name}-{atom_type}.gro"
+        )
+
+        assert metadata["applied"] is False
+        assert metadata["source"] is None
+        assert not hasattr(universe.atoms, "elements")
+
     @pytest.mark.parametrize(
         ("name", "atom_type", "resname"),
         [("NA", "NA", "CLA"), ("CAX", "CA", "CAL")],

--- a/tests/analyses/shared/test_loader.py
+++ b/tests/analyses/shared/test_loader.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from polyzymd.analyses.shared.loader import TrajectoryLoader
+from polyzymd.analyses.shared.loader import TrajectoryLoader, enrich_universe_elements
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -129,6 +129,43 @@ class _FakeTrajectory:
         self.ts.data = {"time": self.raw_times_ps[self.frame]}
 
 
+class _ElementFakeAtoms:
+    """Minimal atom container for element-enrichment tests."""
+
+    def __init__(
+        self,
+        *,
+        names: list[str],
+        types: list[str] | None = None,
+        resnames: list[str] | None = None,
+        elements: list[str] | None = None,
+    ) -> None:
+        self.names = names
+        self.types = types if types is not None else []
+        self.resnames = resnames if resnames is not None else ["ALA"] * len(names)
+        if elements is not None:
+            self.elements = elements
+
+    def __len__(self) -> int:
+        """Return the number of fake atoms."""
+
+        return len(self.names)
+
+
+class _ElementFakeUniverse:
+    """Minimal universe that records added element topology attributes."""
+
+    def __init__(self, atoms: _ElementFakeAtoms) -> None:
+        self.atoms = atoms
+        self.added_topology_attrs: dict[str, list[str]] = {}
+
+    def add_TopologyAttr(self, name: str, values: list[str]) -> None:
+        """Record an added topology attribute on the fake atoms object."""
+
+        self.added_topology_attrs[name] = values
+        setattr(self.atoms, name, values)
+
+
 def _loader_for_trajectory(trajectory: _FakeTrajectory) -> TrajectoryLoader:
     """Build a loader instance backed by a fake trajectory."""
 
@@ -210,6 +247,86 @@ class TestTrajectoryTimingMetadata:
 
         assert loader.get_timestep(1, unit="ps") == pytest.approx(400.0)
         assert trajectory.frame == 2
+
+
+class TestUniverseElementEnrichment:
+    """Universe element enrichment handles GRO-like missing element metadata."""
+
+    def test_existing_elements_are_preserved(self) -> None:
+        """Existing element metadata should not be overwritten."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=["CA", "H1"], types=["C", "H"], elements=["C", "H"])
+        )
+
+        metadata = enrich_universe_elements(universe, topology_key="existing.gro")
+
+        assert metadata["applied"] is False
+        assert metadata["source"] == "existing"
+        assert universe.added_topology_attrs == {}
+
+    def test_safe_atom_types_add_elements(self) -> None:
+        """Element-like GROMACS atom types should be copied as elements."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=["CA", "H1", "NA", "CL"], types=["C", "H", "NA", "CL"])
+        )
+
+        metadata = enrich_universe_elements(universe, topology_key="safe-types.gro")
+
+        assert metadata == {
+            "applied": True,
+            "source": "types",
+            "message": "elements inferred from atom types",
+        }
+        assert universe.atoms.elements == ["C", "H", "Na", "Cl"]
+
+    def test_unsafe_atom_types_fall_back_to_names(self) -> None:
+        """Force-field-like atom types should use conservative atom names."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(
+                names=["CA", "1HA", "OW", "HW1"],
+                types=["CT", "HC", "OW", "HW1"],
+                resnames=["ALA", "ALA", "HOH", "HOH"],
+            )
+        )
+
+        metadata = enrich_universe_elements(universe, topology_key="unsafe-types.gro")
+
+        assert metadata["applied"] is True
+        assert metadata["source"] == "names"
+        assert universe.atoms.elements == ["C", "H", "O", "H"]
+
+    def test_unguessable_names_skip_enrichment(self) -> None:
+        """No partial elements should be added when any atom is ambiguous."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=["CA", "BB"], types=["CT", "XX"], resnames=["ALA", "UNK"])
+        )
+
+        metadata = enrich_universe_elements(universe, topology_key="unguessable.gro")
+
+        assert metadata["applied"] is False
+        assert metadata["source"] is None
+        assert not hasattr(universe.atoms, "elements")
+
+    @pytest.mark.skipif(
+        not Path("/home/joelaforet/Shirts-Lab-Linux/polyzymd_debugging/fn-d10.gro").exists(),
+        reason="external GRO smoke-test topology is not available",
+    )
+    def test_external_gro_smoke_infers_elements(self) -> None:
+        """External beta GRO topology should gain element metadata when present."""
+
+        import MDAnalysis as mda
+
+        gro_path = Path("/home/joelaforet/Shirts-Lab-Linux/polyzymd_debugging/fn-d10.gro")
+        universe = mda.Universe(str(gro_path))
+
+        metadata = enrich_universe_elements(universe, topology_key=gro_path)
+
+        assert metadata["applied"] is True
+        assert len(universe.atoms.elements) == len(universe.atoms)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/analyses/shared/test_loader.py
+++ b/tests/analyses/shared/test_loader.py
@@ -298,6 +298,52 @@ class TestUniverseElementEnrichment:
         assert metadata["source"] == "names"
         assert universe.atoms.elements == ["C", "H", "O", "H"]
 
+    @pytest.mark.parametrize(
+        ("name", "resname", "expected"),
+        [
+            ("CA", "ALA", "C"),
+            ("CA", "CAL", "Ca"),
+            ("NA", "SOD", "Na"),
+            ("CL", "CLA", "Cl"),
+        ],
+    )
+    def test_ion_aliases_are_inferred_from_names(
+        self,
+        name: str,
+        resname: str,
+        expected: str,
+    ) -> None:
+        """Common ion aliases should distinguish ions from biomolecular names."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=[name], types=["XX"], resnames=[resname])
+        )
+
+        metadata = enrich_universe_elements(universe, topology_key=f"ion-{name}-{resname}.gro")
+
+        assert metadata["applied"] is True
+        assert metadata["source"] == "names"
+        assert universe.atoms.elements == [expected]
+
+    @pytest.mark.parametrize(
+        ("name", "resname"),
+        [("NA", "CLA"), ("CAX", "CAL")],
+    )
+    def test_ion_residue_conflicts_skip_enrichment(self, name: str, resname: str) -> None:
+        """Recognized ion residues should reject conflicting atom-name aliases."""
+
+        universe = _ElementFakeUniverse(
+            _ElementFakeAtoms(names=[name], types=["XX"], resnames=[resname])
+        )
+
+        metadata = enrich_universe_elements(
+            universe, topology_key=f"ion-conflict-{name}-{resname}.gro"
+        )
+
+        assert metadata["applied"] is False
+        assert metadata["source"] is None
+        assert not hasattr(universe.atoms, "elements")
+
     def test_unguessable_names_skip_enrichment(self) -> None:
         """No partial elements should be added when any atom is ambiguous."""
 

--- a/tests/analyses/shared/test_loader.py
+++ b/tests/analyses/shared/test_loader.py
@@ -328,6 +328,43 @@ class TestUniverseElementEnrichment:
         assert metadata["applied"] is True
         assert len(universe.atoms.elements) == len(universe.atoms)
 
+    @pytest.mark.skipif(
+        not Path(
+            "/home/joelaforet/Shirts-Lab-Linux/polyzymd_debugging/fn-d10_OEG_n25.gro"
+        ).exists(),
+        reason="external polymer GRO smoke-test topology is not available",
+    )
+    def test_external_polymer_gro_enables_element_h_selection(self) -> None:
+        """Element enrichment should preserve GRO hydrogen-selection UX for polymers."""
+
+        import MDAnalysis as mda
+
+        gro_path = Path("/home/joelaforet/Shirts-Lab-Linux/polyzymd_debugging/fn-d10_OEG_n25.gro")
+        union_selection = "(protein) or (resid 95:219 and not resname HOH)"
+        name_hydrogen_selection = f"({union_selection}) and (name H* or name [123]H*)"
+        element_hydrogen_selection = f"({union_selection}) and element H"
+
+        raw_universe = mda.Universe(str(gro_path))
+        polymer_atoms = raw_universe.select_atoms("resid 95:219 and not resname HOH")
+        name_hydrogens = raw_universe.select_atoms(name_hydrogen_selection)
+
+        assert len(polymer_atoms) > 0
+        assert len(name_hydrogens) == 4400
+        if hasattr(raw_universe.atoms, "elements"):
+            with pytest.raises(AttributeError):
+                raw_universe.select_atoms(element_hydrogen_selection)
+        else:
+            with pytest.raises(AttributeError):
+                raw_universe.select_atoms("element H")
+
+        enriched_universe = mda.Universe(str(gro_path))
+        metadata = enrich_universe_elements(enriched_universe, topology_key=gro_path)
+        element_hydrogens = enriched_universe.select_atoms(element_hydrogen_selection)
+
+        assert metadata["applied"] is True
+        assert len(enriched_universe.atoms.elements) == len(enriched_universe.atoms)
+        assert len(element_hydrogens) == len(name_hydrogens)
+
 
 # ---------------------------------------------------------------------------
 # Lazy engine creation

--- a/tests/data/gromacs/hbonds_element_fallback.gro
+++ b/tests/data/gromacs/hbonds_element_fallback.gro
@@ -1,0 +1,9 @@
+PolyzyMD hydrogen-bond element fallback fixture
+6
+    1ALA      N    1   0.000   0.000   0.000
+    1ALA     CA    2   0.100   0.000   0.000
+    1ALA      H    3   0.000   0.100   0.000
+    2SOD     NA    4   0.300   0.000   0.000
+    3CLA     CL    5   0.400   0.000   0.000
+    4CAL     CA    6   0.500   0.000   0.000
+   1.00000   1.00000   1.00000


### PR DESCRIPTION
## Summary
- infer missing MDAnalysis elements for GRO-like Universes using conservative type/name heuristics
- keep hydrogen_bonds YAML unchanged by using element H when available and name-based hydrogen fallback otherwise
- add optional hydrogens_selection override for unusual hydrogen naming
- add portable tiny GRO fixture plus loader/hydrogen_bonds regression coverage
- document explicit-hydrogen requirement and GRO fallback behavior

## Tests
- pixi run -e cuda-12-6 pytest tests/analyses/shared/test_loader.py -v
- pixi run -e cuda-12-6 pytest tests/analyses/plugins/test_hydrogen_bonds.py -v
- pixi run -e cuda-12-6 ruff check src/polyzymd/analyses/shared/loader.py src/polyzymd/analyses/hydrogen_bonds tests/analyses/shared/test_loader.py tests/analyses/plugins/test_hydrogen_bonds.py
- pixi run -e cuda-12-6 black --check src/polyzymd/analyses/shared/loader.py src/polyzymd/analyses/hydrogen_bonds tests/analyses/shared/test_loader.py tests/analyses/plugins/test_hydrogen_bonds.py
- pixi run -e cuda-12-6 make -C docs clean html

Reviewer verdict: APPROVED