### PR TITLE
Bugfix/neutralize ion counts

### DIFF
--- a/docs/source/get_started/quickstart.md
+++ b/docs/source/get_started/quickstart.md
@@ -98,7 +98,7 @@ solvent:
   co_solvents: []
   ions:
     neutralize: true
-    nacl_concentration: 0.15
+    nacl_concentration: 0.15  # NaCl-equivalent final ion pool (M)
   box:
     padding: 1.2
     shape: "rhombic_dodecahedron"

--- a/docs/source/get_started/quickstart.md
+++ b/docs/source/get_started/quickstart.md
@@ -98,7 +98,7 @@ solvent:
   co_solvents: []
   ions:
     neutralize: true
-    nacl_concentration: 0.15  # NaCl-equivalent final ion pool (M)
+    nacl_concentration: 0.15  # NaCl-equivalent final ion concentration (M)
   box:
     padding: 1.2
     shape: "rhombic_dodecahedron"

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -215,7 +215,7 @@ solvent:
   
   ions:
     neutralize: true                     # Add counter-ions
-    nacl_concentration: 0.15             # NaCl concentration (M)
+    nacl_concentration: 0.15             # NaCl-equivalent final ion pool (M)
   
   box:
     padding: 1.2                         # nm from solute to box edge
@@ -223,6 +223,9 @@ solvent:
     target_density: 1.0                  # g/mL
     tolerance: 2.0                       # PACKMOL tolerance (Angstrom)
 ```
+
+With `neutralize: true`, `nacl_concentration` targets the final neutralized
+Na+/Cl- ion pool, not extra salt added after counter-ions.
 
 ### Water Models
 

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -215,7 +215,7 @@ solvent:
   
   ions:
     neutralize: true                     # Add counter-ions
-    nacl_concentration: 0.15             # NaCl-equivalent final ion pool (M)
+    nacl_concentration: 0.15             # NaCl-equivalent final ion concentration (M)
   
   box:
     padding: 1.2                         # nm from solute to box edge
@@ -225,7 +225,7 @@ solvent:
 ```
 
 With `neutralize: true`, `nacl_concentration` targets the final neutralized
-Na+/Cl- ion pool, not extra salt added after counter-ions.
+Na+/Cl- ion concentration, not extra salt added after counter-ions.
 
 ### Water Models
 

--- a/src/polyzymd/builders/solvent.py
+++ b/src/polyzymd/builders/solvent.py
@@ -143,7 +143,7 @@ class SolventComposition:
     Attributes:
         water_model: Water model to use.
         co_solvents: List of co-solvent specifications.
-        nacl_concentration: NaCl concentration in mol/L.
+        nacl_concentration: NaCl-equivalent target for the final ion pool in mol/L.
         kcl_concentration: KCl concentration in mol/L.
         mgcl2_concentration: MgCl2 concentration in mol/L.
         neutralize: Whether to neutralize system charge.
@@ -151,7 +151,7 @@ class SolventComposition:
 
     water_model: WaterModelType = "tip3p"
     co_solvents: List[CoSolvent] = field(default_factory=list)
-    nacl_concentration: float = 0.0  # mol/L
+    nacl_concentration: float = 0.0  # NaCl-equivalent final ion pool, mol/L
     kcl_concentration: float = 0.0
     mgcl2_concentration: float = 0.0
     neutralize: bool = True
@@ -182,7 +182,7 @@ class SolventBuilder:
 
     This class handles:
     - Water solvation with different water models
-    - Ion addition for neutralization and ionic strength
+    - Ion addition using final-ion-pool neutralization semantics
     - Co-solvent addition with specified mole fractions or concentrations
     - Box shape and padding configuration
 
@@ -298,17 +298,19 @@ class SolventBuilder:
         water_mass = sum(atom.mass for atom in water.atoms)
         molarity_pure_water = Quantity(55.5, "mole / liter")
 
-        # Calculate ions
+        # Calculate NaCl-equivalent target for the final ion pool
         na = Molecule.from_smiles("[Na+]")
         cl = Molecule.from_smiles("[Cl-]")
-        nacl_mass = sum(atom.mass for atom in na.atoms) + sum(atom.mass for atom in cl.atoms)
+        na_mass = sum(atom.mass for atom in na.atoms)
+        cl_mass = sum(atom.mass for atom in cl.atoms)
+        nacl_mass = na_mass + cl_mass
 
         nacl_conc = Quantity(composition.nacl_concentration, "mole / liter")
         nacl_mass_fraction = (nacl_conc * nacl_mass) / (molarity_pure_water * water_mass)
         nacl_mass_to_add = solvent_mass * nacl_mass_fraction
         nacl_to_add = self._round_dimensionless_to_int(nacl_mass_to_add / nacl_mass)
 
-        # Neutralize system
+        # Resolve the final ion pool, including any neutralizing imbalance
         solute_charge = sum(mol.total_charge for mol in topology.molecules)
         na_to_add, cl_to_add = self._calculate_ion_counts(
             nacl_to_add=nacl_to_add,
@@ -339,7 +341,13 @@ class SolventBuilder:
                     f"CoSolvent '{cosolvent.name}' has neither mole_fraction nor concentration"
                 )
 
-        neutral_solvent_mass = solvent_mass - nacl_mass_to_add
+        neutral_solvent_mass = self._calculate_neutral_solvent_mass(
+            solvent_mass=solvent_mass,
+            na_count=na_to_add,
+            cl_count=cl_to_add,
+            na_mass=na_mass,
+            cl_mass=cl_mass,
+        )
         if cosolvent_masses:
             water_to_add, mole_fraction_counts = self._calculate_mole_fraction_counts(
                 neutral_solvent_mass=neutral_solvent_mass,
@@ -533,6 +541,37 @@ class SolventBuilder:
         """
         return int(round(concentration_molar * box_volume_liters * AVOGADRO_CONSTANT))
 
+    @staticmethod
+    def _calculate_neutral_solvent_mass(
+        solvent_mass: Any,
+        na_count: int,
+        cl_count: int,
+        na_mass: Any,
+        cl_mass: Any,
+    ) -> Any:
+        """Calculate solvent mass remaining after reserving actual ions.
+
+        Parameters
+        ----------
+        solvent_mass : Any
+            Total mass available for ions, water, and co-solvents.
+        na_count : int
+            Final number of Na+ ions to add.
+        cl_count : int
+            Final number of Cl- ions to add.
+        na_mass : Any
+            Molecular mass of one Na+ ion.
+        cl_mass : Any
+            Molecular mass of one Cl- ion.
+
+        Returns
+        -------
+        Any
+            Mass remaining for water and co-solvents.
+        """
+        actual_ion_mass = na_count * na_mass + cl_count * cl_mass
+        return solvent_mass - actual_ion_mass
+
     @classmethod
     def _calculate_ion_counts(
         cls,
@@ -540,18 +579,18 @@ class SolventBuilder:
         solute_charge: Any,
         neutralize: bool,
     ) -> tuple[int, int]:
-        """Calculate Na+ and Cl- counts from target NaCl pairs.
+        """Calculate final Na+ and Cl- counts from a NaCl-equivalent target.
 
         When neutralization is enabled, counts are chosen so that the final
-        solute plus ion charge is exactly zero while keeping the total ion
-        count as close as possible to the requested salt-pair total. If parity
+        solute plus ion charge is exactly zero while keeping the final ion pool
+        as close as possible to the requested NaCl-equivalent total. If parity
         makes the target total impossible, the tie is resolved by adding the
         larger feasible ion count.
 
         Parameters
         ----------
         nacl_to_add : Any
-            Target number of NaCl pairs as a scalar or dimensionless quantity.
+            NaCl-equivalent target count as a scalar or dimensionless quantity.
         solute_charge : Any
             Solute net charge in elementary-charge units.
         neutralize : bool

--- a/src/polyzymd/builders/solvent.py
+++ b/src/polyzymd/builders/solvent.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 AVOGADRO_CONSTANT = 6.02214076e23
+ION_CHARGE_TOLERANCE = 1.0e-5
 
 # Water model type
 WaterModelType = Literal["tip3p", "spce", "tip4p", "tip4pew", "opc"]
@@ -305,16 +306,15 @@ class SolventBuilder:
         nacl_conc = Quantity(composition.nacl_concentration, "mole / liter")
         nacl_mass_fraction = (nacl_conc * nacl_mass) / (molarity_pure_water * water_mass)
         nacl_mass_to_add = solvent_mass * nacl_mass_fraction
-        nacl_to_add = (nacl_mass_to_add / nacl_mass).m_as("dimensionless").round()
+        nacl_to_add = self._round_dimensionless_to_int(nacl_mass_to_add / nacl_mass)
 
         # Neutralize system
         solute_charge = sum(mol.total_charge for mol in topology.molecules)
-        if composition.neutralize:
-            na_to_add = int(np.ceil(nacl_to_add - solute_charge.m / 2.0))
-            cl_to_add = int(np.floor(nacl_to_add + solute_charge.m / 2.0))
-        else:
-            na_to_add = int(nacl_to_add)
-            cl_to_add = int(nacl_to_add)
+        na_to_add, cl_to_add = self._calculate_ion_counts(
+            nacl_to_add=nacl_to_add,
+            solute_charge=solute_charge,
+            neutralize=composition.neutralize,
+        )
 
         # Load co-solvents before count calculations so molar masses are known
         cosolvent_masses: list[tuple[str, float, Any]] = []
@@ -532,6 +532,103 @@ class SolventBuilder:
             Number of co-solvent molecules to add.
         """
         return int(round(concentration_molar * box_volume_liters * AVOGADRO_CONSTANT))
+
+    @classmethod
+    def _calculate_ion_counts(
+        cls,
+        nacl_to_add: Any,
+        solute_charge: Any,
+        neutralize: bool,
+    ) -> tuple[int, int]:
+        """Calculate Na+ and Cl- counts from target NaCl pairs.
+
+        When neutralization is enabled, counts are chosen so that the final
+        solute plus ion charge is exactly zero while keeping the total ion
+        count as close as possible to the requested salt-pair total. If parity
+        makes the target total impossible, the tie is resolved by adding the
+        larger feasible ion count.
+
+        Parameters
+        ----------
+        nacl_to_add : Any
+            Target number of NaCl pairs as a scalar or dimensionless quantity.
+        solute_charge : Any
+            Solute net charge in elementary-charge units.
+        neutralize : bool
+            Whether ion counts should neutralize the solute charge.
+
+        Returns
+        -------
+        tuple[int, int]
+            Number of Na+ and Cl- ions to add.
+        """
+        nacl_count = cls._round_dimensionless_to_int(nacl_to_add)
+        if not neutralize:
+            return nacl_count, nacl_count
+
+        solute_charge_int = cls._charge_to_integer(solute_charge)
+        charge_difference = -solute_charge_int
+        minimum_total_ions = abs(charge_difference)
+        target_total_ions = 2 * nacl_count
+
+        lower_total = target_total_ions
+        while lower_total >= minimum_total_ions and (lower_total - charge_difference) % 2 != 0:
+            lower_total -= 1
+
+        upper_total = max(target_total_ions, minimum_total_ions)
+        while (upper_total - charge_difference) % 2 != 0:
+            upper_total += 1
+
+        if lower_total < minimum_total_ions:
+            total_ions = upper_total
+        elif abs(upper_total - target_total_ions) <= abs(target_total_ions - lower_total):
+            total_ions = upper_total
+        else:
+            total_ions = lower_total
+
+        na_count = (total_ions + charge_difference) // 2
+        cl_count = (total_ions - charge_difference) // 2
+        return na_count, cl_count
+
+    @staticmethod
+    def _charge_to_integer(charge: Any, tolerance: float = ION_CHARGE_TOLERANCE) -> int:
+        """Convert a net charge to integer elementary-charge units.
+
+        Tiny floating-point noise from charge assignment is tolerated, but true
+        fractional net charges are rejected because integer ions cannot exactly
+        neutralize them.
+
+        Parameters
+        ----------
+        charge : Any
+            Charge scalar or quantity-like object.
+        tolerance : float, optional
+            Absolute tolerance for floating-point noise, by default
+            ``ION_CHARGE_TOLERANCE``.
+
+        Returns
+        -------
+        int
+            Integer charge in elementary-charge units.
+
+        Raises
+        ------
+        ValueError
+            If the charge is farther than ``tolerance`` from an integer.
+        """
+        if hasattr(charge, "m_as"):
+            charge = charge.m_as("elementary_charge")
+        elif hasattr(charge, "m"):
+            charge = charge.m
+
+        charge_value = float(charge)
+        rounded_charge = round(charge_value)
+        if abs(charge_value - rounded_charge) > tolerance:
+            raise ValueError(
+                "Solute net charge must be an integer when neutralization is enabled; "
+                f"got {charge_value:g} e"
+            )
+        return int(rounded_charge)
 
     @classmethod
     def _calculate_mole_fraction_counts(

--- a/src/polyzymd/builders/solvent.py
+++ b/src/polyzymd/builders/solvent.py
@@ -143,7 +143,7 @@ class SolventComposition:
     Attributes:
         water_model: Water model to use.
         co_solvents: List of co-solvent specifications.
-        nacl_concentration: NaCl-equivalent target for the final ion pool in mol/L.
+        nacl_concentration: NaCl-equivalent target for the final ion concentration in mol/L.
         kcl_concentration: KCl concentration in mol/L.
         mgcl2_concentration: MgCl2 concentration in mol/L.
         neutralize: Whether to neutralize system charge.
@@ -151,7 +151,7 @@ class SolventComposition:
 
     water_model: WaterModelType = "tip3p"
     co_solvents: List[CoSolvent] = field(default_factory=list)
-    nacl_concentration: float = 0.0  # NaCl-equivalent final ion pool, mol/L
+    nacl_concentration: float = 0.0  # NaCl-equivalent target concentration, mol/L
     kcl_concentration: float = 0.0
     mgcl2_concentration: float = 0.0
     neutralize: bool = True
@@ -182,7 +182,7 @@ class SolventBuilder:
 
     This class handles:
     - Water solvation with different water models
-    - Ion addition using final-ion-pool neutralization semantics
+    - Ion addition using neutralized concentration semantics
     - Co-solvent addition with specified mole fractions or concentrations
     - Box shape and padding configuration
 
@@ -298,7 +298,7 @@ class SolventBuilder:
         water_mass = sum(atom.mass for atom in water.atoms)
         molarity_pure_water = Quantity(55.5, "mole / liter")
 
-        # Calculate NaCl-equivalent target for the final ion pool
+        # Calculate NaCl-equivalent target concentration
         na = Molecule.from_smiles("[Na+]")
         cl = Molecule.from_smiles("[Cl-]")
         na_mass = sum(atom.mass for atom in na.atoms)
@@ -310,7 +310,7 @@ class SolventBuilder:
         nacl_mass_to_add = solvent_mass * nacl_mass_fraction
         nacl_to_add = self._round_dimensionless_to_int(nacl_mass_to_add / nacl_mass)
 
-        # Resolve the final ion pool, including any neutralizing imbalance
+        # Resolve ion counts, including any neutralizing imbalance
         solute_charge = sum(mol.total_charge for mol in topology.molecules)
         na_to_add, cl_to_add = self._calculate_ion_counts(
             nacl_to_add=nacl_to_add,
@@ -582,8 +582,11 @@ class SolventBuilder:
         """Calculate final Na+ and Cl- counts from a NaCl-equivalent target.
 
         When neutralization is enabled, counts are chosen so that the final
-        solute plus ion charge is exactly zero while keeping the final ion pool
-        as close as possible to the requested NaCl-equivalent total. If parity
+        solute plus ion charge is exactly zero while keeping the final ion
+        concentration as close as possible to the requested NaCl-equivalent
+        target. Exact counts may differ by one ion from the concentration
+        target to satisfy integer charge neutrality; neutrality is prioritized
+        because this difference is negligible for realistic systems. If parity
         makes the target total impossible, the tie is resolved by adding the
         larger feasible ion count.
 

--- a/src/polyzymd/config/schema.py
+++ b/src/polyzymd/config/schema.py
@@ -566,15 +566,18 @@ class PrimarySolventConfig(BaseModel):
 class IonConfig(BaseModel):
     """Configuration for ions in the solvent.
 
-    Attributes:
-        neutralize: Whether to add ions for charge neutralization
-        nacl_concentration: Additional NaCl concentration in mol/L
-        kcl_concentration: Additional KCl concentration in mol/L
-        mgcl2_concentration: Additional MgCl2 concentration in mol/L
+    ``nacl_concentration`` is a NaCl-equivalent target for the final
+    neutralized Na+/Cl- ion pool. When ``neutralize`` is true, PolyzyMD adjusts
+    Na+ and Cl- counts to cancel solute charge while keeping the final pool near
+    this target; it is not additional salt layered on top of neutralizing ions.
     """
 
     neutralize: bool = Field(True, description="Neutralize system charge")
-    nacl_concentration: float = Field(0.0, ge=0.0, description="NaCl conc. (mol/L)")
+    nacl_concentration: float = Field(
+        0.0,
+        ge=0.0,
+        description="NaCl-equivalent final ion pool (mol/L)",
+    )
     kcl_concentration: float = Field(0.0, ge=0.0, description="KCl conc. (mol/L)")
     mgcl2_concentration: float = Field(0.0, ge=0.0, description="MgCl2 conc. (mol/L)")
 

--- a/src/polyzymd/config/schema.py
+++ b/src/polyzymd/config/schema.py
@@ -566,17 +566,18 @@ class PrimarySolventConfig(BaseModel):
 class IonConfig(BaseModel):
     """Configuration for ions in the solvent.
 
-    ``nacl_concentration`` is a NaCl-equivalent target for the final
-    neutralized Na+/Cl- ion pool. When ``neutralize`` is true, PolyzyMD adjusts
-    Na+ and Cl- counts to cancel solute charge while keeping the final pool near
-    this target; it is not additional salt layered on top of neutralizing ions.
+    ``nacl_concentration`` is a NaCl-equivalent target for the final ion
+    concentration. When ``neutralize`` is true, PolyzyMD adjusts Na+ and Cl-
+    counts to cancel solute charge while keeping the achieved concentration
+    near this target; it is not additional salt layered on top of neutralizing
+    ions.
     """
 
     neutralize: bool = Field(True, description="Neutralize system charge")
     nacl_concentration: float = Field(
         0.0,
         ge=0.0,
-        description="NaCl-equivalent final ion pool (mol/L)",
+        description="NaCl-equivalent target concentration (mol/L)",
     )
     kcl_concentration: float = Field(0.0, ge=0.0, description="KCl conc. (mol/L)")
     mgcl2_concentration: float = Field(0.0, ge=0.0, description="MgCl2 conc. (mol/L)")

--- a/src/polyzymd/templates/examples/dynamic_polymer_test.yaml
+++ b/src/polyzymd/templates/examples/dynamic_polymer_test.yaml
@@ -90,7 +90,7 @@ solvent:
   
   ions:
     neutralize: true
-    nacl_concentration: 0.1  # 100 mM NaCl
+    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion pool
   
   box:
     padding: 1.0  # Smaller padding for faster solvation

--- a/src/polyzymd/templates/examples/dynamic_polymer_test.yaml
+++ b/src/polyzymd/templates/examples/dynamic_polymer_test.yaml
@@ -90,7 +90,7 @@ solvent:
   
   ions:
     neutralize: true
-    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion pool
+    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion concentration
   
   box:
     padding: 1.0  # Smaller padding for faster solvation

--- a/src/polyzymd/templates/examples/enzyme_cosolvent.yaml
+++ b/src/polyzymd/templates/examples/enzyme_cosolvent.yaml
@@ -49,7 +49,7 @@ solvent:
   
   ions:
     neutralize: true
-    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion pool
+    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion concentration
   
   box:
     padding: 2.0  # nm padding (2.0 recommended for PACKMOL convergence)

--- a/src/polyzymd/templates/examples/enzyme_cosolvent.yaml
+++ b/src/polyzymd/templates/examples/enzyme_cosolvent.yaml
@@ -49,7 +49,7 @@ solvent:
   
   ions:
     neutralize: true
-    nacl_concentration: 0.1
+    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion pool
   
   box:
     padding: 2.0  # nm padding (2.0 recommended for PACKMOL convergence)

--- a/src/polyzymd/templates/examples/enzyme_only.yaml
+++ b/src/polyzymd/templates/examples/enzyme_only.yaml
@@ -44,7 +44,7 @@ solvent:
   
   ions:
     neutralize: true  # Add counter-ions to neutralize charge
-    nacl_concentration: 0.1  # 100 mM NaCl
+    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion pool
   
   box:
     padding: 2.0  # nm from solute to box edge (2.0 recommended for PACKMOL convergence)

--- a/src/polyzymd/templates/examples/enzyme_only.yaml
+++ b/src/polyzymd/templates/examples/enzyme_only.yaml
@@ -44,7 +44,7 @@ solvent:
   
   ions:
     neutralize: true  # Add counter-ions to neutralize charge
-    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion pool
+    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion concentration
   
   box:
     padding: 2.0  # nm from solute to box edge (2.0 recommended for PACKMOL convergence)

--- a/src/polyzymd/templates/examples/enzyme_polymer.yaml
+++ b/src/polyzymd/templates/examples/enzyme_polymer.yaml
@@ -77,7 +77,7 @@ solvent:
   
   ions:
     neutralize: true
-    nacl_concentration: 0.1  # 100 mM NaCl
+    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion pool
   
   box:
     padding: 2.0  # nm padding (2.0 recommended for PACKMOL convergence)

--- a/src/polyzymd/templates/examples/enzyme_polymer.yaml
+++ b/src/polyzymd/templates/examples/enzyme_polymer.yaml
@@ -77,7 +77,7 @@ solvent:
   
   ions:
     neutralize: true
-    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion pool
+    nacl_concentration: 0.1  # 100 mM NaCl-equivalent final ion concentration
   
   box:
     padding: 2.0  # nm padding (2.0 recommended for PACKMOL convergence)

--- a/src/polyzymd/templates/templates/config_template.yaml
+++ b/src/polyzymd/templates/templates/config_template.yaml
@@ -211,7 +211,7 @@ description: "Description of your simulation system"
 #   
 #   ions:
 #     neutralize: true                    # Add counter-ions to neutralize
-#     nacl_concentration: 0.15            # Molar (0.15 = 150 mM)
+#     nacl_concentration: 0.15            # NaCl-equivalent final ion pool (M)
 #   
 #   box:
 #     padding: 1.2                        # nm from solute to box edge

--- a/src/polyzymd/templates/templates/config_template.yaml
+++ b/src/polyzymd/templates/templates/config_template.yaml
@@ -211,7 +211,7 @@ description: "Description of your simulation system"
 #   
 #   ions:
 #     neutralize: true                    # Add counter-ions to neutralize
-#     nacl_concentration: 0.15            # NaCl-equivalent final ion pool (M)
+#     nacl_concentration: 0.15            # NaCl-equivalent final ion concentration (M)
 #   
 #   box:
 #     padding: 1.2                        # nm from solute to box edge

--- a/tests/builders/test_solvent.py
+++ b/tests/builders/test_solvent.py
@@ -1,5 +1,7 @@
 """Tests for solvent composition counting helpers."""
 
+import pytest
+
 from polyzymd.builders.solvent import AVOGADRO_CONSTANT, SolventBuilder
 from polyzymd.config.schema import CoSolventSpec, SolventConfig
 
@@ -55,3 +57,60 @@ def test_config_translation_uses_mole_fraction(monkeypatch) -> None:
     assert co_solvents[0].concentration is None
     assert co_solvents[1].mole_fraction is None
     assert co_solvents[1].concentration == 2.0
+
+
+def test_neutralizing_ion_counts_break_parity_ties_toward_more_ions() -> None:
+    """Neutralization should prefer the larger feasible ion total on parity ties."""
+    na_count, cl_count = SolventBuilder._calculate_ion_counts(
+        nacl_to_add=43,
+        solute_charge=-15,
+        neutralize=True,
+    )
+
+    assert (na_count, cl_count) == (51, 36)
+    assert -15 + na_count - cl_count == 0
+
+
+@pytest.mark.parametrize(
+    ("solute_charge", "expected_counts"),
+    [
+        (-4, (12, 8)),
+        (5, (8, 13)),
+        (0, (10, 10)),
+    ],
+)
+def test_neutralizing_ion_counts_produce_zero_net_charge(
+    solute_charge: int,
+    expected_counts: tuple[int, int],
+) -> None:
+    """Neutralizing ion counts should exactly cancel integer solute charge."""
+    na_count, cl_count = SolventBuilder._calculate_ion_counts(
+        nacl_to_add=10,
+        solute_charge=solute_charge,
+        neutralize=True,
+    )
+
+    assert (na_count, cl_count) == expected_counts
+    assert solute_charge + na_count - cl_count == 0
+
+
+def test_non_neutralizing_ion_counts_preserve_equal_salt_pairs() -> None:
+    """Non-neutralizing ion counts should preserve equal NaCl pairs."""
+    na_count, cl_count = SolventBuilder._calculate_ion_counts(
+        nacl_to_add=43,
+        solute_charge=-15,
+        neutralize=False,
+    )
+
+    assert (na_count, cl_count) == (43, 43)
+
+
+def test_charge_to_integer_tolerates_tiny_floating_noise() -> None:
+    """Integer charge conversion should tolerate tiny floating-point noise."""
+    assert SolventBuilder._charge_to_integer(-15.00000024) == -15
+
+
+def test_charge_to_integer_rejects_true_fractional_charge() -> None:
+    """Integer charge conversion should reject fractional net charge."""
+    with pytest.raises(ValueError, match="must be an integer"):
+        SolventBuilder._charge_to_integer(-15.25)

--- a/tests/builders/test_solvent.py
+++ b/tests/builders/test_solvent.py
@@ -28,6 +28,20 @@ def test_mole_fraction_counts_replace_water_from_mass_budget() -> None:
     assert water_count == 90
 
 
+def test_neutral_solvent_mass_subtracts_actual_final_ion_pool() -> None:
+    """Mass budgeting should reserve the actual final neutralized ion pool."""
+    neutral_solvent_mass = SolventBuilder._calculate_neutral_solvent_mass(
+        solvent_mass=5000.0,
+        na_count=51,
+        cl_count=36,
+        na_mass=23.0,
+        cl_mass=35.5,
+    )
+
+    assert neutral_solvent_mass == 5000.0 - (51 * 23.0 + 36 * 35.5)
+    assert neutral_solvent_mass != 5000.0 - (43 * (23.0 + 35.5))
+
+
 def test_config_translation_uses_mole_fraction(monkeypatch) -> None:
     """solvate_from_config should pass mole_fraction into builder composition."""
     captured = {}
@@ -59,8 +73,8 @@ def test_config_translation_uses_mole_fraction(monkeypatch) -> None:
     assert co_solvents[1].concentration == 2.0
 
 
-def test_neutralizing_ion_counts_break_parity_ties_toward_more_ions() -> None:
-    """Neutralization should prefer the larger feasible ion total on parity ties."""
+def test_neutralizing_ion_counts_use_final_pool_and_tie_toward_more_ions() -> None:
+    """Neutralization should target a final ion pool and prefer more ions on ties."""
     na_count, cl_count = SolventBuilder._calculate_ion_counts(
         nacl_to_add=43,
         solute_charge=-15,
@@ -83,7 +97,7 @@ def test_neutralizing_ion_counts_produce_zero_net_charge(
     solute_charge: int,
     expected_counts: tuple[int, int],
 ) -> None:
-    """Neutralizing ion counts should exactly cancel integer solute charge."""
+    """Neutralizing final ion counts should exactly cancel integer solute charge."""
     na_count, cl_count = SolventBuilder._calculate_ion_counts(
         nacl_to_add=10,
         solute_charge=solute_charge,

--- a/tests/builders/test_solvent.py
+++ b/tests/builders/test_solvent.py
@@ -28,8 +28,8 @@ def test_mole_fraction_counts_replace_water_from_mass_budget() -> None:
     assert water_count == 90
 
 
-def test_neutral_solvent_mass_subtracts_actual_final_ion_pool() -> None:
-    """Mass budgeting should reserve the actual final neutralized ion pool."""
+def test_neutral_solvent_mass_subtracts_actual_final_ions() -> None:
+    """Mass budgeting should reserve the actual final neutralized ion counts."""
     neutral_solvent_mass = SolventBuilder._calculate_neutral_solvent_mass(
         solvent_mass=5000.0,
         na_count=51,
@@ -73,8 +73,8 @@ def test_config_translation_uses_mole_fraction(monkeypatch) -> None:
     assert co_solvents[1].concentration == 2.0
 
 
-def test_neutralizing_ion_counts_use_final_pool_and_tie_toward_more_ions() -> None:
-    """Neutralization should target a final ion pool and prefer more ions on ties."""
+def test_neutralizing_ion_counts_use_target_and_tie_toward_more_ions() -> None:
+    """Neutralization should target a concentration and prefer more ions on ties."""
     na_count, cl_count = SolventBuilder._calculate_ion_counts(
         nacl_to_add=43,
         solute_charge=-15,

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -156,15 +156,16 @@ class TestConfigValidation:
         assert config.neutralize is True
         assert config.nacl_concentration == 0.0
 
-    def test_ion_config_nacl_description_documents_final_pool_semantics(self):
-        """IonConfig should document NaCl-equivalent final-pool semantics."""
+    def test_ion_config_nacl_description_documents_target_concentration(self):
+        """IonConfig should document NaCl-equivalent target concentration."""
         from polyzymd.config.schema import IonConfig
 
         description = IonConfig.model_fields["nacl_concentration"].description
 
         assert description is not None
         assert "NaCl-equivalent" in description
-        assert "final ion pool" in description
+        assert "target concentration" in description
+        assert "pool" not in description
         assert "Additional" not in description
 
 

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -156,6 +156,17 @@ class TestConfigValidation:
         assert config.neutralize is True
         assert config.nacl_concentration == 0.0
 
+    def test_ion_config_nacl_description_documents_final_pool_semantics(self):
+        """IonConfig should document NaCl-equivalent final-pool semantics."""
+        from polyzymd.config.schema import IonConfig
+
+        description = IonConfig.model_fields["nacl_concentration"].description
+
+        assert description is not None
+        assert "NaCl-equivalent" in description
+        assert "final ion pool" in description
+        assert "Additional" not in description
+
 
 class TestCoSolventCompositionValidation:
     """Test co-solvent mole fraction and concentration validation."""


### PR DESCRIPTION
## Summary

- Enforces exact electrostatic neutrality when ion neutralization is enabled.
- Fixes odd-charge Na/Cl parity cases, including the reported albumin case:

  ```text
  solute charge = -15
  target salt count = 43
  previous: 51 Na+ / 35 Cl- -> net +1
  fixed:    51 Na+ / 36 Cl- -> net 0
  ```

- Updates solvent mass budgeting to subtract the actual final Na+/Cl- ion masses.
- Clarifies docs, schema descriptions, and templates around NaCl-equivalent final ion concentration.

## Background

The previous neutralization logic split the target salt count using `ceil` and `floor`:

```python
Na = ceil(target_salt_pairs - solute_charge / 2)
Cl = floor(target_salt_pairs + solute_charge / 2)
```

For odd solute charges, this can overshoot by one ion. For example, a `-15` solute charge with target count `43` produced:

```text
Na = 51
Cl = 35
ion charge = +16
total system charge = -15 + 16 = +1
```

The new logic chooses integer Na+/Cl- counts such that:

```python
solute_charge + Na - Cl == 0
```

When two neutral choices are equally close to the target concentration, it chooses the option with one more ion.

## Tests

Passed locally:

```bash
pixi run -e build pytest tests/builders/test_solvent.py -v
pixi run -e build pytest tests/config/test_schema.py -v -k 'IonConfig or ion or nacl'
pixi run -e build ruff check src/polyzymd/builders/solvent.py src/polyzymd/config/schema.py tests/builders/test_solvent.py tests/config/test_schema.py
pixi run -e build black --check src/polyzymd/builders/solvent.py src/polyzymd/config/schema.py tests/builders/test_solvent.py tests/config/test_schema.py
pixi run -e build make -C docs clean html
```

## Notes

- This PR prioritizes electrostatic neutrality when `ions.neutralize: true`.
- Exact ion counts may differ by one ion from the concentration target in odd-charge parity cases, which is negligible compared with leaving the system charged.