### PR TITLE
Use templates for SLURM job names

### DIFF
--- a/docs/source/reference/data_requirements.md
+++ b/docs/source/reference/data_requirements.md
@@ -79,6 +79,18 @@ how per-replicate directories are named.
 | `{temperature}` | `thermodynamics.temperature` (integer) | `300` |
 | `{replicate}` | Replicate number (1-indexed) | `1` |
 | `{duration}` | `simulation_phases.production.duration` (integer ns) | `100` |
+| `{primary_solvent}` | Primary solvent token | `water_tip3p` |
+| `{cosolvent_composition}` | Co-solvents sorted by normalized name, or `none` | `dmso_30pctv_urea_2p5M` |
+| `{solvent_composition}` | Primary solvent plus co-solvents when present | `water_tip3p_dmso_30pctv` |
+
+PolyzyMD uses the same resolved template for daisy-chain SLURM job names, so
+job names match the per-replicate run directories after SLURM-safe
+sanitization.
+
+Solvent tokens are normalized for directory and SLURM job-name safety. Spaces,
+slashes, parentheses, percent signs, and raw decimal points are replaced or
+removed; concentration decimals use `p` (for example, `2.5 M` becomes
+`urea_2p5M`). Ions are not included in solvent naming placeholders.
 
 **Example resolved name:**
 

--- a/src/polyzymd/config/schema.py
+++ b/src/polyzymd/config/schema.py
@@ -8,14 +8,55 @@ providing validation, type safety, and YAML/JSON serialization support.
 from __future__ import annotations
 
 import logging
+import re
 import shlex
 from enum import Enum
 from pathlib import Path
+from string import Formatter
 from typing import Any, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 LOGGER = logging.getLogger(__name__)
+
+_TOKEN_UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9_-]+")
+_TOKEN_UNDERSCORES = re.compile(r"_+")
+
+
+def _format_safe_token(value: object) -> str:
+    """Convert a value into a safe lowercase naming token.
+
+    Parameters
+    ----------
+    value : object
+        Value to normalize for a directory or job-name token.
+
+    Returns
+    -------
+    str
+        Sanitized token using only alphanumerics, underscores, and hyphens.
+    """
+    token = str(value).strip().lower()
+    token = _TOKEN_UNSAFE_CHARS.sub("_", token)
+    token = _TOKEN_UNDERSCORES.sub("_", token)
+    return token.strip("_") or "unknown"
+
+
+def _format_decimal_token(value: float) -> str:
+    """Format a decimal value without raw decimal points.
+
+    Parameters
+    ----------
+    value : float
+        Numeric value to format.
+
+    Returns
+    -------
+    str
+        Compact token, using ``p`` as the decimal separator when needed.
+    """
+    formatted = f"{value:g}"
+    return formatted.replace(".", "p")
 
 
 class ChargeMethod(str, Enum):
@@ -1014,24 +1055,49 @@ class OutputConfig(BaseModel):
         substrate: str,
         polymer_type: str,
         temperature: float,
-        replicate: int,
+        replicate: int | str,
         duration: float = 0.0,
+        primary_solvent: str = "water_tip3p",
+        cosolvent_composition: str = "none",
+        solvent_composition: str | None = None,
         **kwargs: Any,
     ) -> str:
         """Format the directory name using the template.
 
-        Args:
-            enzyme: Enzyme name
-            substrate: Substrate name
-            polymer_type: Polymer type (or "none")
-            temperature: Temperature in K
-            replicate: Replicate number
-            duration: Production duration in ns
-            **kwargs: Additional template variables
+        Parameters
+        ----------
+        enzyme : str
+            Enzyme name.
+        substrate : str
+            Substrate name.
+        polymer_type : str
+            Polymer type, or ``"none"``.
+        temperature : float
+            Temperature in K.
+        replicate : int or str
+            Replicate number or glob token.
+        duration : float, optional
+            Production duration in ns, by default 0.0.
+        primary_solvent : str, optional
+            Primary solvent token, by default ``"water_tip3p"``.
+        cosolvent_composition : str, optional
+            Co-solvent composition token, by default ``"none"``.
+        solvent_composition : str or None, optional
+            Full solvent composition token. When not provided, the primary solvent
+            and co-solvent tokens are combined.
+        **kwargs : Any
+            Additional template variables.
 
-        Returns:
-            Formatted directory name
+        Returns
+        -------
+        str
+            Formatted directory name.
         """
+        if solvent_composition is None:
+            solvent_composition = primary_solvent
+            if cosolvent_composition != "none":
+                solvent_composition = f"{primary_solvent}_{cosolvent_composition}"
+
         return self.naming_template.format(
             enzyme=enzyme,
             substrate=substrate,
@@ -1039,6 +1105,9 @@ class OutputConfig(BaseModel):
             temperature=int(temperature),
             replicate=replicate,
             duration=int(duration),
+            primary_solvent=primary_solvent,
+            cosolvent_composition=cosolvent_composition,
+            solvent_composition=solvent_composition,
             **kwargs,
         )
 
@@ -1354,6 +1423,101 @@ class SimulationConfig(BaseModel):
 
         save_config(self, path)
 
+    def _primary_solvent_token(self) -> str:
+        """Format the primary solvent naming token.
+
+        Returns
+        -------
+        str
+            Primary solvent token for naming templates.
+        """
+        primary = self.solvent.primary
+        primary_type = _format_safe_token(primary.type)
+        if primary_type == "water":
+            return f"water_{_format_safe_token(primary.model.value)}"
+        return primary_type
+
+    def _cosolvent_composition_token(self) -> str:
+        """Format the co-solvent composition naming token.
+
+        Returns
+        -------
+        str
+            Co-solvent token or ``none`` when no co-solvents are configured.
+        """
+        if not self.solvent.co_solvents:
+            return "none"
+
+        tokens: list[tuple[str, str]] = []
+        for cosolvent in self.solvent.co_solvents:
+            name = _format_safe_token(cosolvent.name)
+            if cosolvent.volume_fraction is not None:
+                percent = _format_decimal_token(cosolvent.volume_fraction * 100)
+                token = f"{name}_{percent}pctv"
+            elif cosolvent.concentration is not None:
+                concentration = _format_decimal_token(cosolvent.concentration)
+                token = f"{name}_{concentration}M"
+            else:
+                # Validation guarantees one composition mode, but keep errors explicit
+                raise ValueError(f"Co-solvent '{cosolvent.name}' has no composition value")
+            tokens.append((name, token))
+
+        return "_".join(token for _, token in sorted(tokens, key=lambda item: item[0]))
+
+    def _run_directory_template_values(self, replicate: int | str = 1) -> dict[str, Any]:
+        """Build centralized values for run-directory naming templates.
+
+        Parameters
+        ----------
+        replicate : int or str, optional
+            Replicate token to insert into the template, by default 1.
+
+        Returns
+        -------
+        dict of str to Any
+            Template values shared by directory naming and replicate discovery.
+        """
+        polymer_type = "none"
+        if self.polymers and self.polymers.enabled:
+            probs = {m.label: m.probability for m in self.polymers.monomers}
+            sorted_labels = sorted(probs.keys())
+            composition = "_".join(f"{lbl}{probs[lbl] * 100:.0f}" for lbl in sorted_labels)
+            polymer_type = f"{self.polymers.type_prefix}_{composition}"
+
+        substrate_name = self.substrate.name if self.substrate else "apo"
+        primary_solvent = self._primary_solvent_token()
+        cosolvent_composition = self._cosolvent_composition_token()
+        solvent_composition = primary_solvent
+        if cosolvent_composition != "none":
+            solvent_composition = f"{primary_solvent}_{cosolvent_composition}"
+
+        return {
+            "enzyme": self.enzyme.name,
+            "substrate": substrate_name.replace("-", ""),
+            "polymer_type": polymer_type,
+            "temperature": int(self.thermodynamics.temperature),
+            "replicate": replicate,
+            "duration": int(self.simulation_phases.production.duration),
+            "primary_solvent": primary_solvent,
+            "cosolvent_composition": cosolvent_composition,
+            "solvent_composition": solvent_composition,
+        }
+
+    def format_run_directory_name(self, replicate: int | str = 1) -> str:
+        """Format the run directory name for a replicate.
+
+        Parameters
+        ----------
+        replicate : int or str, optional
+            Replicate number or glob token, by default 1.
+
+        Returns
+        -------
+        str
+            Formatted run directory name.
+        """
+        return self.output.format_directory_name(**self._run_directory_template_values(replicate))
+
     def get_working_directory(self, replicate: int = 1) -> Path:
         """Get the working directory path for a given replicate (in scratch).
 
@@ -1366,7 +1530,7 @@ class SimulationConfig(BaseModel):
         Returns:
             Path to the working directory (in scratch)
         """
-        dir_name = self._format_run_directory_name(replicate)
+        dir_name = self.format_run_directory_name(replicate)
         return self.output.effective_scratch_directory / dir_name
 
     def get_projects_directory(self) -> Path:
@@ -1388,41 +1552,32 @@ class SimulationConfig(BaseModel):
         Returns:
             Sorted list of ``(replicate_number, directory_path)`` tuples.
         """
-        import re
+        fields = {
+            field for _, field, _, _ in Formatter().parse(self.output.naming_template) if field
+        }
+        if "replicate" not in fields:
+            raise ValueError(
+                "Cannot discover replicate directories because output.naming_template does not "
+                "include the {replicate} placeholder."
+            )
 
-        # Build the same template values as _format_run_directory_name
-        # but substitute replicate with "*" for globbing.
-        polymer_type = "none"
-        if self.polymers and self.polymers.enabled:
-            probs = {m.label: m.probability for m in self.polymers.monomers}
-            sorted_labels = sorted(probs.keys())
-            composition = "_".join(f"{lbl}{probs[lbl] * 100:.0f}" for lbl in sorted_labels)
-            polymer_type = f"{self.polymers.type_prefix}_{composition}"
-
-        substrate_name = self.substrate.name if self.substrate else "apo"
-
-        glob_pattern = self.output.naming_template.format(
-            enzyme=self.enzyme.name,
-            substrate=substrate_name.replace("-", ""),
-            polymer_type=polymer_type,
-            temperature=int(self.thermodynamics.temperature),
-            replicate="*",
-            duration=int(self.simulation_phases.production.duration),
-        )
+        glob_pattern = self.format_run_directory_name(replicate="*")
+        regex_pattern = "^" + re.escape(glob_pattern).replace(r"\*", r"(?P<replicate>\d+)") + "$"
+        replicate_regex = re.compile(regex_pattern)
 
         scratch = self.output.effective_scratch_directory
         results: list[tuple[int, Path]] = []
         for path in scratch.glob(glob_pattern):
             if not path.is_dir():
                 continue
-            match = re.search(r"run(\d+)$", path.name)
+            match = replicate_regex.fullmatch(path.name)
             if match:
-                results.append((int(match.group(1)), path))
+                results.append((int(match.group("replicate")), path))
 
         results.sort(key=lambda t: t[0])
         return results
 
-    def _format_run_directory_name(self, replicate: int) -> str:
+    def _format_run_directory_name(self, replicate: int | str) -> str:
         """Format the run directory name for a replicate.
 
         Args:
@@ -1431,25 +1586,7 @@ class SimulationConfig(BaseModel):
         Returns:
             Formatted directory name
         """
-        polymer_type = "none"
-        if self.polymers and self.polymers.enabled:
-            # Format polymer type with full composition info
-            # Sort by label (A, B, C...) alphabetically - user controls which is "A"
-            probs = {m.label: m.probability for m in self.polymers.monomers}
-            sorted_labels = sorted(probs.keys())
-            composition = "_".join(f"{lbl}{probs[lbl] * 100:.0f}" for lbl in sorted_labels)
-            polymer_type = f"{self.polymers.type_prefix}_{composition}"
-
-        substrate_name = self.substrate.name if self.substrate else "apo"
-
-        return self.output.format_directory_name(
-            enzyme=self.enzyme.name,
-            substrate=substrate_name.replace("-", ""),
-            polymer_type=polymer_type,
-            temperature=self.thermodynamics.temperature,
-            replicate=replicate,
-            duration=self.simulation_phases.production.duration,
-        )
+        return self.format_run_directory_name(replicate)
 
     def to_signac_statepoint(self, replicate: int = 1) -> dict[str, Any]:
         """Convert configuration to a Signac-compatible state point dictionary.

--- a/src/polyzymd/workflow/daisy_chain.py
+++ b/src/polyzymd/workflow/daisy_chain.py
@@ -33,6 +33,9 @@ from polyzymd.workflow.slurm import (
 
 LOGGER = logging.getLogger(__name__)
 
+_SLURM_JOB_NAME_UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
+_SLURM_JOB_NAME_UNDERSCORES = re.compile(r"_+")
+
 
 # ---------------------------------------------------------------------------
 # squeue-based duplicate detection
@@ -96,11 +99,65 @@ def check_existing_slurm_jobs(job_name: str) -> List[str]:
     return job_ids
 
 
-def create_job_name(sim_config: SimulationConfig, replicate: int) -> str:
-    """Create a descriptive SLURM job name for a replicate.
+def _sanitize_slurm_job_name(job_name: object, replicate: int) -> str:
+    """Sanitize a job name for SLURM and log-file use.
 
-    Produces names like ``r1_310K_Fibronectin_SBMA-OEGMA_A75_B25``
-    matching the directory naming convention.
+    Parameters
+    ----------
+    job_name : object
+        Candidate job name.
+    replicate : int
+        Replicate number used for the fallback name.
+
+    Returns
+    -------
+    str
+        Sanitized job name.
+    """
+    sanitized = _SLURM_JOB_NAME_UNSAFE.sub("_", str(job_name).strip())
+    sanitized = _SLURM_JOB_NAME_UNDERSCORES.sub("_", sanitized).strip("_")
+    if not sanitized:
+        sanitized = f"pzmd_r{replicate}"
+    return sanitized
+
+
+def _legacy_job_name(sim_config: SimulationConfig, replicate: int) -> str:
+    """Create a legacy synthesized job name for config-like test objects.
+
+    Parameters
+    ----------
+    sim_config : SimulationConfig
+        Simulation configuration or legacy config-like object.
+    replicate : int
+        Replicate number.
+
+    Returns
+    -------
+    str
+        Legacy formatted job name.
+    """
+
+    enzyme = sim_config.enzyme.name
+    temp = int(sim_config.thermodynamics.temperature)
+
+    polymer_info = ""
+    polymers = getattr(sim_config, "polymers", None)
+    if polymers is not None and getattr(polymers, "enabled", False) is True:
+        prefix = polymers.type_prefix
+        probs = {m.label: m.probability for m in polymers.monomers}
+        composition = "_".join(f"{lbl}{int(round(probs[lbl] * 100))}" for lbl in sorted(probs))
+        polymer_info = f"_{prefix}_{composition}"
+
+    return f"r{replicate}_{temp}K_{enzyme}{polymer_info}"
+
+
+def create_job_name(sim_config: SimulationConfig, replicate: int) -> str:
+    """Create a sanitized SLURM job name for a replicate.
+
+    Real ``SimulationConfig`` objects use ``output.naming_template`` via
+    :meth:`SimulationConfig.format_run_directory_name`, so SLURM job names match
+    run directory names. Legacy config-like objects fall back to the historical
+    synthesized format.
 
     Parameters
     ----------
@@ -114,17 +171,13 @@ def create_job_name(sim_config: SimulationConfig, replicate: int) -> str:
     str
         Formatted job name.
     """
-    enzyme = sim_config.enzyme.name
-    temp = int(sim_config.thermodynamics.temperature)
+    formatter = getattr(sim_config, "format_run_directory_name", None)
+    if callable(formatter):
+        formatted = formatter(replicate)
+        if isinstance(formatted, str):
+            return _sanitize_slurm_job_name(formatted, replicate)
 
-    polymer_info = ""
-    if sim_config.polymers and sim_config.polymers.enabled:
-        prefix = sim_config.polymers.type_prefix
-        probs = {m.label: m.probability for m in sim_config.polymers.monomers}
-        composition = "_".join(f"{lbl}{int(round(probs[lbl] * 100))}" for lbl in sorted(probs))
-        polymer_info = f"_{prefix}_{composition}"
-
-    return f"r{replicate}_{temp}K_{enzyme}{polymer_info}"
+    return _sanitize_slurm_job_name(_legacy_job_name(sim_config, replicate), replicate)
 
 
 @dataclass
@@ -360,6 +413,32 @@ class DaisyChainSubmitter:
         scratch_dir = self._sim_config.get_working_directory(replicate)
         return str(scratch_dir.resolve())
 
+    def _generate_job_script(self, replicate: int, job_name: str) -> str:
+        """Generate a self-resubmitting job script with a precomputed job name.
+
+        Parameters
+        ----------
+        replicate : int
+            Replicate number.
+        job_name : str
+            Sanitized SLURM job name shared with duplicate detection and log paths.
+
+        Returns
+        -------
+        str
+            Complete SLURM batch script content.
+        """
+        logs_subdir = self._sim_config.output.slurm_logs_subdir
+        output_file = f"{logs_subdir}/{job_name}.%j.out"
+
+        return self._generator.generate_job_script(
+            config_path=self._dc_config.config_path,
+            replicate=replicate,
+            working_dir=self._get_scratch_dir(replicate),
+            job_name=job_name,
+            output_file=output_file,
+        )
+
     def generate_job_script(self, replicate: int) -> str:
         """Generate a self-resubmitting job script for a replicate.
 
@@ -373,17 +452,7 @@ class DaisyChainSubmitter:
         str
             Complete SLURM batch script content.
         """
-        job_name = self._create_job_name(replicate)
-        logs_subdir = self._sim_config.output.slurm_logs_subdir
-        output_file = f"{logs_subdir}/{job_name}.%j.out"
-
-        return self._generator.generate_job_script(
-            config_path=self._dc_config.config_path,
-            replicate=replicate,
-            working_dir=self._get_scratch_dir(replicate),
-            job_name=job_name,
-            output_file=output_file,
-        )
+        return self._generate_job_script(replicate, self._create_job_name(replicate))
 
     def _save_script(self, content: str, filename: str) -> Path:
         """Save a script to the output directory.
@@ -543,7 +612,7 @@ class DaisyChainSubmitter:
             LOGGER.info(f"[DRY RUN] Would submit replicate {replicate} with sbatch")
             return result
 
-        script_content = self.generate_job_script(replicate)
+        script_content = self._generate_job_script(replicate, job_name)
         filename = f"run_rep{replicate}.sh"
         script_path = self._save_script(script_content, filename)
 

--- a/tests/cli/test_main_status.py
+++ b/tests/cli/test_main_status.py
@@ -42,6 +42,17 @@ def _make_mock_config(scratch_dir: Path, template: str | None = None):
         template = "{enzyme}_{substrate}_{polymer_type}_{duration}ns_{temperature}K_run{replicate}"
     mock.output.naming_template = template
     mock.output.effective_scratch_directory = scratch_dir
+    mock.format_run_directory_name.side_effect = lambda replicate=1: template.format(
+        enzyme="fnIII",
+        substrate="apo",
+        polymer_type="OEGMA-SBMA_A50_B50",
+        duration=100,
+        temperature=310,
+        replicate=replicate,
+        primary_solvent="water_tip3p",
+        cosolvent_composition="none",
+        solvent_composition="water_tip3p",
+    )
 
     return mock
 

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -210,6 +210,154 @@ class TestCoSolventVolumeValidation:
         assert len(config.co_solvents) == 2
 
 
+class TestRunDirectoryNaming:
+    """Test centralized run-directory naming helpers."""
+
+    def test_output_config_format_directory_name_accepts_solvent_tokens(self):
+        """Output formatter should support solvent template placeholders directly."""
+        from polyzymd.config.schema import OutputConfig
+
+        output = OutputConfig(
+            naming_template=(
+                "{enzyme}_{primary_solvent}_{cosolvent_composition}_{solvent_composition}_"
+                "r{replicate}"
+            ),
+        )
+
+        assert (
+            output.format_directory_name(
+                enzyme="LipA",
+                substrate="apo",
+                polymer_type="none",
+                temperature=310.0,
+                replicate=2,
+                primary_solvent="water_tip3p",
+                cosolvent_composition="dmso_30pctv",
+                solvent_composition="water_tip3p_dmso_30pctv",
+            )
+            == "LipA_water_tip3p_dmso_30pctv_water_tip3p_dmso_30pctv_r2"
+        )
+        assert (
+            output.format_directory_name(
+                enzyme="LipA",
+                substrate="apo",
+                polymer_type="none",
+                temperature=310.0,
+                replicate=2,
+                primary_solvent="water_tip3p",
+                cosolvent_composition="dmso_30pctv",
+            )
+            == "LipA_water_tip3p_dmso_30pctv_water_tip3p_dmso_30pctv_r2"
+        )
+
+    def test_format_run_directory_name_uses_output_formatter(self, minimal_config_data):
+        """Simulation formatter should route centralized values through OutputConfig."""
+        from polyzymd.config.schema import SimulationConfig
+
+        config = SimulationConfig(**minimal_config_data)
+        calls = []
+        original = config.output.format_directory_name
+
+        def spy_format_directory_name(**values):
+            calls.append(values)
+            return original(**values)
+
+        object.__setattr__(config.output, "format_directory_name", spy_format_directory_name)
+
+        assert config.format_run_directory_name(4) == "TestEnzyme_apo_none_1ns_300K_run4"
+        assert calls == [config._run_directory_template_values(4)]
+
+    def test_solvent_token_formatting(self, minimal_config_data):
+        """Solvent placeholders should render safe composition tokens."""
+        minimal_config_data["solvent"] = {
+            "primary": {"type": "water", "model": "tip3p"},
+            "co_solvents": [
+                {"name": "urea", "concentration": 2.5},
+                {
+                    "name": "tert butanol",
+                    "smiles": "CC(C)(C)O",
+                    "density": 0.78,
+                    "volume_fraction": 0.125,
+                },
+                {"name": "dmso", "volume_fraction": 0.30},
+            ],
+        }
+        minimal_config_data["output"] = {
+            "naming_template": "{primary_solvent}_{cosolvent_composition}_{solvent_composition}"
+        }
+
+        config = SimulationConfig(**minimal_config_data)
+
+        assert config.format_run_directory_name() == (
+            "water_tip3p_dmso_30pctv_tert_butanol_12p5pctv_urea_2p5M_"
+            "water_tip3p_dmso_30pctv_tert_butanol_12p5pctv_urea_2p5M"
+        )
+
+    def test_absent_cosolvent_uses_none_and_primary_only_composition(self, minimal_config_data):
+        """No co-solvents should produce none and primary-only solvent composition."""
+        minimal_config_data["output"] = {
+            "naming_template": "{primary_solvent}_{cosolvent_composition}_{solvent_composition}"
+        }
+
+        config = SimulationConfig(**minimal_config_data)
+
+        assert config.format_run_directory_name() == "water_tip3p_none_water_tip3p"
+
+    def test_non_water_primary_solvent_is_sanitized(self, minimal_config_data):
+        """Non-water primary solvent names should normalize unsafe punctuation."""
+        minimal_config_data["solvent"] = {"primary": {"type": "ACN / MeOH"}}
+        minimal_config_data["output"] = {"naming_template": "{primary_solvent}"}
+
+        config = SimulationConfig(**minimal_config_data)
+
+        assert config.format_run_directory_name() == "acn_meoh"
+
+    def test_format_run_directory_name_and_working_directory_match(
+        self, minimal_config_data, tmp_path
+    ):
+        """The public formatter should match get_working_directory().name."""
+        minimal_config_data["output"] = {
+            "scratch_directory": str(tmp_path),
+            "naming_template": "{enzyme}_{temperature}K_run{replicate}_{solvent_composition}",
+        }
+        config = SimulationConfig(**minimal_config_data)
+
+        run_name = config.format_run_directory_name(3)
+
+        assert run_name == "TestEnzyme_300K_run3_water_tip3p"
+        assert config.get_working_directory(3).name == run_name
+
+    def test_discover_replicate_dirs_with_solvent_placeholder_and_middle_replicate(
+        self, minimal_config_data, tmp_path
+    ):
+        """Discovery should work when solvent placeholders are present after replicate."""
+        minimal_config_data["output"] = {
+            "scratch_directory": str(tmp_path),
+            "naming_template": "run{replicate}_{solvent_composition}_{enzyme}",
+        }
+        config = SimulationConfig(**minimal_config_data)
+        first = tmp_path / config.format_run_directory_name(1)
+        third = tmp_path / config.format_run_directory_name(3)
+        first.mkdir()
+        third.mkdir()
+        (tmp_path / "runX_water_tip3p_TestEnzyme").mkdir()
+
+        assert config.discover_replicate_dirs() == [(1, first), (3, third)]
+
+    def test_discover_replicate_dirs_requires_replicate_placeholder(
+        self, minimal_config_data, tmp_path
+    ):
+        """Discovery should fail clearly when the template has no replicate token."""
+        minimal_config_data["output"] = {
+            "scratch_directory": str(tmp_path),
+            "naming_template": "{enzyme}_{solvent_composition}",
+        }
+        config = SimulationConfig(**minimal_config_data)
+
+        with pytest.raises(ValueError, match=r"does not include the \{replicate\} placeholder"):
+            config.discover_replicate_dirs()
+
+
 class TestSimulationPhasesConfig:
     """Test staged equilibration requirements."""
 

--- a/tests/workflow/test_daisy_chain.py
+++ b/tests/workflow/test_daisy_chain.py
@@ -5,6 +5,38 @@ from pathlib import Path
 import pytest
 
 
+def _simulation_config_data(tmp_path: Path) -> dict:
+    """Create minimal simulation configuration data for job-name tests."""
+    return {
+        "name": "test_simulation",
+        "engine": "openmm",
+        "enzyme": {"name": "LipA", "pdb_path": "enzyme.pdb"},
+        "substrate": {"name": "Sub-A", "sdf_path": "substrate.sdf"},
+        "thermodynamics": {"temperature": 310.0},
+        "solvent": {
+            "primary": {"type": "water", "model": "tip3p"},
+            "co_solvents": [{"name": "dmso", "volume_fraction": 0.3}],
+        },
+        "simulation_phases": {
+            "equilibration_stages": [
+                {"name": "eq", "duration": 0.1, "temperature": 310.0, "ensemble": "NVT"}
+            ],
+            "production": {
+                "ensemble": "NPT",
+                "duration": 100.0,
+                "samples": 10,
+                "report_interval": 50000,
+                "checkpoint_interval": 60.0,
+            },
+        },
+        "output": {
+            "projects_directory": str(tmp_path / "projects"),
+            "scratch_directory": str(tmp_path / "scratch"),
+            "naming_template": "{enzyme}_{solvent_composition}_run{replicate}",
+        },
+    }
+
+
 class TestSbatchOutputParsing:
     """C8-M1: sbatch job ID parsing should use regex."""
 
@@ -95,6 +127,113 @@ class TestJobNameGeneration:
         name = submitter._create_job_name(1)
         assert "A33" in name
         assert "B67" in name
+
+    def test_template_derived_job_name_matches_run_directory(self, tmp_path):
+        """Real configs should derive job names from naming_template."""
+        from polyzymd.config.schema import SimulationConfig
+        from polyzymd.workflow.daisy_chain import create_job_name
+
+        sim_config = SimulationConfig(**_simulation_config_data(tmp_path))
+
+        assert create_job_name(sim_config, 2) == sim_config.format_run_directory_name(2)
+
+    def test_changing_template_changes_job_name(self, tmp_path):
+        """Changing output.naming_template should change the SLURM job name."""
+        from polyzymd.config.schema import SimulationConfig
+        from polyzymd.workflow.daisy_chain import create_job_name
+
+        first = _simulation_config_data(tmp_path)
+        second = _simulation_config_data(tmp_path)
+        second["output"]["naming_template"] = "job_{replicate}_{enzyme}_{temperature}K"
+
+        assert create_job_name(SimulationConfig(**first), 1) != create_job_name(
+            SimulationConfig(**second), 1
+        )
+        assert create_job_name(SimulationConfig(**second), 1) == "job_1_LipA_310K"
+
+    def test_solvent_placeholders_appear_in_job_name(self, tmp_path):
+        """Solvent template placeholders should flow into SLURM job names."""
+        from polyzymd.config.schema import SimulationConfig
+        from polyzymd.workflow.daisy_chain import create_job_name
+
+        data = _simulation_config_data(tmp_path)
+        data["output"]["naming_template"] = "{primary_solvent}_{cosolvent_composition}_r{replicate}"
+        sim_config = SimulationConfig(**data)
+
+        assert create_job_name(sim_config, 1) == "water_tip3p_dmso_30pctv_r1"
+
+    def test_job_name_sanitizer_removes_unsafe_characters(self, tmp_path):
+        """Generated SLURM job names should be safe for headers and log paths."""
+        from polyzymd.config.schema import SimulationConfig
+        from polyzymd.workflow.daisy_chain import create_job_name
+
+        data = _simulation_config_data(tmp_path)
+        data["enzyme"]["name"] = "LipA/(variant)"
+        data["output"]["naming_template"] = "{enzyme} / run {replicate}"
+        sim_config = SimulationConfig(**data)
+
+        assert create_job_name(sim_config, 1) == "LipA_variant_run_1"
+
+    def test_magicmock_fallback_uses_legacy_name(self):
+        """Legacy config-like mocks should still use the historical fallback."""
+        submitter = self._make_submitter("Fibronectin_8_to_10", 310.0, None)
+        assert submitter._create_job_name(1) == "r1_310K_Fibronectin_8_to_10"
+
+    def test_duplicate_guard_header_and_log_use_same_sanitized_name(self, tmp_path, monkeypatch):
+        """Duplicate checks, SBATCH headers, and logs should share one job name."""
+        from unittest.mock import MagicMock
+
+        from polyzymd.config.schema import SimulationConfig
+        from polyzymd.workflow.daisy_chain import (
+            DaisyChainConfig,
+            DaisyChainSubmitter,
+            SubmissionResult,
+        )
+        from polyzymd.workflow.slurm import SlurmConfig
+
+        data = _simulation_config_data(tmp_path)
+        data["output"]["naming_template"] = "{enzyme} run/{replicate}"
+        sim_config = SimulationConfig(**data)
+
+        checked_names = []
+        monkeypatch.setattr(
+            "polyzymd.workflow.daisy_chain.check_existing_slurm_jobs",
+            lambda job_name: checked_names.append(job_name) or [],
+        )
+
+        dc_config = MagicMock(spec=DaisyChainConfig)
+        dc_config.dry_run = False
+        dc_config.generate_only = False
+        dc_config.force = False
+        dc_config.slurm_config = SlurmConfig.from_preset("testing")
+        dc_config.output_script_dir = tmp_path
+        dc_config.config_path = "/fake/config.yaml"
+
+        submitter = DaisyChainSubmitter(sim_config=sim_config, dc_config=dc_config)
+        generated_names = []
+        original_generate_job_script = submitter._generator.generate_job_script
+
+        def spy_generate_job_script(**kwargs):
+            generated_names.append(kwargs["job_name"])
+            return original_generate_job_script(**kwargs)
+
+        monkeypatch.setattr(submitter._generator, "generate_job_script", spy_generate_job_script)
+        monkeypatch.setattr(
+            submitter,
+            "_submit_job",
+            lambda script_path, replicate: SubmissionResult(
+                job_id="12345", script_path=script_path, segment_index=0, replicate=replicate
+            ),
+        )
+        result = submitter.submit_replicate(1)
+
+        job_name = "LipA_run_1"
+        assert checked_names == [job_name]
+        assert generated_names == [job_name]
+        assert result.script_path == tmp_path / "run_rep1.sh"
+        script = result.script_path.read_text()
+        assert f"#SBATCH --job-name={job_name}" in script
+        assert f"#SBATCH --output=slurm_logs/{job_name}.%j.out" in script
 
 
 class TestSubmissionResultStateSemantics:


### PR DESCRIPTION
## Summary
- derive SLURM job names from output.naming_template via run-directory formatting
- add primary_solvent, cosolvent_composition, and solvent_composition naming placeholders
- centralize replicate directory discovery on the same template values and document solvent tokens

## Validation
- pixi run -e build pytest tests/workflow/test_daisy_chain.py tests/config/test_schema.py tests/cli/test_main_status.py -v
- pixi run -e build ruff check src/ tests/workflow/test_daisy_chain.py tests/config/test_schema.py tests/cli/test_main_status.py
- pixi run -e build black src/ tests/workflow/test_daisy_chain.py tests/config/test_schema.py tests/cli/test_main_status.py --check

## Review
- @reviewer approved final implementation with no required fixes.