### PR TITLE
Phase 5: centralize Pablo charge helpers

### DIFF
--- a/src/polyzymd/builders/conjugation/final_interchange.py
+++ b/src/polyzymd/builders/conjugation/final_interchange.py
@@ -13,6 +13,7 @@ from polyzymd.builders.conjugation.pablo.parameterization import (
     create_interchange_from_pablo_topology,
     deduplicate_charge_templates,
 )
+from polyzymd.builders.conjugation.pablo.product_state import product_residue_names
 
 LOGGER = logging.getLogger(__name__)
 
@@ -130,14 +131,4 @@ def _product_residue_names(
     product_state_pablo_library: Any, definitions: tuple[Any, ...]
 ) -> tuple[str, ...]:
     """Resolve product residue names from summaries or definitions."""
-    names = tuple(
-        str(name) for name in getattr(product_state_pablo_library, "residue_names", ()) or ()
-    )
-    if names:
-        return names
-    definition_names = []
-    for definition in definitions:
-        name = str(getattr(definition, "residue_name", "")).strip()
-        if name:
-            definition_names.append(name)
-    return tuple(definition_names)
+    return product_residue_names(product_state_pablo_library, definitions)

--- a/src/polyzymd/builders/conjugation/pablo/__init__.py
+++ b/src/polyzymd/builders/conjugation/pablo/__init__.py
@@ -41,6 +41,10 @@ from polyzymd.builders.conjugation.pablo.product import (
     build_product_state_pablo_library,
     build_product_state_pablo_library_for_specs,
 )
+from polyzymd.builders.conjugation.pablo.product_state import (
+    product_residue_names,
+    product_state_library_has_provenance,
+)
 from polyzymd.builders.conjugation.pablo.residue_library import (
     PabloResidueLibraryDiagnostic,
     PabloResidueLibraryError,
@@ -80,4 +84,6 @@ __all__ = [
     "create_interchange_from_pablo_topology",
     "deduplicate_charge_templates",
     "load_combined_smirnoff_force_field",
+    "product_residue_names",
+    "product_state_library_has_provenance",
 ]

--- a/src/polyzymd/builders/conjugation/pablo/charge_bridge.py
+++ b/src/polyzymd/builders/conjugation/pablo/charge_bridge.py
@@ -24,6 +24,20 @@ from polyzymd.builders.conjugation.pablo.parameterization import (
     load_combined_smirnoff_force_field,
     suppress_openff_library_charge_info,
 )
+from polyzymd.builders.conjugation.pablo.product_state import (
+    atom_identity_tuple,
+    format_identity,
+    product_conjugate_molecule,
+    product_residue_name_set,
+    target_identities_from_molecule,
+)
+from polyzymd.builders.conjugation.pablo.sdf import (
+    charged_sdf_partial_charges,
+    fragment_atom_element,
+    fragment_atoms_in_sdf_order,
+    guess_element,
+    validated_charged_sdf_molecule,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -263,19 +277,7 @@ def build_product_state_charge_bridge(
 
 def _product_residue_names(product_state_pablo_library: Any) -> set[str]:
     """Return product-state residue names from a Pablo library."""
-    product_names = {
-        str(name).strip().upper()
-        for name in tuple(getattr(product_state_pablo_library, "residue_names", ()) or ())
-        if str(name).strip()
-    }
-    product_names.update(
-        str(getattr(definition, "residue_name", "")).strip().upper()
-        for definition in tuple(getattr(product_state_pablo_library, "definitions", ()) or ())
-        if str(getattr(definition, "residue_name", "")).strip()
-    )
-    if not product_names:
-        raise ValueError("Product-state charge bridge requires product residue names")
-    return product_names
+    return product_residue_name_set(product_state_pablo_library, require=True)
 
 
 def _empty_local_reconciliation_diagnostic(
@@ -480,15 +482,11 @@ def _product_conjugate_molecule(
     product_atoms: tuple[Any, ...],
 ) -> Any:
     """Return the topology molecule containing product-state residues."""
-    for molecule in tuple(getattr(product_topology, "molecules", ()) or ()):
-        if any(_atom_identity(atom)[1] in product_names for atom in getattr(molecule, "atoms", ())):
-            return molecule
-    molecules = tuple(getattr(product_topology, "molecules", ()) or ())
-    if len(molecules) == 1 and any(
-        atom.residue_name.upper() in product_names for atom in product_atoms
-    ):
-        return molecules[0]
-    raise ValueError("Could not locate the product-state conjugate molecule in the Pablo topology")
+    return product_conjugate_molecule(
+        product_topology,
+        product_names=product_names,
+        product_atoms=product_atoms,
+    )
 
 
 def _target_identities(
@@ -497,22 +495,7 @@ def _target_identities(
     product_atoms: tuple[Any, ...],
 ) -> tuple[tuple[str, str, int | None, str, str], ...]:
     """Return target atom identities, falling back to product PDB order."""
-    atoms = tuple(getattr(target_molecule, "atoms", ()) or ())
-    identities = tuple(_atom_identity(atom) for atom in atoms)
-    if all(identity[1] and identity[4] for identity in identities):
-        return identities
-    if len(atoms) == len(product_atoms):
-        return tuple(
-            (
-                atom.chain_id.strip(),
-                atom.residue_name.strip().upper(),
-                atom.residue_number,
-                atom.insertion_code.strip(),
-                atom.atom_name.strip(),
-            )
-            for atom in product_atoms
-        )
-    return identities
+    return target_identities_from_molecule(target_molecule, product_atoms=product_atoms)
 
 
 def _protein_ff14sb_records(
@@ -1138,44 +1121,19 @@ def _source_sdf_path(spec: Any) -> Path | None:
 
 def _charged_sdf_atom_charges(path: Path, *, generated_fragment: Any) -> tuple[float, ...]:
     """Read partial charges from a validated production charged SDF."""
-    from rdkit import Chem
-
     fragment_atoms = tuple(getattr(generated_fragment, "atoms", ()) or ())
-    if not fragment_atoms:
-        raise ValueError("Attached polymer charge transfer requires generated-fragment atoms")
-    sdf_path = Path(path)
-    mol = _validated_charged_sdf_molecule(
-        sdf_path,
-        fragment_atoms=fragment_atoms,
-        supplier_cls=Chem.SDMolSupplier,
-    )
-    charges = []
-    for index, atom in enumerate(mol.GetAtoms(), start=1):
-        if not atom.HasProp("PartialCharge"):
-            raise ValueError(
-                "Attached polymer SDF does not contain per-atom partial charges; refusing to "
-                f"use AM1-BCC, Gasteiger, or formal fallback for atom {index} in {sdf_path}"
-            )
-        charges.append(float(atom.GetDoubleProp("PartialCharge")))
-    if len(charges) != len(fragment_atoms):
-        raise ValueError(
-            "Attached polymer charged SDF atom count does not match extracted charges: "
-            f"{len(charges)} charges vs {len(fragment_atoms)} atom(s) for {sdf_path}"
-        )
-    return tuple(charges)
+    return charged_sdf_partial_charges(path, fragment_atoms=fragment_atoms)
 
 
 def _validate_charged_sdf_matches_fragment(path: Path, *, generated_fragment: Any) -> None:
     """Validate that a charged SDF preserves generated-fragment atom order."""
-    from rdkit import Chem
-
     fragment_atoms = tuple(getattr(generated_fragment, "atoms", ()) or ())
     if not fragment_atoms:
         raise ValueError("Attached polymer charge transfer requires generated-fragment atoms")
-    _validated_charged_sdf_molecule(
-        Path(path),
+    validated_charged_sdf_molecule(
+        path,
         fragment_atoms=fragment_atoms,
-        supplier_cls=Chem.SDMolSupplier,
+        source_label="Attached polymer charged SDF",
     )
 
 
@@ -1186,33 +1144,12 @@ def _validated_charged_sdf_molecule(
     supplier_cls: Any,
 ) -> Any:
     """Return the charged SDF molecule after atom-order validation."""
-    if not sdf_path.exists():
-        raise ValueError(f"Attached polymer charged SDF sidecar does not exist: {sdf_path}")
-    supplier = supplier_cls(str(sdf_path), removeHs=False, sanitize=False)
-    molecules = [mol for mol in supplier if mol is not None]
-    if not molecules:
-        raise ValueError(f"Attached polymer charged SDF sidecar could not be read: {sdf_path}")
-    mol = _select_charged_sdf_molecule(
-        molecules,
-        expected_atoms=len(fragment_atoms),
-        sdf_path=sdf_path,
+    _ = supplier_cls
+    return validated_charged_sdf_molecule(
+        sdf_path,
+        fragment_atoms=fragment_atoms,
+        source_label="Attached polymer charged SDF",
     )
-    observed = tuple(atom.GetSymbol().upper() for atom in mol.GetAtoms())
-    expected = tuple(
-        _fragment_atom_element(atom) for atom in _fragment_atoms_in_sdf_order(fragment_atoms)
-    )
-    if observed != expected:
-        preview = ", ".join(
-            f"{index + 1}:{want}->{got}"
-            for index, (want, got) in enumerate(zip(expected, observed, strict=True))
-            if want != got
-        )
-        raise ValueError(
-            "Attached polymer charged SDF atom element/order does not match the generated "
-            f"fragment for {sdf_path}: {preview}. Regenerate charged_sdf and bond_sdf from "
-            "the same production polymer molecule."
-        )
-    return mol
 
 
 def _select_charged_sdf_molecule(
@@ -1231,25 +1168,17 @@ def _select_charged_sdf_molecule(
 
 def _fragment_atoms_in_sdf_order(fragment_atoms: Sequence[Any]) -> tuple[Any, ...]:
     """Return fragment atoms in the atom-index order used by production SDF sidecars."""
-    if all(getattr(atom, "atom_index", None) is not None for atom in fragment_atoms):
-        return tuple(sorted(fragment_atoms, key=lambda atom: int(atom.atom_index)))
-    return tuple(fragment_atoms)
+    return fragment_atoms_in_sdf_order(fragment_atoms)
 
 
 def _fragment_atom_element(atom: Any) -> str:
     """Return a generated-fragment atom element symbol for sidecar validation."""
-    element = str(getattr(atom, "element", "") or "").strip().upper()
-    if element:
-        return element
-    return _guess_element(str(getattr(atom, "atom_name", "") or getattr(atom, "name", "")))
+    return fragment_atom_element(atom)
 
 
 def _guess_element(atom_name: str) -> str:
     """Guess a PDB-style element symbol from an atom name."""
-    stripped = "".join(char for char in atom_name.strip() if char.isalpha())
-    if not stripped:
-        return ""
-    return stripped[0].upper()
+    return guess_element(atom_name)
 
 
 def _mapped_polymer_residue(atom: Any, mappings: Mapping[str, Any]) -> dict[str, Any]:
@@ -1369,16 +1298,7 @@ def _interchange_charges_by_atom_index(interchange: Any) -> dict[int, float]:
 
 def _atom_identity(atom: Any) -> tuple[str, str, int | None, str, str]:
     """Return chain/residue/atom identity for an OpenFF-like atom."""
-    metadata = getattr(atom, "metadata", None) or {}
-    return (
-        str(_metadata_value(metadata, "chain_id", "chain", default="") or "").strip(),
-        str(_metadata_value(metadata, "residue_name", "residue", default="") or "").strip().upper(),
-        _optional_int(_metadata_value(metadata, "residue_number", "residue_id", default=None)),
-        str(_metadata_value(metadata, "insertion_code", default="") or "").strip(),
-        str(
-            _metadata_value(metadata, "atom_name", "name", default=getattr(atom, "name", "")) or ""
-        ).strip(),
-    )
+    return atom_identity_tuple(atom)
 
 
 def _metadata_value(metadata: Any, *names: str, default: Any = None) -> Any:
@@ -1435,9 +1355,4 @@ def _optional_int(value: Any) -> int | None:
 
 def _format_identity(identity: tuple[str, str, int | None, str, str]) -> str:
     """Format an atom identity for diagnostics."""
-    chain_id, residue_name, residue_number, insertion_code, atom_name = identity
-    return (
-        f"chain {chain_id or '?'} residue {residue_name or '?'} "
-        f"{residue_number if residue_number is not None else '?'}{insertion_code} "
-        f"atom {atom_name or '?'}"
-    )
+    return format_identity(identity)

--- a/src/polyzymd/builders/conjugation/pablo/charge_templates.py
+++ b/src/polyzymd/builders/conjugation/pablo/charge_templates.py
@@ -7,6 +7,11 @@ import math
 from dataclasses import dataclass
 from typing import Any
 
+from polyzymd.builders.conjugation.pablo.product_state import (
+    metadata_value,
+    product_residue_name_set,
+)
+
 _PROVENANCE_KEYS = (
     "polyzymd_charge_provenance",
     "charge_provenance",
@@ -361,18 +366,7 @@ def _charged_template_from_ordered_source(
 
 def _product_residue_names(product_state_pablo_library: Any) -> set[str]:
     """Return uppercase product-state residue names from a Pablo library."""
-    names = {
-        str(name).strip().upper()
-        for name in tuple(getattr(product_state_pablo_library, "residue_names", ()) or ())
-        if str(name).strip()
-    }
-    definitions = tuple(getattr(product_state_pablo_library, "definitions", ()) or ())
-    names.update(
-        str(getattr(definition, "residue_name", "")).strip().upper()
-        for definition in definitions
-        if str(getattr(definition, "residue_name", "")).strip()
-    )
-    return names
+    return product_residue_name_set(product_state_pablo_library)
 
 
 def _molecule_contains_product_residue(molecule: Any, product_names: set[str]) -> bool:
@@ -403,14 +397,7 @@ def _atom_identity(atom: Any) -> _AtomIdentity:
 
 def _metadata_value(metadata: Any, *names: str, default: Any = None) -> Any:
     """Return the first populated metadata value for a set of field names."""
-    for name in names:
-        if isinstance(metadata, dict):
-            value = metadata.get(name)
-        else:
-            value = getattr(metadata, name, None)
-        if value not in (None, ""):
-            return value
-    return default
+    return metadata_value(metadata, *names, default=default)
 
 
 def _record_value(record: Any, name: str, default: Any) -> Any:

--- a/src/polyzymd/builders/conjugation/pablo/product.py
+++ b/src/polyzymd/builders/conjugation/pablo/product.py
@@ -14,6 +14,17 @@ from polyzymd.builders.conjugation._linkage import (
     PabloCrosslinkRequirement,
     parse_pdb_atom_records,
 )
+from polyzymd.builders.conjugation.pablo.sdf import (
+    charged_sdf_formal_charges,
+    explicit_bond_order,
+    fragment_atom_element,
+    fragment_atoms_in_sdf_order,
+    guess_element,
+    read_sdf_molecules,
+    select_sdf_molecule,
+    validate_sdf_atom_elements,
+    validate_sdf_bond_orders,
+)
 from polyzymd.builders.conjugation.structure.parsing import parse_pdb_conect_pairs
 from polyzymd.builders.conjugation.structure.pdb import PdbAtomRecord
 
@@ -583,7 +594,7 @@ def _fragment_bonds(generated_fragment: Any | None) -> tuple[tuple[Any, Any, int
     order_lookup: dict[frozenset[Any], int] = {}
     for entry in getattr(generated_fragment, "bond_orders", ()) or ():
         if len(entry) >= 3:
-            order_lookup[frozenset((entry[0], entry[1]))] = _explicit_bond_order(
+            order_lookup[frozenset((entry[0], entry[1]))] = explicit_bond_order(
                 entry[2], source="generated polymer fragment"
             )
     bonds = []
@@ -617,15 +628,7 @@ def _polymer_sdf_bonds(
     if not sdf_path.exists():
         raise ValueError(f"Polymer SDF sidecar does not exist: {sdf_path}")
 
-    from rdkit import Chem
-
-    supplier = Chem.SDMolSupplier(str(sdf_path), removeHs=False, sanitize=False)
-    molecules = [mol for mol in supplier if mol is not None]
-    if not molecules:
-        raise ValueError(
-            f"Polymer SDF sidecar could not be read as an RDKit molecule: {sdf_path}. "
-            "Regenerate the polymer SDF with explicit bond orders."
-        )
+    molecules = read_sdf_molecules(sdf_path, source_label="Polymer SDF")
     atoms_by_index = {
         getattr(atom, "atom_index", None): atom
         for atom in getattr(generated_fragment, "atoms", ()) or ()
@@ -636,12 +639,18 @@ def _polymer_sdf_bonds(
             "Generated polymer fragment atoms do not carry atom_index values, so SDF bond "
             "orders cannot be mapped onto product-state Pablo definitions."
         )
-    mol = _select_sdf_molecule(molecules, expected_atoms=len(atoms_by_index), sdf_path=sdf_path)
-    _validate_sdf_bond_orders(mol, sdf_path)
+    mol = select_sdf_molecule(
+        molecules,
+        expected_atoms=len(atoms_by_index),
+        sdf_path=sdf_path,
+        source_label="Polymer SDF sidecar",
+        prefer_most_bonds=True,
+    )
+    validate_sdf_bond_orders(mol, sdf_path, source_label="Polymer SDF sidecar")
     unique_atom_names = _unique_fragment_atom_names(generated_fragment)
     bonds: list[tuple[Any, Any, int]] = []
     for bond in mol.GetBonds():
-        order = _explicit_bond_order(bond.GetBondTypeAsDouble(), source=f"SDF {sdf_path}")
+        order = explicit_bond_order(bond.GetBondTypeAsDouble(), source=f"SDF {sdf_path}")
         atom1 = _fragment_atom_descriptor(
             atoms_by_index.get(bond.GetBeginAtomIdx()), unique_atom_names=unique_atom_names
         )
@@ -772,42 +781,19 @@ def _charged_sdf_formal_charges(
     """Return non-zero formal charges from a validated charged SDF sidecar."""
     if charged_polymer_sdf is None:
         return {}
-    from rdkit import Chem
-
-    sdf_path = Path(charged_polymer_sdf)
-    if not sdf_path.exists():
-        raise ValueError(f"Charged polymer SDF sidecar does not exist: {sdf_path}")
-    supplier = Chem.SDMolSupplier(str(sdf_path), removeHs=False, sanitize=False)
-    molecules = [mol for mol in supplier if mol is not None]
-    if not molecules:
-        raise ValueError(f"Charged polymer SDF sidecar could not be read: {sdf_path}")
     fragment_atoms = tuple(getattr(generated_fragment, "atoms", ()) or ())
-    mol = _select_sdf_molecule(molecules, expected_atoms=len(fragment_atoms), sdf_path=sdf_path)
-    _validate_sdf_atom_elements(
-        mol,
-        fragment_atoms=_fragment_atoms_in_sdf_order(fragment_atoms),
-        sdf_path=sdf_path,
-        source_label="Charged polymer SDF",
-    )
-    charges = {}
-    for atom in mol.GetAtoms():
-        formal_charge = int(atom.GetFormalCharge())
-        if formal_charge:
-            charges[int(atom.GetIdx())] = formal_charge
-    return charges
+    return charged_sdf_formal_charges(charged_polymer_sdf, fragment_atoms=fragment_atoms)
 
 
 def _select_sdf_molecule(molecules: list[Any], *, expected_atoms: int, sdf_path: Path) -> Any:
     """Select the SDF molecule matching the generated-fragment atom count."""
-    matches = [mol for mol in molecules if mol.GetNumAtoms() == expected_atoms]
-    if not matches:
-        observed = ", ".join(str(mol.GetNumAtoms()) for mol in molecules)
-        raise ValueError(
-            "Polymer SDF sidecar atom count does not match the generated fragment: "
-            f"expected {expected_atoms}, observed {observed} in {sdf_path}. Regenerate the "
-            "polymer PDB/SDF pair from the same source molecule."
-        )
-    return max(matches, key=lambda candidate: candidate.GetNumBonds())
+    return select_sdf_molecule(
+        molecules,
+        expected_atoms=expected_atoms,
+        sdf_path=sdf_path,
+        source_label="Polymer SDF sidecar",
+        prefer_most_bonds=True,
+    )
 
 
 def _validate_sdf_atom_elements(
@@ -818,74 +804,32 @@ def _validate_sdf_atom_elements(
     source_label: str,
 ) -> None:
     """Validate that an SDF atom sequence matches a generated fragment."""
-    observed = tuple(atom.GetSymbol().upper() for atom in mol.GetAtoms())
-    expected = tuple(_fragment_atom_element(atom) for atom in fragment_atoms)
-    if observed != expected:
-        mismatches = [
-            f"{index + 1}:{want}->{got}"
-            for index, (want, got) in enumerate(zip(expected, observed, strict=True))
-            if want != got
-        ]
-        preview = ", ".join(mismatches[:8])
-        suffix = "" if len(mismatches) <= 8 else f", ... {len(mismatches) - 8} more"
-        raise ValueError(
-            f"{source_label} atom element/order does not match the generated fragment for "
-            f"{sdf_path}: {preview}{suffix}. Regenerate charged_sdf and bond_sdf from the "
-            "same production polymer molecule."
-        )
+    validate_sdf_atom_elements(
+        mol,
+        fragment_atoms=fragment_atoms,
+        sdf_path=sdf_path,
+        source_label=source_label,
+    )
 
 
 def _fragment_atoms_in_sdf_order(fragment_atoms: tuple[Any, ...]) -> tuple[Any, ...]:
     """Return fragment atoms in the atom-index order used by production SDF sidecars."""
-    if all(getattr(atom, "atom_index", None) is not None for atom in fragment_atoms):
-        return tuple(sorted(fragment_atoms, key=lambda atom: int(atom.atom_index)))
-    return fragment_atoms
+    return fragment_atoms_in_sdf_order(fragment_atoms)
 
 
 def _fragment_atom_element(atom: Any) -> str:
     """Return a generated-fragment atom element symbol for sidecar validation."""
-    element = str(getattr(atom, "element", "") or "").strip().upper()
-    if element:
-        return element
-    return _guess_element(str(getattr(atom, "atom_name", "") or getattr(atom, "name", "")))
+    return fragment_atom_element(atom)
 
 
 def _validate_sdf_bond_orders(mol: Any, sdf_path: Path) -> None:
     """Require explicit positive bond orders in an SDF source molecule."""
-    invalid = [
-        (bond.GetBeginAtomIdx() + 1, bond.GetEndAtomIdx() + 1)
-        for bond in mol.GetBonds()
-        if float(bond.GetBondTypeAsDouble()) <= 0.0
-    ]
-    if invalid:
-        preview = ", ".join(f"{left}-{right}" for left, right in invalid[:5])
-        extra = "" if len(invalid) <= 5 else f" and {len(invalid) - 5} more"
-        raise ValueError(
-            "Polymer SDF sidecar contains under-specified zero/unknown bond orders "
-            f"for atom pairs {preview}{extra} in {sdf_path}. Polymer SDF files must contain "
-            "explicit bond orders and fully specified valence; regenerate the SDF from the "
-            "source molecule rather than relying on product-state chemistry repair."
-        )
+    validate_sdf_bond_orders(mol, sdf_path, source_label="Polymer SDF sidecar")
 
 
 def _explicit_bond_order(value: Any, *, source: str) -> int:
     """Return a supported integer bond order or raise an actionable error."""
-    try:
-        order = float(value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"Invalid bond order {value!r} from {source}") from exc
-    if order <= 0.0:
-        raise ValueError(
-            f"Invalid zero/unknown bond order {value!r} from {source}; polymer chemistry "
-            "must be supplied with explicit positive bond orders."
-        )
-    rounded = round(order)
-    if abs(order - rounded) > 1e-6:
-        raise ValueError(
-            f"Unsupported non-integer bond order {value!r} from {source}; product-state "
-            "Pablo definitions currently require explicit integer bond orders."
-        )
-    return int(rounded)
+    return explicit_bond_order(value, source=source)
 
 
 def _fragment_atom_lookup(generated_fragment: Any) -> dict[Any, Any]:

--- a/src/polyzymd/builders/conjugation/pablo/product_state.py
+++ b/src/polyzymd/builders/conjugation/pablo/product_state.py
@@ -1,0 +1,179 @@
+"""Shared product-state Pablo residue, topology, and provenance helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+AtomIdentityTuple = tuple[str, str, int | None, str, str]
+
+
+def product_residue_names(
+    product_state_pablo_library: Any,
+    definitions: Iterable[Any] | None = None,
+    *,
+    uppercase: bool = False,
+    require: bool = False,
+) -> tuple[str, ...]:
+    """Resolve product-state residue names from library summaries or definitions.
+
+    Parameters
+    ----------
+    product_state_pablo_library : Any
+        Generated product-state Pablo library or compatible object.
+    definitions : iterable of Any or None, optional
+        Definition fallback when not read from the library, by default ``None``.
+    uppercase : bool, optional
+        Return normalized uppercase names, by default ``False``.
+    require : bool, optional
+        Raise if no names are found, by default ``False``.
+
+    Returns
+    -------
+    tuple of str
+        Unique product-state residue names in discovery order.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    raw_names = tuple(getattr(product_state_pablo_library, "residue_names", ()) or ())
+    fallback_definitions = tuple(
+        definitions
+        if definitions is not None
+        else tuple(getattr(product_state_pablo_library, "definitions", ()) or ())
+    )
+    raw_names = (
+        *raw_names,
+        *(getattr(definition, "residue_name", "") for definition in fallback_definitions),
+    )
+    for raw_name in raw_names:
+        name = str(raw_name).strip()
+        if not name:
+            continue
+        if uppercase:
+            name = name.upper()
+        key = name.upper()
+        if key in seen:
+            continue
+        seen.add(key)
+        names.append(name)
+    if require and not names:
+        raise ValueError("Product-state charge bridge requires product residue names")
+    return tuple(names)
+
+
+def product_residue_name_set(
+    product_state_pablo_library: Any, *, require: bool = False
+) -> set[str]:
+    """Return uppercase product-state residue names from a Pablo library."""
+    return set(product_residue_names(product_state_pablo_library, uppercase=True, require=require))
+
+
+def product_state_library_has_provenance(product_state_pablo_library: Any) -> bool:
+    """Return whether a generated product-state library has residue provenance."""
+    names = tuple(getattr(product_state_pablo_library, "residue_names", ()) or ())
+    definitions = tuple(getattr(product_state_pablo_library, "definitions", ()) or ())
+    return bool(names or definitions)
+
+
+def metadata_value(metadata: Any, *names: str, default: Any = None) -> Any:
+    """Return the first populated metadata value for a set of field names."""
+    for name in names:
+        if isinstance(metadata, dict):
+            value = metadata.get(name)
+        else:
+            value = getattr(metadata, name, None)
+        if value not in (None, ""):
+            return value
+    return default
+
+
+def metadata_residue_name(metadata: Any) -> str:
+    """Return an uppercase residue name from atom or molecule metadata."""
+    if metadata is None:
+        return ""
+    return (
+        str(metadata_value(metadata, "residue_name", "residue", default="") or "").strip().upper()
+    )
+
+
+def atom_identity_tuple(atom: Any) -> AtomIdentityTuple:
+    """Return residue atom identity from OpenFF atom metadata as a tuple."""
+    metadata = getattr(atom, "metadata", None) or {}
+    return (
+        str(metadata_value(metadata, "chain_id", "chain", default="") or "").strip(),
+        str(metadata_value(metadata, "residue_name", "residue", default="") or "").strip().upper(),
+        optional_int(metadata_value(metadata, "residue_number", "residue_id", "residue_index")),
+        str(metadata_value(metadata, "insertion_code", default="") or "").strip(),
+        str(
+            metadata_value(metadata, "atom_name", "name", default=getattr(atom, "name", "")) or ""
+        ).strip(),
+    )
+
+
+def molecule_contains_product_residue(molecule: Any, product_names: set[str]) -> bool:
+    """Return whether a molecule contains product-state residue metadata."""
+    atom_match = any(
+        atom_identity_tuple(atom)[1] in product_names for atom in getattr(molecule, "atoms", ())
+    )
+    if atom_match:
+        return True
+    return metadata_residue_name(getattr(molecule, "properties", None)) in product_names
+
+
+def product_conjugate_molecule(
+    product_topology: Any,
+    *,
+    product_names: set[str],
+    product_atoms: tuple[Any, ...],
+) -> Any:
+    """Return the topology molecule containing product-state residues."""
+    for molecule in tuple(getattr(product_topology, "molecules", ()) or ()):
+        if molecule_contains_product_residue(molecule, product_names):
+            return molecule
+    molecules = tuple(getattr(product_topology, "molecules", ()) or ())
+    if len(molecules) == 1 and any(
+        atom.residue_name.upper() in product_names for atom in product_atoms
+    ):
+        return molecules[0]
+    raise ValueError("Could not locate the product-state conjugate molecule in the Pablo topology")
+
+
+def target_identities_from_molecule(
+    target_molecule: Any,
+    *,
+    product_atoms: tuple[Any, ...],
+) -> tuple[AtomIdentityTuple, ...]:
+    """Return target atom identities, falling back to product PDB order."""
+    atoms = tuple(getattr(target_molecule, "atoms", ()) or ())
+    identities = tuple(atom_identity_tuple(atom) for atom in atoms)
+    if all(identity[1] and identity[4] for identity in identities):
+        return identities
+    if len(atoms) == len(product_atoms):
+        return tuple(
+            (
+                atom.chain_id.strip(),
+                atom.residue_name.strip().upper(),
+                atom.residue_number,
+                atom.insertion_code.strip(),
+                atom.atom_name.strip(),
+            )
+            for atom in product_atoms
+        )
+    return identities
+
+
+def optional_int(value: Any) -> int | None:
+    """Return an optional integer from residue metadata."""
+    if value in (None, ""):
+        return None
+    return int(value)
+
+
+def format_identity(identity: AtomIdentityTuple) -> str:
+    """Format an atom identity for diagnostics."""
+    chain_id, residue_name, residue_number, insertion_code, atom_name = identity
+    residue_number_text = "?" if residue_number is None else str(residue_number)
+    chain = chain_id or "?"
+    atom = atom_name or "?"
+    residue = residue_name or "?"
+    return f"chain {chain} residue {residue} {residue_number_text}{insertion_code} atom {atom}"

--- a/src/polyzymd/builders/conjugation/pablo/sdf.py
+++ b/src/polyzymd/builders/conjugation/pablo/sdf.py
@@ -1,0 +1,234 @@
+"""Shared SDF helpers for product-state Pablo charge and template construction."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+
+def read_sdf_molecules(path: Path | str, *, source_label: str) -> tuple[Any, ...]:
+    """Read non-empty RDKit molecules from an SDF sidecar.
+
+    Parameters
+    ----------
+    path : pathlib.Path or str
+        SDF sidecar path to read.
+    source_label : str
+        Human-readable sidecar label for diagnostics.
+
+    Returns
+    -------
+    tuple of Any
+        Non-null RDKit molecules from the SDF supplier.
+    """
+    sdf_path = Path(path)
+    if not sdf_path.exists():
+        raise ValueError(f"{source_label} sidecar does not exist: {sdf_path}")
+
+    from rdkit import Chem
+
+    supplier = Chem.SDMolSupplier(str(sdf_path), removeHs=False, sanitize=False)
+    molecules = tuple(mol for mol in supplier if mol is not None)
+    if not molecules:
+        raise ValueError(f"{source_label} sidecar could not be read: {sdf_path}")
+    return molecules
+
+
+def select_sdf_molecule(
+    molecules: Sequence[Any],
+    *,
+    expected_atoms: int,
+    sdf_path: Path,
+    source_label: str,
+    prefer_most_bonds: bool = False,
+) -> Any:
+    """Select an SDF molecule matching an expected atom count.
+
+    Parameters
+    ----------
+    molecules : sequence of Any
+        RDKit molecules read from an SDF supplier.
+    expected_atoms : int
+        Expected atom count from the generated fragment.
+    sdf_path : pathlib.Path
+        Source SDF path for diagnostics.
+    source_label : str
+        Human-readable sidecar label for diagnostics.
+    prefer_most_bonds : bool, optional
+        Select the matching molecule with the most bonds, by default ``False``.
+
+    Returns
+    -------
+    Any
+        Selected RDKit molecule.
+    """
+    matches = [mol for mol in molecules if mol.GetNumAtoms() == expected_atoms]
+    if not matches:
+        observed = ", ".join(str(mol.GetNumAtoms()) for mol in molecules)
+        raise ValueError(
+            f"{source_label} atom count does not match the generated fragment: "
+            f"expected {expected_atoms}, observed {observed} in {sdf_path}"
+        )
+    if prefer_most_bonds:
+        return max(matches, key=lambda candidate: candidate.GetNumBonds())
+    return matches[0]
+
+
+def fragment_atoms_in_sdf_order(fragment_atoms: Sequence[Any]) -> tuple[Any, ...]:
+    """Return fragment atoms in the atom-index order used by production SDF sidecars."""
+    if all(getattr(atom, "atom_index", None) is not None for atom in fragment_atoms):
+        return tuple(sorted(fragment_atoms, key=lambda atom: int(atom.atom_index)))
+    return tuple(fragment_atoms)
+
+
+def fragment_atom_element(atom: Any) -> str:
+    """Return a generated-fragment atom element symbol for sidecar validation."""
+    element = str(getattr(atom, "element", "") or "").strip().upper()
+    if element:
+        return element
+    return guess_element(str(getattr(atom, "atom_name", "") or getattr(atom, "name", "")))
+
+
+def validate_sdf_atom_elements(
+    mol: Any,
+    *,
+    fragment_atoms: Sequence[Any],
+    sdf_path: Path,
+    source_label: str,
+) -> None:
+    """Validate that an SDF atom sequence matches a generated fragment."""
+    observed = tuple(atom.GetSymbol().upper() for atom in mol.GetAtoms())
+    expected = tuple(
+        fragment_atom_element(atom) for atom in fragment_atoms_in_sdf_order(fragment_atoms)
+    )
+    if observed != expected:
+        mismatches = [
+            f"{index + 1}:{want}->{got}"
+            for index, (want, got) in enumerate(zip(expected, observed, strict=True))
+            if want != got
+        ]
+        preview = ", ".join(mismatches[:8])
+        suffix = "" if len(mismatches) <= 8 else f", ... {len(mismatches) - 8} more"
+        raise ValueError(
+            f"{source_label} atom element/order does not match the generated fragment for "
+            f"{sdf_path}: {preview}{suffix}. Regenerate charged_sdf and bond_sdf from the "
+            "same production polymer molecule."
+        )
+
+
+def validate_sdf_bond_orders(mol: Any, sdf_path: Path, *, source_label: str) -> None:
+    """Require explicit positive bond orders in an SDF source molecule."""
+    invalid = [
+        (bond.GetBeginAtomIdx() + 1, bond.GetEndAtomIdx() + 1)
+        for bond in mol.GetBonds()
+        if float(bond.GetBondTypeAsDouble()) <= 0.0
+    ]
+    if invalid:
+        preview = ", ".join(f"{left}-{right}" for left, right in invalid[:5])
+        extra = "" if len(invalid) <= 5 else f" and {len(invalid) - 5} more"
+        raise ValueError(
+            f"{source_label} contains under-specified zero/unknown bond orders for atom pairs "
+            f"{preview}{extra} in {sdf_path}. Polymer SDF files must contain explicit bond "
+            "orders and fully specified valence; regenerate the SDF from the source molecule "
+            "rather than relying on product-state chemistry repair."
+        )
+
+
+def explicit_bond_order(value: Any, *, source: str) -> int:
+    """Return a supported integer bond order or raise an actionable error."""
+    try:
+        order = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid bond order {value!r} from {source}") from exc
+    if order <= 0.0:
+        raise ValueError(
+            f"Invalid zero/unknown bond order {value!r} from {source}; polymer chemistry "
+            "must be supplied with explicit positive bond orders."
+        )
+    rounded = round(order)
+    if abs(order - rounded) > 1e-6:
+        raise ValueError(
+            f"Unsupported non-integer bond order {value!r} from {source}; product-state "
+            "Pablo definitions currently require explicit integer bond orders."
+        )
+    return int(rounded)
+
+
+def validated_charged_sdf_molecule(
+    path: Path | str,
+    *,
+    fragment_atoms: Sequence[Any],
+    source_label: str,
+) -> Any:
+    """Return a charged SDF molecule after atom-order validation."""
+    sdf_path = Path(path)
+    molecules = read_sdf_molecules(sdf_path, source_label=source_label)
+    mol = select_sdf_molecule(
+        molecules,
+        expected_atoms=len(fragment_atoms),
+        sdf_path=sdf_path,
+        source_label=source_label,
+    )
+    validate_sdf_atom_elements(
+        mol,
+        fragment_atoms=fragment_atoms,
+        sdf_path=sdf_path,
+        source_label=source_label,
+    )
+    return mol
+
+
+def charged_sdf_partial_charges(
+    path: Path | str, *, fragment_atoms: Sequence[Any]
+) -> tuple[float, ...]:
+    """Read per-atom partial charges from a validated production charged SDF."""
+    if not fragment_atoms:
+        raise ValueError("Attached polymer charge transfer requires generated-fragment atoms")
+    sdf_path = Path(path)
+    mol = validated_charged_sdf_molecule(
+        sdf_path,
+        fragment_atoms=fragment_atoms,
+        source_label="Attached polymer charged SDF",
+    )
+    charges = []
+    for index, atom in enumerate(mol.GetAtoms(), start=1):
+        if not atom.HasProp("PartialCharge"):
+            raise ValueError(
+                "Attached polymer SDF does not contain per-atom partial charges; refusing to "
+                f"use AM1-BCC, Gasteiger, or formal fallback for atom {index} in {sdf_path}"
+            )
+        charges.append(float(atom.GetDoubleProp("PartialCharge")))
+    if len(charges) != len(fragment_atoms):
+        raise ValueError(
+            "Attached polymer charged SDF atom count does not match extracted charges: "
+            f"{len(charges)} charges vs {len(fragment_atoms)} atom(s) for {sdf_path}"
+        )
+    return tuple(charges)
+
+
+def charged_sdf_formal_charges(
+    path: Path | str, *, fragment_atoms: Sequence[Any]
+) -> dict[int, int]:
+    """Return non-zero formal charges from a validated charged SDF sidecar."""
+    if not fragment_atoms:
+        return {}
+    mol = validated_charged_sdf_molecule(
+        path,
+        fragment_atoms=fragment_atoms,
+        source_label="Charged polymer SDF",
+    )
+    charges = {}
+    for atom in mol.GetAtoms():
+        formal_charge = int(atom.GetFormalCharge())
+        if formal_charge:
+            charges[int(atom.GetIdx())] = formal_charge
+    return charges
+
+
+def guess_element(atom_name: str) -> str:
+    """Guess a PDB-style element symbol from an atom name."""
+    stripped = "".join(char for char in atom_name.strip() if char.isalpha())
+    if not stripped:
+        return ""
+    return stripped[0].upper()

--- a/src/polyzymd/builders/conjugation/system_workflow.py
+++ b/src/polyzymd/builders/conjugation/system_workflow.py
@@ -48,6 +48,12 @@ from polyzymd.builders.conjugation.pablo.parameterization import (
     build_formal_charge_smoke_template,
     create_interchange_from_pablo_topology,
 )
+from polyzymd.builders.conjugation.pablo.product_state import (
+    metadata_residue_name,
+    molecule_contains_product_residue,
+    product_residue_names,
+    product_state_library_has_provenance,
+)
 from polyzymd.builders.conjugation.placement import (
     PackmolModifierPlacementSettings,
     place_modifiers_with_resolved_plans,
@@ -1151,9 +1157,7 @@ def _supports_charge_bridge(
 ) -> bool:
     """Return whether the local NAGL bridge supports the product-state library."""
     _ = product_specs
-    names = tuple(getattr(product_state_pablo_library, "residue_names", ()) or ())
-    definitions = tuple(getattr(product_state_pablo_library, "definitions", ()) or ())
-    return bool(names or definitions)
+    return product_state_library_has_provenance(product_state_pablo_library)
 
 
 def _charged_product_state_molecules_from_topology(
@@ -1176,39 +1180,17 @@ def _charged_product_state_molecules_from_topology(
 
 def _product_state_library_residue_names(product_state_pablo_library: Any) -> tuple[str, ...]:
     """Resolve product-state residue names from a generated Pablo library."""
-    names = tuple(
-        str(name) for name in getattr(product_state_pablo_library, "residue_names", ()) or ()
-    )
-    if names:
-        return names
-    definitions = tuple(getattr(product_state_pablo_library, "definitions", ()) or ())
-    return tuple(
-        str(getattr(definition, "residue_name", "")).strip()
-        for definition in definitions
-        if str(getattr(definition, "residue_name", "")).strip()
-    )
+    return product_residue_names(product_state_pablo_library)
 
 
 def _molecule_has_product_residue(molecule: Any, product_names: set[str]) -> bool:
     """Return whether a molecule contains any product-state residue metadata."""
-    for atom in tuple(getattr(molecule, "atoms", ()) or ()):
-        residue_name = _metadata_residue_name(getattr(atom, "metadata", None))
-        if residue_name in product_names:
-            return True
-    properties = getattr(molecule, "properties", None)
-    residue_name = _metadata_residue_name(properties)
-    return residue_name in product_names
+    return molecule_contains_product_residue(molecule, product_names)
 
 
 def _metadata_residue_name(metadata: Any) -> str:
     """Return an uppercase residue name from atom or molecule metadata."""
-    if metadata is None:
-        return ""
-    if isinstance(metadata, dict):
-        value = metadata.get("residue_name") or metadata.get("residue")
-    else:
-        value = getattr(metadata, "residue_name", None) or getattr(metadata, "residue", None)
-    return str(value or "").strip().upper()
+    return metadata_residue_name(metadata)
 
 
 def _local_minimization_settings_for_product(


### PR DESCRIPTION
## Summary
- Add shared Pablo SDF helpers for molecule selection, atom-order validation, bond-order checks/coercion, and formal/partial charge extraction.
- Add shared product-state helpers for residue-name resolution, provenance validation, product molecule detection, and atom metadata helpers.
- Update product Pablo library, charge bridge, charge templates, final Interchange, and system workflow paths to use the centralized helpers.
- Preserve compatibility wrappers and existing charge audit/provenance behavior.

## Validation
- pixi run -e build pytest tests/test_conjugation_charge_templates.py tests/test_conjugation_charge_bridge.py -v — 19 passed.
- pixi run -e build pytest tests/test_conjugation_product_pablo.py tests/test_conjugation_final_interchange.py -v — 22 passed.
- pixi run -e build pytest tests/test_conjugation_system_workflow.py -v — 24 passed.
- pixi run -e build pytest tests/test_conjugation_parameterization.py tests/test_conjugation_validation.py -v — 36 passed.
- pixi run -e build pytest tests/test_conjugation_integrated_construction.py -v — 3 passed.
- pixi run -e build pytest tests/test_conjugation_*.py -v — 315 passed, 3 skipped.
- pixi run -e build ruff check src/polyzymd/builders/conjugation tests/test_conjugation_*.py — passed.
- pixi run -e build black src/polyzymd/builders/conjugation tests/test_conjugation_*.py --check — passed.
- User benchmark validation: passed.

## LOC impact
- Staged source diff: 513 insertions, 275 deletions.
- New helper modules add upfront LOC while centralizing duplicated product/charge/SDF logic.

## Notes
- POC notebooks/artifacts, pixi files, temp data, and local test_files were intentionally not staged or committed.
- RDKit/OpenFF/Pablo imports remain lazy where applicable.
- Final Interchange still refuses formal/smoke-only charge fallbacks.