### PR TITLE
Phase 2: remove POC recipe APIs

### DIFF
--- a/src/polyzymd/builders/conjugation/_moiety_provider.py
+++ b/src/polyzymd/builders/conjugation/_moiety_provider.py
@@ -11,10 +11,10 @@ from polyzymd.builders.conjugation._specs import _generated_fragment_from_moiety
 from polyzymd.builders.conjugation.polymer import (
     GeneratedMoietyFragment,
     GeneratedPolymerFragment,
-    PolymeristGenerationResult,
+    MultiResidueGenerationResult,
     PolymerRecipe,
     build_smiles_moiety_fragment,
-    generate_polymerist_recipe_polymer,
+    generate_multi_residue_molecule,
 )
 from polyzymd.builders.conjugation.polymer.polymerist import generated_fragment_from_polymerist_pdb
 
@@ -28,7 +28,7 @@ class ResolvedMoietySource(BaseModel):
     source_fragment: Any | None = Field(default=None, exclude=True)
     source_kind: Literal["polymer", "smiles"]
     sidecars: dict[str, Path] = Field(default_factory=dict)
-    generation: PolymeristGenerationResult | None = None
+    generation: MultiResidueGenerationResult | None = None
     reactive_sequence_index: int | None = None
     reactive_selector: dict[str, int | str] | None = None
     diagnostics: tuple[str, ...] = Field(default_factory=tuple)
@@ -60,9 +60,9 @@ def resolve_moiety_source(
     force_regenerate : bool, optional
         Regenerate polymer artifacts when using a polymer recipe, by default ``False``.
     max_retries : int, optional
-        Polymerist generation retry count, by default 3.
+        Multi-residue generation retry count, by default 3.
     energy_minimize : bool, optional
-        Whether Polymerist should minimize generated polymers, by default ``True``.
+        Whether the generation backend should minimize generated polymers, by default ``True``.
     random_seed : int or None, optional
         Optional RDKit seed for SMILES moiety conformer generation, by default ``None``.
 
@@ -137,12 +137,12 @@ def _resolve_polymer_recipe_source(
     max_retries: int,
     energy_minimize: bool,
 ) -> ResolvedMoietySource:
-    """Resolve a Polymerist-backed polymer source."""
+    """Resolve a recipe-backed multi-residue polymer source."""
     recipe = getattr(attachment.moiety, "polymer_recipe", None)
     if not isinstance(recipe, PolymerRecipe):
         raise ValueError("attachment.moiety.polymer_recipe must define a PolymerRecipe")
     reactive_sequence_index = _reactive_sequence_index(recipe)
-    generation = generate_polymerist_recipe_polymer(
+    generation = generate_multi_residue_molecule(
         recipe,
         output_dir / f"{attachment_index:02d}_{_safe_attachment_token(attachment.name)}",
         force_regenerate=force_regenerate,
@@ -150,7 +150,7 @@ def _resolve_polymer_recipe_source(
         energy_minimize=energy_minimize,
     )
     if generation.pdb_path is None:
-        raise RuntimeError("Polymerist did not produce a conjugate-polymer PDB")
+        raise RuntimeError("Generation backend did not produce a conjugate-polymer PDB")
     reactive_selector = _reactive_residue_selector(
         generation.pdb_path,
         sequence=generation.sequence,
@@ -290,7 +290,7 @@ def _reactive_residue_selector(
     )
     if pdb_order_index >= len(residues):
         raise ValueError(
-            "reactive sequence index maps outside the Polymerist PDB residue list: "
+            "reactive sequence index maps outside the generated PDB residue list: "
             f"sequence_index={reactive_sequence_index}, pdb_order_index={pdb_order_index}, "
             f"residues={len(residues)}"
         )

--- a/src/polyzymd/builders/conjugation/_moiety_provider.py
+++ b/src/polyzymd/builders/conjugation/_moiety_provider.py
@@ -11,10 +11,10 @@ from polyzymd.builders.conjugation._specs import _generated_fragment_from_moiety
 from polyzymd.builders.conjugation.polymer import (
     GeneratedMoietyFragment,
     GeneratedPolymerFragment,
-    PolymeristGenerationSmokeResult,
+    PolymeristGenerationResult,
     PolymerRecipe,
     build_smiles_moiety_fragment,
-    generate_polymerist_smoke_polymer,
+    generate_polymerist_recipe_polymer,
 )
 from polyzymd.builders.conjugation.polymer.polymerist import generated_fragment_from_polymerist_pdb
 
@@ -28,7 +28,7 @@ class ResolvedMoietySource(BaseModel):
     source_fragment: Any | None = Field(default=None, exclude=True)
     source_kind: Literal["polymer", "smiles"]
     sidecars: dict[str, Path] = Field(default_factory=dict)
-    generation: PolymeristGenerationSmokeResult | None = None
+    generation: PolymeristGenerationResult | None = None
     reactive_sequence_index: int | None = None
     reactive_selector: dict[str, int | str] | None = None
     diagnostics: tuple[str, ...] = Field(default_factory=tuple)
@@ -142,7 +142,7 @@ def _resolve_polymer_recipe_source(
     if not isinstance(recipe, PolymerRecipe):
         raise ValueError("attachment.moiety.polymer_recipe must define a PolymerRecipe")
     reactive_sequence_index = _reactive_sequence_index(recipe)
-    generation = generate_polymerist_smoke_polymer(
+    generation = generate_polymerist_recipe_polymer(
         recipe,
         output_dir / f"{attachment_index:02d}_{_safe_attachment_token(attachment.name)}",
         force_regenerate=force_regenerate,

--- a/src/polyzymd/builders/conjugation/polymer/__init__.py
+++ b/src/polyzymd/builders/conjugation/polymer/__init__.py
@@ -10,12 +10,10 @@ from polyzymd.builders.conjugation.polymer.moiety import (
     build_smiles_moiety_fragment,
 )
 from polyzymd.builders.conjugation.polymer.recipe import (
-    PolymeristGenerationSmokeResult,
+    PolymeristGenerationResult,
     PolymerMonomerRecipe,
     PolymerRecipe,
-    generate_polymerist_smoke_polymer,
-    sbma_egpma_nhs_recipe,
-    sbma_nhs_egpma_acb_recipe,
+    generate_polymerist_recipe_polymer,
 )
 
 __all__ = [
@@ -26,8 +24,6 @@ __all__ = [
     "build_smiles_moiety_fragment",
     "PolymerMonomerRecipe",
     "PolymerRecipe",
-    "PolymeristGenerationSmokeResult",
-    "generate_polymerist_smoke_polymer",
-    "sbma_nhs_egpma_acb_recipe",
-    "sbma_egpma_nhs_recipe",
+    "PolymeristGenerationResult",
+    "generate_polymerist_recipe_polymer",
 ]

--- a/src/polyzymd/builders/conjugation/polymer/__init__.py
+++ b/src/polyzymd/builders/conjugation/polymer/__init__.py
@@ -10,10 +10,10 @@ from polyzymd.builders.conjugation.polymer.moiety import (
     build_smiles_moiety_fragment,
 )
 from polyzymd.builders.conjugation.polymer.recipe import (
-    PolymeristGenerationResult,
+    MultiResidueGenerationResult,
     PolymerMonomerRecipe,
     PolymerRecipe,
-    generate_polymerist_recipe_polymer,
+    generate_multi_residue_molecule,
 )
 
 __all__ = [
@@ -22,8 +22,8 @@ __all__ = [
     "PolymerFragmentAtom",
     "PolymerFragmentResidue",
     "build_smiles_moiety_fragment",
+    "MultiResidueGenerationResult",
     "PolymerMonomerRecipe",
     "PolymerRecipe",
-    "PolymeristGenerationResult",
-    "generate_polymerist_recipe_polymer",
+    "generate_multi_residue_molecule",
 ]

--- a/src/polyzymd/builders/conjugation/polymer/recipe.py
+++ b/src/polyzymd/builders/conjugation/polymer/recipe.py
@@ -8,16 +8,6 @@ from typing import Any
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
-POC_SBMA_SMILES = (
-    "[H]C([H])=C(C(=O)OC([H])([H])C([H])([H])[N+]"
-    "(C([H])([H])[H])(C([H])([H])[H])C([H])([H])C([H])([H])"
-    "C([H])([H])S(=O)(=O)[O-])C([H])([H])[H]"
-)
-POC_EGPMA_SMILES = (
-    "[H]C([H])=C(C(=O)OC([H])([H])C([H])([H])Oc1c([H])c([H])c([H])c([H])c1[H])C([H])([H])[H]"
-)
-POC_NHS_SMILES = "CC(=C)C(=O)ON1C(=O)CCC1=O"
-
 DEFAULT_PROBABILITY_TOLERANCE = 1.0e-6
 
 
@@ -238,7 +228,7 @@ class PolymerRecipe(BaseModel):
         return {monomer.name: monomer.residue_name for monomer in self.monomers}
 
 
-class PolymeristGenerationSmokeResult(BaseModel):
+class PolymeristGenerationResult(BaseModel):
     """Summary from the optional Polymerist recipe-generation boundary."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -255,90 +245,14 @@ class PolymeristGenerationSmokeResult(BaseModel):
     rdkit_mol: Any | None = Field(default=None, exclude=True)
 
 
-def sbma_egpma_nhs_recipe(
-    *,
-    length: int = 10,
-    seed: int | None = 42,
-    reactive_monomer_index: int | None = None,
-    fixed_sequence: str | None = None,
-) -> PolymerRecipe:
-    """Build the SBMA/EGPMA/NHS recipe used by the conjugation POC.
-
-    Parameters
-    ----------
-    length : int, optional
-        Degree of polymerization, by default 10.
-    seed : int or None, optional
-        Random seed for deterministic sequence generation, by default 42.
-    reactive_monomer_index : int or None, optional
-        Zero-based NHS residue index. ``None`` centers NHS, by default ``None``.
-    fixed_sequence : str or None, optional
-        Exact monomer-label sequence overriding stochastic generation, by default
-        ``None``.
-
-    Returns
-    -------
-    PolymerRecipe
-        Validated stochastic polymer recipe.
-    """
-    return PolymerRecipe(
-        name="SBMA-EGPMA-NHS",
-        monomers=(
-            PolymerMonomerRecipe(
-                label="A",
-                name="SBMA",
-                residue_name="SBM",
-                smiles=POC_SBMA_SMILES,
-                probability=0.945,
-            ),
-            PolymerMonomerRecipe(
-                label="B",
-                name="EGPMA",
-                residue_name="EGP",
-                smiles=POC_EGPMA_SMILES,
-                probability=0.045,
-            ),
-            PolymerMonomerRecipe(
-                label="C",
-                name="NHS",
-                residue_name="NHS",
-                smiles=POC_NHS_SMILES,
-                probability=0.01,
-            ),
-        ),
-        length=length,
-        seed=seed,
-        reactive_monomer_label="C",
-        reactive_monomer_index=reactive_monomer_index,
-        fixed_sequence=fixed_sequence,
-    )
-
-
-def sbma_nhs_egpma_acb_recipe() -> PolymerRecipe:
-    """Build the deterministic v1 SBMA:NHS:EGPMA recipe.
-
-    Returns
-    -------
-    PolymerRecipe
-        Three-monomer recipe whose fixed sequence ``ACB`` maps to
-        SBMA:NHS:EGPMA with the NHS monomer centered for Lys linkage.
-    """
-    return sbma_egpma_nhs_recipe(
-        length=3,
-        seed=None,
-        reactive_monomer_index=1,
-        fixed_sequence="ACB",
-    )
-
-
-def generate_polymerist_smoke_polymer(
+def generate_polymerist_recipe_polymer(
     recipe: PolymerRecipe,
     cache_directory: Path | str,
     *,
     force_regenerate: bool = False,
     max_retries: int = 3,
     energy_minimize: bool = True,
-) -> PolymeristGenerationSmokeResult:
+) -> PolymeristGenerationResult:
     """Generate a small Polymerist-backed polymer artifact from a recipe.
 
     This boundary intentionally stops at Polymerist fragment and PDB generation.
@@ -361,7 +275,7 @@ def generate_polymerist_smoke_polymer(
 
     Returns
     -------
-    PolymeristGenerationSmokeResult
+    PolymeristGenerationResult
         Summary with generated sequence, cache paths, and object metadata.
     """
     from polyzymd.builders.fragment_generator import FragmentGenerator
@@ -425,7 +339,7 @@ def generate_polymerist_smoke_polymer(
     if atom_count is None:
         atom_count = _get_polymerist_atom_count(polymer_object)
 
-    return PolymeristGenerationSmokeResult(
+    return PolymeristGenerationResult(
         recipe_name=recipe.name,
         sequence=sequence,
         cache_directory=cache_path,

--- a/src/polyzymd/builders/conjugation/polymer/recipe.py
+++ b/src/polyzymd/builders/conjugation/polymer/recipe.py
@@ -1,4 +1,4 @@
-"""Polymer recipe models and Polymerist generation boundary."""
+"""Polymer recipe models and multi-residue generation boundary."""
 
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ class PolymerMonomerRecipe(BaseModel):
     @field_validator("name")
     @classmethod
     def normalize_name(cls, value: str) -> str:
-        """Normalize a monomer name for Polymerist fragment lookup."""
+        """Normalize a monomer name for backend fragment lookup."""
         normalized = value.strip()
         if not normalized:
             raise ValueError("Monomer names cannot be blank")
@@ -220,7 +220,7 @@ class PolymerRecipe(BaseModel):
         return {monomer.name: monomer.smiles for monomer in self.monomers}
 
     def to_sequence_monomer_names(self) -> dict[str, str]:
-        """Return the sequence-label to monomer-name mapping expected by Polymerist."""
+        """Return the sequence-label to monomer-name mapping expected by the backend."""
         return {monomer.label: monomer.name for monomer in self.monomers}
 
     def to_polymerist_residue_names(self) -> dict[str, str]:
@@ -228,11 +228,12 @@ class PolymerRecipe(BaseModel):
         return {monomer.name: monomer.residue_name for monomer in self.monomers}
 
 
-class PolymeristGenerationResult(BaseModel):
-    """Summary from the optional Polymerist recipe-generation boundary."""
+class MultiResidueGenerationResult(BaseModel):
+    """Summary from the optional multi-residue generation boundary."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    backend: str = "polymerist"
     recipe_name: str
     sequence: str
     cache_directory: Path
@@ -245,17 +246,17 @@ class PolymeristGenerationResult(BaseModel):
     rdkit_mol: Any | None = Field(default=None, exclude=True)
 
 
-def generate_polymerist_recipe_polymer(
+def generate_multi_residue_molecule(
     recipe: PolymerRecipe,
     cache_directory: Path | str,
     *,
     force_regenerate: bool = False,
     max_retries: int = 3,
     energy_minimize: bool = True,
-) -> PolymeristGenerationResult:
-    """Generate a small Polymerist-backed polymer artifact from a recipe.
+) -> MultiResidueGenerationResult:
+    """Generate a small multi-residue molecule artifact from a recipe.
 
-    This boundary intentionally stops at Polymerist fragment and PDB generation.
+    This boundary intentionally stops at backend fragment and PDB generation.
     It does not perform placement, relaxation, charging, Interchange export, or
     simulation setup.
 
@@ -264,18 +265,18 @@ def generate_polymerist_recipe_polymer(
     recipe : PolymerRecipe
         Validated polymer recipe containing monomer SMILES and probabilities.
     cache_directory : pathlib.Path or str
-        Directory for Polymerist fragment and polymer PDB cache files.
+        Directory for generated fragment and polymer PDB cache files.
     force_regenerate : bool, optional
-        Rebuild cached Polymerist fragments when possible, by default ``False``.
+        Rebuild cached backend fragments when possible, by default ``False``.
     max_retries : int, optional
-        Maximum Polymerist structure-building attempts, by default 3.
+        Maximum backend structure-building attempts, by default 3.
     energy_minimize : bool, optional
-        Whether Polymerist should run its built-in minimization during structure
+        Whether the backend should run its built-in minimization during structure
         generation, by default ``True``.
 
     Returns
     -------
-    PolymeristGenerationResult
+    MultiResidueGenerationResult
         Summary with generated sequence, cache paths, and object metadata.
     """
     from polyzymd.builders.fragment_generator import FragmentGenerator
@@ -339,7 +340,7 @@ def generate_polymerist_recipe_polymer(
     if atom_count is None:
         atom_count = _get_polymerist_atom_count(polymer_object)
 
-    return PolymeristGenerationResult(
+    return MultiResidueGenerationResult(
         recipe_name=recipe.name,
         sequence=sequence,
         cache_directory=cache_path,

--- a/src/polyzymd/builders/conjugation/system_workflow.py
+++ b/src/polyzymd/builders/conjugation/system_workflow.py
@@ -50,7 +50,7 @@ from polyzymd.builders.conjugation.pablo.parameterization import (
     build_formal_charge_smoke_template,
     create_interchange_from_pablo_topology,
 )
-from polyzymd.builders.conjugation.polymer import PolymeristGenerationResult
+from polyzymd.builders.conjugation.polymer import MultiResidueGenerationResult
 from polyzymd.builders.conjugation.reactions._roles import (
     STRUCTURE_MATCHING_BLOCKER_MESSAGE,
     atom_mapped_reaction_from_mechanism_config,
@@ -502,7 +502,7 @@ def _build_attachment_spec(
     use_cache_dir: bool = True,
 ) -> tuple[
     AttachmentBuildSpec,
-    PolymeristGenerationResult | None,
+    MultiResidueGenerationResult | None,
     int,
     dict[str, int | str],
     Any,

--- a/src/polyzymd/builders/conjugation/system_workflow.py
+++ b/src/polyzymd/builders/conjugation/system_workflow.py
@@ -50,7 +50,7 @@ from polyzymd.builders.conjugation.pablo.parameterization import (
     build_formal_charge_smoke_template,
     create_interchange_from_pablo_topology,
 )
-from polyzymd.builders.conjugation.polymer import PolymeristGenerationSmokeResult
+from polyzymd.builders.conjugation.polymer import PolymeristGenerationResult
 from polyzymd.builders.conjugation.reactions._roles import (
     STRUCTURE_MATCHING_BLOCKER_MESSAGE,
     atom_mapped_reaction_from_mechanism_config,
@@ -502,7 +502,7 @@ def _build_attachment_spec(
     use_cache_dir: bool = True,
 ) -> tuple[
     AttachmentBuildSpec,
-    PolymeristGenerationSmokeResult | None,
+    PolymeristGenerationResult | None,
     int,
     dict[str, int | str],
     Any,

--- a/tests/_support/conjugation_polymer_recipes.py
+++ b/tests/_support/conjugation_polymer_recipes.py
@@ -1,0 +1,91 @@
+"""Test support recipes for conjugation polymer fixtures."""
+
+from __future__ import annotations
+
+from polyzymd.builders.conjugation.polymer.recipe import PolymerMonomerRecipe, PolymerRecipe
+
+SBMA_SMILES = (
+    "[H]C([H])=C(C(=O)OC([H])([H])C([H])([H])[N+]"
+    "(C([H])([H])[H])(C([H])([H])[H])C([H])([H])C([H])([H])"
+    "C([H])([H])S(=O)(=O)[O-])C([H])([H])[H]"
+)
+EGPMA_SMILES = (
+    "[H]C([H])=C(C(=O)OC([H])([H])C([H])([H])Oc1c([H])c([H])c([H])c([H])c1[H])C([H])([H])[H]"
+)
+NHS_SMILES = "CC(=C)C(=O)ON1C(=O)CCC1=O"
+
+
+def sbma_egpma_nhs_recipe(
+    *,
+    length: int = 10,
+    seed: int | None = 42,
+    reactive_monomer_index: int | None = None,
+    fixed_sequence: str | None = None,
+) -> PolymerRecipe:
+    """Build an SBMA/EGPMA/NHS recipe fixture.
+
+    Parameters
+    ----------
+    length : int, optional
+        Degree of polymerization, by default 10.
+    seed : int or None, optional
+        Random seed for deterministic sequence generation, by default 42.
+    reactive_monomer_index : int or None, optional
+        Zero-based NHS residue index. ``None`` centers NHS, by default ``None``.
+    fixed_sequence : str or None, optional
+        Exact monomer-label sequence overriding stochastic generation, by default
+        ``None``.
+
+    Returns
+    -------
+    PolymerRecipe
+        Validated stochastic polymer recipe.
+    """
+    return PolymerRecipe(
+        name="SBMA-EGPMA-NHS",
+        monomers=(
+            PolymerMonomerRecipe(
+                label="A",
+                name="SBMA",
+                residue_name="SBM",
+                smiles=SBMA_SMILES,
+                probability=0.945,
+            ),
+            PolymerMonomerRecipe(
+                label="B",
+                name="EGPMA",
+                residue_name="EGP",
+                smiles=EGPMA_SMILES,
+                probability=0.045,
+            ),
+            PolymerMonomerRecipe(
+                label="C",
+                name="NHS",
+                residue_name="NHS",
+                smiles=NHS_SMILES,
+                probability=0.01,
+            ),
+        ),
+        length=length,
+        seed=seed,
+        reactive_monomer_label="C",
+        reactive_monomer_index=reactive_monomer_index,
+        fixed_sequence=fixed_sequence,
+    )
+
+
+def sbma_nhs_egpma_acb_recipe() -> PolymerRecipe:
+    """Build the deterministic SBMA:NHS:EGPMA recipe fixture.
+
+    Returns
+    -------
+    PolymerRecipe
+        Three-monomer recipe whose fixed sequence ``ACB`` maps to
+        SBMA:NHS:EGPMA with the NHS monomer centered for Lys linkage.
+    """
+    return sbma_egpma_nhs_recipe(
+        length=3,
+        seed=None,
+        reactive_monomer_index=1,
+        fixed_sequence="ACB",
+    )

--- a/tests/test_conjugation_integrated_smoke.py
+++ b/tests/test_conjugation_integrated_smoke.py
@@ -48,7 +48,7 @@ from polyzymd.builders.conjugation.pablo.parameterization import (
     create_interchange_from_pablo_topology,
 )
 from polyzymd.builders.conjugation.polymer.polymerist import generated_fragment_from_polymerist_pdb
-from polyzymd.builders.conjugation.polymer.recipe import generate_polymerist_recipe_polymer
+from polyzymd.builders.conjugation.polymer.recipe import generate_multi_residue_molecule
 from polyzymd.builders.conjugation.structure.pdb import (
     CrosslinkedPdbAssemblyOptions,
     PdbAtomRecord,
@@ -90,9 +90,9 @@ def test_opt_in_integrated_conjugation_physics_smoke(tmp_path: Path):
 
     recipe = sbma_egpma_nhs_recipe(length=3, seed=51, reactive_monomer_index=1)
     generation = _run_stage(
-        "Polymerist SBMA/EGPMA/NHS generation",
+        "SBMA/EGPMA/NHS multi-residue generation",
         artifact_dir,
-        lambda: generate_polymerist_recipe_polymer(
+        lambda: generate_multi_residue_molecule(
             recipe,
             artifact_dir / "polymerist-cache",
             force_regenerate=True,
@@ -101,8 +101,8 @@ def test_opt_in_integrated_conjugation_physics_smoke(tmp_path: Path):
     )
     if generation.pdb_path is None:
         _fail_blocker(
-            "Polymerist SBMA/EGPMA/NHS generation",
-            RuntimeError("Polymerist did not return a generated PDB path"),
+            "SBMA/EGPMA/NHS multi-residue generation",
+            RuntimeError("Generation backend did not return a generated PDB path"),
             artifact_dir,
         )
 

--- a/tests/test_conjugation_integrated_smoke.py
+++ b/tests/test_conjugation_integrated_smoke.py
@@ -48,15 +48,13 @@ from polyzymd.builders.conjugation.pablo.parameterization import (
     create_interchange_from_pablo_topology,
 )
 from polyzymd.builders.conjugation.polymer.polymerist import generated_fragment_from_polymerist_pdb
-from polyzymd.builders.conjugation.polymer.recipe import (
-    generate_polymerist_smoke_polymer,
-    sbma_egpma_nhs_recipe,
-)
+from polyzymd.builders.conjugation.polymer.recipe import generate_polymerist_recipe_polymer
 from polyzymd.builders.conjugation.structure.pdb import (
     CrosslinkedPdbAssemblyOptions,
     PdbAtomRecord,
     write_crosslinked_pdb,
 )
+from tests._support.conjugation_polymer_recipes import sbma_egpma_nhs_recipe
 
 T = TypeVar("T")
 
@@ -94,7 +92,7 @@ def test_opt_in_integrated_conjugation_physics_smoke(tmp_path: Path):
     generation = _run_stage(
         "Polymerist SBMA/EGPMA/NHS generation",
         artifact_dir,
-        lambda: generate_polymerist_smoke_polymer(
+        lambda: generate_polymerist_recipe_polymer(
             recipe,
             artifact_dir / "polymerist-cache",
             force_regenerate=True,

--- a/tests/test_conjugation_polymer_recipe.py
+++ b/tests/test_conjugation_polymer_recipe.py
@@ -1,4 +1,4 @@
-"""Tests for conjugation polymer recipes and Polymerist generation."""
+"""Tests for conjugation polymer recipes and multi-residue generation."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from polyzymd.builders.conjugation.polymer.recipe import (
     PolymerRecipe,
     _polymerist_to_pdb_aligned_rdkit_mol,
     _write_rdkit_sdf_sidecar,
-    generate_polymerist_recipe_polymer,
+    generate_multi_residue_molecule,
 )
 from polyzymd.config.loader import load_config
 from polyzymd.config.schema import SimulationConfig
@@ -260,16 +260,17 @@ conjugation:
     assert loaded_recipe.generate_sequence()[loaded_recipe.effective_reactive_index] == "C"
 
 
-def test_real_polymerist_recipe_generation(tmp_path):
-    """Polymerist should consume the real SBMA/EGPMA/NHS recipe when installed."""
+def test_real_multi_residue_recipe_generation(tmp_path):
+    """The backend should consume the real SBMA/EGPMA/NHS recipe when installed."""
     recipe = sbma_egpma_nhs_recipe(length=3, seed=5, reactive_monomer_index=1)
 
     try:
-        result = generate_polymerist_recipe_polymer(recipe, tmp_path / "polymerist", max_retries=1)
+        result = generate_multi_residue_molecule(recipe, tmp_path / "polymerist", max_retries=1)
     except Exception as exc:
         pytest.skip(f"Polymerist generation stack unavailable in this environment: {exc}")
 
     assert result.sequence[1] == "C"
+    assert result.backend == "polymerist"
     assert result.monomer_group_path.exists()
     assert result.pdb_path is not None and result.pdb_path.exists()
     assert result.pdb_path.with_suffix(".sdf").exists()
@@ -300,7 +301,7 @@ def test_polymerist_to_pdb_aligned_rdkit_mol_matches_pdb_atoms_and_bond_orders(
     assert all(float(bond.GetBondTypeAsDouble()) > 0.0 for bond in mol.GetBonds())
 
 
-def test_generate_polymerist_recipe_polymer_returns_pdb_aligned_rdkit_sidecar(
+def test_generate_multi_residue_molecule_returns_pdb_aligned_rdkit_sidecar(
     monkeypatch,
     tmp_path,
 ):
@@ -358,7 +359,7 @@ def test_generate_polymerist_recipe_polymer_returns_pdb_aligned_rdkit_sidecar(
     monkeypatch.setitem(sys.modules, "polyzymd.data.reactions", fake_reactions_module)
 
     recipe = sbma_nhs_egpma_acb_recipe()
-    result = generate_polymerist_recipe_polymer(recipe, tmp_path / "cache")
+    result = generate_multi_residue_molecule(recipe, tmp_path / "cache")
     Chem = pytest.importorskip("rdkit.Chem")
     sidecar_mols = [
         mol

--- a/tests/test_conjugation_polymer_recipe.py
+++ b/tests/test_conjugation_polymer_recipe.py
@@ -1,4 +1,4 @@
-"""Tests for conjugation polymer recipes and Polymerist smoke generation."""
+"""Tests for conjugation polymer recipes and Polymerist generation."""
 
 from __future__ import annotations
 
@@ -13,12 +13,14 @@ from polyzymd.builders.conjugation.polymer.recipe import (
     PolymerRecipe,
     _polymerist_to_pdb_aligned_rdkit_mol,
     _write_rdkit_sdf_sidecar,
-    generate_polymerist_smoke_polymer,
-    sbma_egpma_nhs_recipe,
-    sbma_nhs_egpma_acb_recipe,
+    generate_polymerist_recipe_polymer,
 )
 from polyzymd.config.loader import load_config
 from polyzymd.config.schema import SimulationConfig
+from tests._support.conjugation_polymer_recipes import (
+    sbma_egpma_nhs_recipe,
+    sbma_nhs_egpma_acb_recipe,
+)
 
 
 def _minimal_simulation_config_data() -> dict:
@@ -258,12 +260,12 @@ conjugation:
     assert loaded_recipe.generate_sequence()[loaded_recipe.effective_reactive_index] == "C"
 
 
-def test_real_polymerist_generation_smoke(tmp_path):
+def test_real_polymerist_recipe_generation(tmp_path):
     """Polymerist should consume the real SBMA/EGPMA/NHS recipe when installed."""
     recipe = sbma_egpma_nhs_recipe(length=3, seed=5, reactive_monomer_index=1)
 
     try:
-        result = generate_polymerist_smoke_polymer(recipe, tmp_path / "polymerist", max_retries=1)
+        result = generate_polymerist_recipe_polymer(recipe, tmp_path / "polymerist", max_retries=1)
     except Exception as exc:
         pytest.skip(f"Polymerist generation stack unavailable in this environment: {exc}")
 
@@ -298,11 +300,11 @@ def test_polymerist_to_pdb_aligned_rdkit_mol_matches_pdb_atoms_and_bond_orders(
     assert all(float(bond.GetBondTypeAsDouble()) > 0.0 for bond in mol.GetBonds())
 
 
-def test_generate_polymerist_smoke_polymer_returns_pdb_aligned_rdkit_sidecar(
+def test_generate_polymerist_recipe_polymer_returns_pdb_aligned_rdkit_sidecar(
     monkeypatch,
     tmp_path,
 ):
-    """Smoke generation should return a PDB-aligned RDKit mol and SDF sidecar."""
+    """Recipe generation should return a PDB-aligned RDKit mol and SDF sidecar."""
     built_sequences = []
 
     class FakeFragmentGenerator:
@@ -356,7 +358,7 @@ def test_generate_polymerist_smoke_polymer_returns_pdb_aligned_rdkit_sidecar(
     monkeypatch.setitem(sys.modules, "polyzymd.data.reactions", fake_reactions_module)
 
     recipe = sbma_nhs_egpma_acb_recipe()
-    result = generate_polymerist_smoke_polymer(recipe, tmp_path / "cache")
+    result = generate_polymerist_recipe_polymer(recipe, tmp_path / "cache")
     Chem = pytest.importorskip("rdkit.Chem")
     sidecar_mols = [
         mol

--- a/tests/test_conjugation_polymerist_pdb.py
+++ b/tests/test_conjugation_polymerist_pdb.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from polyzymd.builders.conjugation.polymer.polymerist import generated_fragment_from_polymerist_pdb
-from polyzymd.builders.conjugation.polymer.recipe import generate_polymerist_recipe_polymer
+from polyzymd.builders.conjugation.polymer.recipe import generate_multi_residue_molecule
 from polyzymd.builders.conjugation.structure.pdb import NhsLysPdbAttachment, write_crosslinked_pdb
 from tests._support.conjugation_polymer_recipes import sbma_egpma_nhs_recipe
 
@@ -297,7 +297,7 @@ def test_real_polymerist_generation_pdb_converts_to_generated_fragment(tmp_path)
     pytest.importorskip("polymerist", exc_type=ImportError)
 
     recipe = sbma_egpma_nhs_recipe(length=3, seed=5, reactive_monomer_index=1)
-    result = generate_polymerist_recipe_polymer(recipe, tmp_path / "polymerist", max_retries=1)
+    result = generate_multi_residue_molecule(recipe, tmp_path / "polymerist", max_retries=1)
     assert result.pdb_path is not None
 
     fragment = generated_fragment_from_polymerist_pdb(

--- a/tests/test_conjugation_polymerist_pdb.py
+++ b/tests/test_conjugation_polymerist_pdb.py
@@ -7,11 +7,9 @@ from pathlib import Path
 import pytest
 
 from polyzymd.builders.conjugation.polymer.polymerist import generated_fragment_from_polymerist_pdb
-from polyzymd.builders.conjugation.polymer.recipe import (
-    generate_polymerist_smoke_polymer,
-    sbma_egpma_nhs_recipe,
-)
+from polyzymd.builders.conjugation.polymer.recipe import generate_polymerist_recipe_polymer
 from polyzymd.builders.conjugation.structure.pdb import NhsLysPdbAttachment, write_crosslinked_pdb
+from tests._support.conjugation_polymer_recipes import sbma_egpma_nhs_recipe
 
 
 def _pdb_atom(
@@ -299,7 +297,7 @@ def test_real_polymerist_generation_pdb_converts_to_generated_fragment(tmp_path)
     pytest.importorskip("polymerist", exc_type=ImportError)
 
     recipe = sbma_egpma_nhs_recipe(length=3, seed=5, reactive_monomer_index=1)
-    result = generate_polymerist_smoke_polymer(recipe, tmp_path / "polymerist", max_retries=1)
+    result = generate_polymerist_recipe_polymer(recipe, tmp_path / "polymerist", max_retries=1)
     assert result.pdb_path is not None
 
     fragment = generated_fragment_from_polymerist_pdb(

--- a/tests/test_conjugation_system_workflow.py
+++ b/tests/test_conjugation_system_workflow.py
@@ -28,7 +28,7 @@ from polyzymd.builders.conjugation.polymer import (
     GeneratedPolymerFragment,
     PolymerFragmentAtom,
     PolymerFragmentResidue,
-    PolymeristGenerationSmokeResult,
+    PolymeristGenerationResult,
     PolymerMonomerRecipe,
     PolymerRecipe,
 )
@@ -1408,7 +1408,7 @@ def test_config_nhs_lys_path_builds_specs_before_shared_construction(
             chain_policy=ConjugationChainPolicyConfig(),
         ),
     )
-    generation = PolymeristGenerationSmokeResult(
+    generation = PolymeristGenerationResult(
         recipe_name="test",
         sequence="AA",
         cache_directory=tmp_path / "cache",
@@ -1534,7 +1534,7 @@ def test_config_nhs_lys_path_still_accepts_one_attachment(monkeypatch, tmp_path:
             chain_policy=ConjugationChainPolicyConfig(),
         ),
     )
-    generation = PolymeristGenerationSmokeResult(
+    generation = PolymeristGenerationResult(
         recipe_name="test",
         sequence="AA",
         cache_directory=tmp_path / "cache",

--- a/tests/test_conjugation_system_workflow.py
+++ b/tests/test_conjugation_system_workflow.py
@@ -26,9 +26,9 @@ from polyzymd.builders.conjugation.pablo.parameterization import InterchangePara
 from polyzymd.builders.conjugation.polymer import (
     GeneratedMoietyFragment,
     GeneratedPolymerFragment,
+    MultiResidueGenerationResult,
     PolymerFragmentAtom,
     PolymerFragmentResidue,
-    PolymeristGenerationResult,
     PolymerMonomerRecipe,
     PolymerRecipe,
 )
@@ -1408,7 +1408,7 @@ def test_config_nhs_lys_path_builds_specs_before_shared_construction(
             chain_policy=ConjugationChainPolicyConfig(),
         ),
     )
-    generation = PolymeristGenerationResult(
+    generation = MultiResidueGenerationResult(
         recipe_name="test",
         sequence="AA",
         cache_directory=tmp_path / "cache",
@@ -1534,7 +1534,7 @@ def test_config_nhs_lys_path_still_accepts_one_attachment(monkeypatch, tmp_path:
             chain_policy=ConjugationChainPolicyConfig(),
         ),
     )
-    generation = PolymeristGenerationResult(
+    generation = MultiResidueGenerationResult(
         recipe_name="test",
         sequence="AA",
         cache_directory=tmp_path / "cache",


### PR DESCRIPTION
## Summary
- Rename Polymerist generation APIs to backend-neutral multi-residue generation names.
- Add generation provenance with backend = "polymerist" while keeping Polymerist as the current implementation backend.
- Remove SBMA/EGPMA/NHS POC recipe constants and factories from production code.
- Move equivalent SBMA/EGPMA/NHS helpers into tests/_support for test-only use.
- Update production and tests to use neutral generation result/function names.

## Validation
- pixi run -e build pytest tests/test_conjugation_polymer_recipe.py tests/test_conjugation_polymerist_pdb.py -v — 20 passed.
- pixi run -e build pytest tests/test_conjugation_system_workflow.py tests/test_conjugation_integrated_smoke.py -v — 24 passed, 1 skipped.
- pixi run -e build pytest tests/ -v -k "conjugation" — 323 passed, 3 skipped, 2436 deselected.
- pixi run -e build ruff check src/ tests/ — passed.
- pixi run -e build black src/ tests/ --check — passed; Black skipped .ipynb files due unavailable Jupyter dependencies.
- Residual production-name check: no old PolymeristGenerationResult or generate_polymerist_recipe_polymer names in src/polyzymd Python files.

## Notes
- POC notebooks/artifacts intentionally untouched and out of scope for Phase 2.
- Legitimate backend-specific Polymerist adapter names remain where they describe Polymerist PDB outputs/helpers.
- Config/YAML schema names such as PolymerRecipe and polymer_recipe were intentionally left unchanged.
- Existing local dirty/untracked files were not staged or committed.