### PR TITLE
refactor(conjugation): remove previous conjugation API

### DIFF
--- a/src/polyzymd/builders/conjugation/_moiety_provider.py
+++ b/src/polyzymd/builders/conjugation/_moiety_provider.py
@@ -15,8 +15,8 @@ from polyzymd.builders.conjugation.polymer import (
     PolymerRecipe,
     build_smiles_moiety_fragment,
     generate_polymerist_smoke_polymer,
-    generated_fragment_from_polymerist_pdb,
 )
+from polyzymd.builders.conjugation.polymer.polymerist import generated_fragment_from_polymerist_pdb
 
 
 class ResolvedMoietySource(BaseModel):

--- a/src/polyzymd/builders/conjugation/polymer/__init__.py
+++ b/src/polyzymd/builders/conjugation/polymer/__init__.py
@@ -28,18 +28,6 @@ __all__ = [
     "PolymerRecipe",
     "PolymeristGenerationSmokeResult",
     "generate_polymerist_smoke_polymer",
-    "generated_fragment_from_polymerist_pdb",
     "sbma_nhs_egpma_acb_recipe",
     "sbma_egpma_nhs_recipe",
 ]
-
-
-def __getattr__(name: str):
-    """Lazily expose Polymerist PDB helpers without import-time reaction cycles."""
-    if name == "generated_fragment_from_polymerist_pdb":
-        from polyzymd.builders.conjugation.polymer.polymerist import (
-            generated_fragment_from_polymerist_pdb,
-        )
-
-        return generated_fragment_from_polymerist_pdb
-    raise AttributeError(name)

--- a/src/polyzymd/builders/conjugation/reactions/__init__.py
+++ b/src/polyzymd/builders/conjugation/reactions/__init__.py
@@ -1,10 +1,6 @@
 """Reaction-template registry for conjugation builders."""
 
-from polyzymd.builders.conjugation.reactions.base import (
-    ReactionContext,
-    ReactionResult,
-    ReactionTemplate,
-)
+from polyzymd.builders.conjugation.reactions.base import ReactionTemplate
 from polyzymd.builders.conjugation.reactions.library import get_reaction, list_reactions
 from polyzymd.builders.conjugation.reactions.n_glycosylation import (
     NGlycosylationReaction,
@@ -17,8 +13,6 @@ __all__ = [
     "NGlycosylationReactionSettings",
     "NhsLysReaction",
     "NhsLysReactionSettings",
-    "ReactionContext",
-    "ReactionResult",
     "ReactionTemplate",
     "get_reaction",
     "list_reactions",

--- a/src/polyzymd/builders/conjugation/reactions/base.py
+++ b/src/polyzymd/builders/conjugation/reactions/base.py
@@ -5,27 +5,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, Field
-
-
-class ReactionContext(BaseModel):
-    """Placeholder context passed to future reaction templates."""
-
-    model_config = {"arbitrary_types_allowed": True}
-
-    protein: Any | None = None
-    moiety: Any | None = None
-    metadata: dict[str, Any] = Field(default_factory=dict)
-
-
-class ReactionResult(BaseModel):
-    """Placeholder result returned by future reaction templates."""
-
-    model_config = {"arbitrary_types_allowed": True}
-
-    plan: Any | None = None
-    metadata: dict[str, Any] = Field(default_factory=dict)
-
 
 class ReactionTemplate(ABC):
     """Base class for conjugation reaction mechanisms.
@@ -72,20 +51,3 @@ class ReactionTemplate(ABC):
         Any
             A mechanism-owned generic resolved attachment plan.
         """
-
-    def plan(self, context: ReactionContext) -> ReactionResult:
-        """Resolve a generic plan from a reaction context."""
-        site_config = context.metadata.get("site_config") or context.metadata.get("site")
-        settings = context.metadata.get("settings")
-        if context.protein is None or context.moiety is None or site_config is None:
-            raise ValueError(
-                "Reaction planning requires context.protein, context.moiety, and "
-                "metadata['site_config']"
-            )
-        plan = self.resolve_attachment(
-            context.protein,
-            site_config,
-            context.moiety,
-            settings=settings,
-        )
-        return ReactionResult(plan=plan, metadata={"mechanism": self.name})

--- a/src/polyzymd/builders/conjugation/reactions/n_glycosylation.py
+++ b/src/polyzymd/builders/conjugation/reactions/n_glycosylation.py
@@ -17,11 +17,7 @@ from polyzymd.builders.conjugation._linkage import (
     resolve_explicit_linkage_contract,
 )
 from polyzymd.builders.conjugation.polymer import GeneratedMoietyFragment
-from polyzymd.builders.conjugation.reactions.base import (
-    ReactionContext,
-    ReactionResult,
-    ReactionTemplate,
-)
+from polyzymd.builders.conjugation.reactions.base import ReactionTemplate
 from polyzymd.builders.conjugation.structure.pdb import PdbAtomRecord
 
 
@@ -296,23 +292,6 @@ class NGlycosylationReaction(ReactionTemplate):
             fragment,
             settings=settings,
         )
-
-    def plan(self, context: ReactionContext) -> ReactionResult:
-        """Resolve a plan from a reaction context carrying protein, site, and moiety."""
-        site_config = context.metadata.get("site_config") or context.metadata.get("site")
-        settings = context.metadata.get("settings")
-        if context.protein is None or context.moiety is None or site_config is None:
-            raise ValueError(
-                "N-glycosylation planning requires context.protein, context.moiety, and "
-                "metadata['site_config']"
-            )
-        plan = self.resolve_plan(
-            context.protein,
-            site_config,
-            context.moiety,
-            settings=settings,
-        )
-        return ReactionResult(plan=plan, metadata={"mechanism": self.name})
 
 
 def detect_glycan_anomeric_group(mol: Any) -> GlycanAnomericGroup:

--- a/src/polyzymd/builders/conjugation/reactions/nhs_lys.py
+++ b/src/polyzymd/builders/conjugation/reactions/nhs_lys.py
@@ -19,11 +19,7 @@ from polyzymd.builders.conjugation.reactions._rdkit_graph import (
     extract_lysine_reactive_site,
     plan_nhs_lys_amide,
 )
-from polyzymd.builders.conjugation.reactions.base import (
-    ReactionContext,
-    ReactionResult,
-    ReactionTemplate,
-)
+from polyzymd.builders.conjugation.reactions.base import ReactionTemplate
 
 
 class NhsLysReactionSettings(BaseModel):
@@ -310,10 +306,6 @@ class NhsLysReaction(ReactionTemplate):
             reactive_group,
             site_hydrogen_indices_to_remove=site_hydrogen_indices_to_remove,
         )
-
-    def plan(self, context: ReactionContext) -> ReactionResult:
-        """Resolve a generic NHS-Lys plan from a reaction context."""
-        return super().plan(context)
 
 
 def _coalesce_text(*values: str | None) -> str:

--- a/tests/test_conjugation_integrated_smoke.py
+++ b/tests/test_conjugation_integrated_smoke.py
@@ -47,7 +47,7 @@ from polyzymd.builders.conjugation.pablo.ingestion import PabloIngestionResult, 
 from polyzymd.builders.conjugation.pablo.parameterization import (
     create_interchange_from_pablo_topology,
 )
-from polyzymd.builders.conjugation.polymer import generated_fragment_from_polymerist_pdb
+from polyzymd.builders.conjugation.polymer.polymerist import generated_fragment_from_polymerist_pdb
 from polyzymd.builders.conjugation.polymer.recipe import (
     generate_polymerist_smoke_polymer,
     sbma_egpma_nhs_recipe,

--- a/tests/test_conjugation_polymerist_pdb.py
+++ b/tests/test_conjugation_polymerist_pdb.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from polyzymd.builders.conjugation.polymer import generated_fragment_from_polymerist_pdb
+from polyzymd.builders.conjugation.polymer.polymerist import generated_fragment_from_polymerist_pdb
 from polyzymd.builders.conjugation.polymer.recipe import (
     generate_polymerist_smoke_polymer,
     sbma_egpma_nhs_recipe,

--- a/tests/test_conjugation_product_pablo.py
+++ b/tests/test_conjugation_product_pablo.py
@@ -16,10 +16,8 @@ from polyzymd.builders.conjugation.pablo.product import (
     build_product_state_pablo_library,
     build_product_state_pablo_library_for_specs,
 )
-from polyzymd.builders.conjugation.polymer import (
-    GeneratedPolymerFragment,
-    generated_fragment_from_polymerist_pdb,
-)
+from polyzymd.builders.conjugation.polymer import GeneratedPolymerFragment
+from polyzymd.builders.conjugation.polymer.polymerist import generated_fragment_from_polymerist_pdb
 from polyzymd.builders.conjugation.structure.pdb import PdbAtomRecord
 from polyzymd.config.schema import ConjugationCcdPabloPolicyConfig
 


### PR DESCRIPTION
## Summary
- Remove lazy polymer package compatibility shim for generated_fragment_from_polymerist_pdb.
- Remove dead/future reaction planning API: ReactionContext, ReactionResult, ReactionTemplate.plan, and unused plan overrides.
- Update active imports/tests to use direct Polymerist adapter imports.

## Validation
- pixi run -e build pytest tests/test_conjugation_nhs_lys.py tests/test_conjugation_n_glycosylation.py -v — 18 passed.
- pixi run -e build pytest tests/test_conjugation_system_workflow.py tests/test_conjugation_api.py -v — 41 passed.
- pixi run -e build pytest tests/ -v -k "conjugation" — 323 passed, 3 skipped.
- pixi run -e build ruff check src/polyzymd/builders/conjugation tests/test_conjugation*.py — passed.
- pixi run -e build black src/polyzymd/builders/conjugation tests/test_conjugation*.py --check — passed.
- Known config dry-run passed for config_005_linkages.yaml.

## Review
- Adversarial review: APPROVED_WITH_FOLLOWUPS.
- No blockers.

## Notes
- POC notebooks/artifacts intentionally untouched and out of scope for Phase 1.
- Existing local dirty/untracked files were not staged or committed.