### PR TITLE
Retain multi-chain proteins (homodimers)

### DIFF
--- a/docs/source/how_to/troubleshoot_openff_pdb_ingestion.md
+++ b/docs/source/how_to/troubleshoot_openff_pdb_ingestion.md
@@ -82,8 +82,9 @@ def main() -> None:
 
     from openff.toolkit import Topology
 
-    Topology.from_pdb(args.pdb)
+    topology = Topology.from_pdb(args.pdb)
     print("OpenFF PDB ingestion succeeded")
+    print(f"molecules: {topology.n_molecules}")
 
 
 if __name__ == "__main__":
@@ -99,6 +100,20 @@ pixi run -e build python validate_openff.py prepared_enzyme.pdb
 If direct validation fails, the problem is in the PDB chemistry OpenFF sees. A
 passing `polyzymd validate` or `polyzymd build --dry-run` does not prove OpenFF
 can ingest the enzyme PDB.
+
+## Check multi-molecule enzyme inputs
+
+Some valid enzyme PDBs contain more than one disconnected protein molecule. For
+example, homodimer preparations may load with more than one OpenFF molecule
+(`Topology.from_pdb(...).n_molecules > 1`). Older PolyzyMD builds only carried
+`molecule(0)` forward, so output PDB/GRO files silently kept one monomer and
+dropped the other.
+
+Use the direct OpenFF validation script above and check the printed molecule
+count. If `n_molecules` is greater than one, the fixed behavior is that PolyzyMD
+retains all enzyme molecules in OpenFF order. All retained enzyme/protein
+molecules are assigned chain `A`; substrate remains chain `B`, polymers chain
+`C`, and solvent starts at `D`.
 
 ## Interpret OpenFF error dumps
 
@@ -122,6 +137,7 @@ consistent model and validate it again.
 | Failure around `CYS#0001`, terminal `H`, or N-terminal cysteine | N-terminal cysteine/cystine has terminal hydrogens and disulfide state OpenFF does not match cleanly | Check N-terminal atom names, SG-HG absence, and SG-SG bond | Curate the terminal cystine or use a narrow `NCYX` custom substructure proof of concept | Private OpenFF API; not universal |
 | Residue names include `CYX`, but OpenFF still fails | `CYX` may be treated as a cysteine alias, not a complete public template solution | Compare residue atoms and SG-SG connectivity | Add/verify disulfide connectivity and hydrogens; consider upstream issue/PR | Do not assume renaming to CYX is sufficient |
 | Failure near residues reported in `REMARK 465` | Missing-coordinate residues or missing heavy atoms affect chemistry or termini | Read PDB header and visualize gaps | Model missing regions with an external tool when scientifically appropriate | PolyzyMD should receive a curated result |
+| OpenFF validation succeeds with `n_molecules > 1`, but older PolyzyMD output has one monomer | Historical PolyzyMD builds retained only enzyme `molecule(0)` after OpenFF parsing | Print `Topology.from_pdb(path).n_molecules` and compare output atom counts to the input enzyme copies | Use a fixed PolyzyMD build; all enzyme molecules are retained before substrate and polymers | All enzyme/protein molecules use chain `A` by convention |
 
 ## Disulfides
 

--- a/docs/source/reference/openff_pdb_ingestion.md
+++ b/docs/source/reference/openff_pdb_ingestion.md
@@ -24,7 +24,7 @@ analysis. These are project conventions, not OpenFF parser requirements.
 
 | Role | PolyzyMD chain convention | Notes |
 |---|---|---|
-| Protein/enzyme | `A` | The enzyme PDB passed to OpenFF is usually protein-only on chain `A` |
+| Protein/enzyme | `A` | The enzyme PDB passed to OpenFF is usually protein-only on chain `A`; multiple OpenFF enzyme molecules are all retained on chain `A` |
 | Substrate | `B` | Usually kept separate from the enzyme PDB and configured as substrate input |
 | Polymer | `C` | Used for conjugates and polymer-specific selections |
 | Solvent/ions/other | `D` and later | Usually generated or handled outside the enzyme PDB |
@@ -32,6 +32,26 @@ analysis. These are project conventions, not OpenFF parser requirements.
 An enzyme PDB can satisfy PolyzyMD chain conventions and still fail OpenFF
 ingestion if the residue graph, hydrogens, termini, or disulfide connectivity do
 not match supported chemistry.
+
+## Multi-molecule enzyme topology behavior
+
+OpenFF may parse a protein-only enzyme PDB as multiple molecules when the input
+contains disconnected protein copies, such as a homodimer. Diagnose this with:
+
+```python
+from openff.toolkit import Topology
+
+topology = Topology.from_pdb("enzyme.pdb")
+print(topology.n_molecules)
+```
+
+Fixed PolyzyMD builds retain all enzyme molecules in the original OpenFF order
+before substrate and polymer components. Chain assignment still follows the
+canonical convention: every protein/enzyme molecule is chain `A`, substrate is
+chain `B`, polymers are chain `C`, and solvent/ions start at chain `D`. Older
+builds incorrectly used only `molecule(0)`, which made homodimer outputs look
+like single-monomer systems even though OpenFF had loaded multiple protein
+molecules.
 
 ## OpenFF disulfide behavior
 
@@ -90,6 +110,7 @@ narrow custom-substructure proof of concept. Do not suppress the error.
 | Error dump names `CYS#0001`, terminal `H`, or N-terminal cysteine/cystine | N-terminal cysteine has terminal hydrogens plus disulfide chemistry that does not match OpenFF's template | Check SG-HG absence, SG-SG bond, N-terminal hydrogens, and residue naming | Curate the cystine or test a structure-specific `NCYX` custom substructure | Seen in 4CHA proof of concept; not universal |
 | Renaming disulfide cysteine to `CYX` does not resolve ingestion | `CYX` aliasing is not equivalent to a complete public template for all contexts | Validate direct OpenFF ingestion and inspect charge mismatch | Fix connectivity/hydrogens or prepare an upstream OpenFF issue/PR | Avoid relying on residue rename alone |
 | Failure adjacent to residues listed in `REMARK 465` | Missing-coordinate residues or missing heavy atoms alter termini or local chemistry | Read PDB header and visualize gaps | Model missing regions externally if required for the study | Automatic filling is a modeling decision |
+| `Topology.from_pdb()` reports `n_molecules > 1`, but older output contains only one protein copy | Historical PolyzyMD solute combination dropped all enzyme molecules except `molecule(0)` | Compare `Topology.from_pdb(path).n_molecules` and output atom counts/chains | Use a fixed PolyzyMD build; all enzyme molecules are retained before substrate/polymers | Multiple protein molecules intentionally share chain `A` |
 
 ## Catalog maintenance rule
 

--- a/src/polyzymd/builders/system_builder.py
+++ b/src/polyzymd/builders/system_builder.py
@@ -111,14 +111,30 @@ class SystemBuilder:
     def build_enzyme(self, pdb_path: Union[str, Path]) -> Topology:
         """Build the enzyme component.
 
-        Args:
-            pdb_path: Path to enzyme PDB file.
+        Parameters
+        ----------
+        pdb_path : str or Path
+            Path to enzyme PDB file.
 
-        Returns:
+        Returns
+        -------
+        Topology
             Enzyme topology.
+
+        Raises
+        ------
+        RuntimeError
+            If OpenFF loads the enzyme PDB without any molecules.
         """
         self._enzyme_topology = self._enzyme_builder.build(pdb_path)
-        self._n_enzyme_molecules = 1
+        self._n_enzyme_molecules = self._enzyme_topology.n_molecules
+        if self._n_enzyme_molecules <= 0:
+            raise RuntimeError("OpenFF enzyme topology contains no molecules")
+        if self._n_enzyme_molecules > 1:
+            LOGGER.info(
+                "Enzyme topology contains %d protein molecules; retaining all on chain A",
+                self._n_enzyme_molecules,
+            )
         return self._enzyme_topology
 
     def build_substrate(
@@ -219,11 +235,19 @@ class SystemBuilder:
     def combine_solutes(self) -> Topology:
         """Combine enzyme, substrate, and polymers into a single topology.
 
-        Returns:
+        All OpenFF enzyme topology molecules are retained in their original
+        order before substrate and polymer components are added. During export,
+        every enzyme molecule is assigned to PolyzyMD protein chain ``A``.
+
+        Returns
+        -------
+        Topology
             Combined topology ready for solvation.
 
-        Raises:
-            RuntimeError: If enzyme has not been built.
+        Raises
+        ------
+        RuntimeError
+            If enzyme has not been built or contains no molecules.
         """
         if self._enzyme_topology is None:
             raise RuntimeError("Enzyme must be built before combining solutes")
@@ -232,8 +256,13 @@ class SystemBuilder:
 
         from openff.toolkit import Topology
 
-        # Start with enzyme
-        molecules = [self._enzyme_topology.molecule(0)]
+        enzyme_molecule_count = self._enzyme_topology.n_molecules
+        if enzyme_molecule_count <= 0:
+            raise RuntimeError("OpenFF enzyme topology contains no molecules")
+        self._n_enzyme_molecules = enzyme_molecule_count
+
+        # Retain all enzyme molecules before substrate and polymers
+        molecules = [self._enzyme_topology.molecule(i) for i in range(self._n_enzyme_molecules)]
 
         # Add substrate if present
         if self._substrate_molecule is not None:
@@ -594,7 +623,8 @@ class SystemBuilder:
         source of truth for what each molecule represents.
 
         Chain assignment uses FIXED letters regardless of component presence:
-        - Chain A: Protein (preserves original residue numbers from input PDB)
+
+        - Chain A: Protein/enzyme molecules (preserves original residue numbers)
         - Chain B: Substrate (residue 1; letter reserved even if no substrate)
         - Chain C: Polymers (preserves per-monomer residue numbers)
         - Chain D+: Solvent (overflow at 9999 residues per chain)
@@ -617,7 +647,7 @@ class SystemBuilder:
         CHAIN_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         mol_idx = 0
 
-        # Fixed chain letter assignments per component type.
+        # Fixed chain letter assignments per component type
         # A=protein, B=substrate, C=polymer, D+=solvent — regardless of whether
         # a component is present. This ensures downstream code (SystemComponentInfo,
         # AtomGroupResolver, from_topology()) always sees the expected chain IDs.
@@ -626,9 +656,12 @@ class SystemBuilder:
         POLYMER_CHAIN = "C"
         SOLVENT_START_IDX = 3  # index of 'D' in CHAIN_LETTERS
 
-        # 1. Protein: Always chain A, preserve original residue numbers
+        # Protein molecules always use chain A and preserve original residue numbers
         if self._n_enzyme_molecules > 0:
-            LOGGER.debug(f"Assigning chain {PROTEIN_CHAIN} to protein")
+            LOGGER.debug(
+                f"Assigning chain {PROTEIN_CHAIN} to "
+                f"{self._n_enzyme_molecules} protein molecule(s)"
+            )
 
             for _ in range(self._n_enzyme_molecules):
                 mol = self._solvated_topology.molecule(mol_idx)
@@ -640,7 +673,7 @@ class SystemBuilder:
                         atom.metadata["residue_number"] = str(atom.metadata["residue_number"])
                 mol_idx += 1
 
-        # 2. Substrate: Always chain B, residue 1
+        # Substrate always uses chain B and residue 1
         if self._n_substrate_molecules > 0:
             LOGGER.debug(f"Assigning chain {SUBSTRATE_CHAIN} to substrate")
 
@@ -651,7 +684,7 @@ class SystemBuilder:
                     atom.metadata["residue_number"] = "1"
                 mol_idx += 1
 
-        # 3. Polymers: Always chain C, continue residue numbering across chains
+        # Polymers always use chain C and continue residue numbering across chains
         if self._n_polymer_chains > 0:
             LOGGER.debug(
                 f"Assigning chain {POLYMER_CHAIN} to {self._n_polymer_chains} polymer chain(s)"
@@ -685,7 +718,7 @@ class SystemBuilder:
                 polymer_residue_num += 1
                 mol_idx += 1
 
-        # 4. Solvent: Always starts at chain D (index 3)
+        # Solvent always starts at chain D
         self._assign_solvent_identifiers(
             start_mol_idx=mol_idx,
             start_chain_idx=SOLVENT_START_IDX,

--- a/src/polyzymd/exporters/gromacs.py
+++ b/src/polyzymd/exporters/gromacs.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
         SimulationConfig,
         SimulationPhaseConfig,
     )
-    from polyzymd.core.atom_groups import AtomGroupResolver, SystemComponentInfo
+    from polyzymd.core.atom_groups import SystemComponentInfo
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +83,26 @@ WATER_COMPRESSIBILITY = 4.5e-5
 POLYZYMD_BRANDING = FULL_CREDIT_LINE
 _GROMACS_TEMPLATE_PACKAGE = "polyzymd.engines.gromacs"
 _LOCAL_RUN_TEMPLATE = "run_gromacs.sh.jinja"
+
+
+def _is_hydrogen_atom_name(name: str) -> bool:
+    """Return whether an atom name denotes hydrogen.
+
+    Leading digits are ignored because PDB-derived and force-field atom names
+    can place numeric disambiguators before hydrogen labels, such as ``1H``,
+    ``2HA``, or ``3HD1``.
+
+    Parameters
+    ----------
+    name : str
+        Atom name from a topology or ITP atom record.
+
+    Returns
+    -------
+    bool
+        ``True`` when the digit-stripped atom name starts with ``H``.
+    """
+    return name.lstrip("0123456789").upper().startswith("H")
 
 
 def _validate_local_shell_token(value: str, field_name: str) -> str:
@@ -745,6 +765,17 @@ class MDPGenerator:
 # =============================================================================
 
 
+@dataclass(frozen=True)
+class _ComponentItpAssignment:
+    """Topology-derived component assignment for one molecule ITP."""
+
+    component_type: str
+    mol_name: str
+    itp_path: Path
+    atom_count: int
+    n_copies: int
+
+
 class PositionRestraintGenerator:
     """Generates GROMACS position restraint sections for molecule ITP files.
 
@@ -752,23 +783,21 @@ class PositionRestraintGenerator:
     using local atom indices (1 to N within each molecule), which is required
     by GROMACS.
 
-    For protein and ligand components (single molecule type each), it uses the
-    AtomGroupResolver to identify restrained atoms by global index and maps
-    them to local indices within that molecule's ITP.
-
-    For polymers, OpenFF Interchange may create multiple unique molecule types
-    (one per unique monomer sequence). This class discovers ALL polymer ITP
-    files and adds position restraints to each by parsing the ITP's [ atoms ]
-    section to identify heavy (non-hydrogen) atoms directly, rather than
-    relying on global-to-local index mapping.
+    Component ITPs are classified from the exported topology molecule layout
+    and SystemComponentInfo atom counts. Each selected ITP is restrained using
+    atom indices parsed from that ITP's own [ atoms ] section, so homodimers
+    and other multi-protein layouts do not generate global atom indices inside
+    molecule-local restraint blocks.
 
     GROMACS requires position restraints to be:
+
     1. Inside the [ moleculetype ] section of each molecule
     2. Using local atom indices (1 to N) within that molecule
 
-    Example:
-        >>> generator = PositionRestraintGenerator(topology, component_info)
-        >>> generator.add_posres_to_itp_files(config, output_dir, "MySystem")
+    Examples
+    --------
+    >>> generator = PositionRestraintGenerator(topology, component_info)
+    >>> generator.add_posres_to_itp_files(config, output_dir, "MySystem")
     """
 
     # Maps atom group names to (component_type, posres_define)
@@ -787,15 +816,15 @@ class PositionRestraintGenerator:
     ):
         """Initialize the position restraint generator.
 
-        Args:
-            topology: OpenMM Topology object from Interchange.
-            component_info: SystemComponentInfo with atom counts/chain assignments.
+        Parameters
+        ----------
+        topology : OpenMMTopology
+            OpenMM Topology object from Interchange.
+        component_info : SystemComponentInfo
+            SystemComponentInfo with atom counts and chain assignments.
         """
-        from polyzymd.core.atom_groups import AtomGroupResolver
-
         self._topology = topology
         self._component_info = component_info
-        self._resolver = AtomGroupResolver(topology, component_info)
 
     def add_posres_to_itp_files(
         self,
@@ -805,24 +834,25 @@ class PositionRestraintGenerator:
     ) -> Dict[str, str]:
         """Add position restraint sections to molecule .itp files.
 
-        For each restraint group in the config's equilibration stages:
-        1. Determines the component type (protein, ligand, or polymer)
-        2. Finds the relevant ITP file(s)
-        3. Identifies restrained atoms (heavy atoms for *_heavy groups)
-        4. Appends #ifdef POSRES blocks to each ITP
+        For each restraint group in the config's equilibration stages, the
+        exporter determines the component type, finds topology-classified ITP
+        files, parses local restrained atoms from each ITP, and appends
+        ``#ifdef POSRES`` blocks.
 
-        For protein/ligand, there is exactly one ITP per component. For
-        polymers, there may be many unique molecule types (one per unique
-        monomer sequence), and ALL polymer ITPs receive position restraints.
+        Parameters
+        ----------
+        config : SimulationConfig
+            Simulation configuration with equilibration stages.
+        output_dir : Path
+            Directory containing exported ITP files.
+        prefix : str
+            Filename prefix used for exported files.
 
-        Args:
-            config: SimulationConfig with equilibration stages.
-            output_dir: Directory containing .itp files.
-            prefix: Filename prefix used for .itp files.
-
-        Returns:
-            Dictionary mapping component types to POSRES define names used.
-            E.g., {"protein": "POSRES_PROTEIN", "polymer": "POSRES_POLYMER"}
+        Returns
+        -------
+        dict[str, str]
+            Mapping of component types to POSRES define names used, such as
+            ``{"protein": "POSRES_PROTEIN", "polymer": "POSRES_POLYMER"}``.
         """
         phases = config.simulation_phases
         posres_defines: Dict[str, str] = {}
@@ -849,31 +879,24 @@ class PositionRestraintGenerator:
                 logger.warning(f"Cannot determine component for group '{group_name}' - skipping")
                 continue
 
-            if component_type == "polymer":
-                count = self._add_posres_to_polymer_itps(
-                    output_dir, prefix, force_constant, posres_define, group_name
-                )
-                if count > 0:
-                    posres_defines[component_type] = posres_define
-            else:
-                added = self._add_posres_to_single_itp(
-                    output_dir,
-                    prefix,
-                    component_type,
-                    group_name,
-                    force_constant,
-                    posres_define,
-                )
-                if added:
-                    posres_defines[component_type] = posres_define
+            count = self._add_posres_to_component_itps(
+                output_dir,
+                prefix,
+                component_type,
+                group_name,
+                force_constant,
+                posres_define,
+            )
+            if count > 0:
+                posres_defines[component_type] = posres_define
 
         return posres_defines
 
     # ------------------------------------------------------------------
-    # Single-ITP path (protein / ligand)
+    # Component ITP discovery and classification
     # ------------------------------------------------------------------
 
-    def _add_posres_to_single_itp(
+    def _add_posres_to_component_itps(
         self,
         output_dir: Path,
         prefix: str,
@@ -881,60 +904,259 @@ class PositionRestraintGenerator:
         group_name: str,
         force_constant: float,
         posres_define: str,
-    ) -> bool:
-        """Add position restraints to a single-molecule-type ITP (protein or ligand).
+    ) -> int:
+        """Add position restraints to every ITP assigned to a component.
 
-        Uses global-to-local index mapping via the AtomGroupResolver.
+        Parameters
+        ----------
+        output_dir : Path
+            Directory containing exported topology and ITP files.
+        prefix : str
+            Export filename prefix.
+        component_type : str
+            Component type to restrain, such as ``"protein"`` or ``"polymer"``.
+        group_name : str
+            Restraint atom group name.
+        force_constant : float
+            Position restraint force constant in kJ/mol/nm^2.
+        posres_define : str
+            Preprocessor define wrapping the generated restraints.
 
-        Returns:
-            True if restraints were added, False otherwise.
+        Returns
+        -------
+        int
+            Number of ITP files that received position restraints.
         """
-        global_indices = self._resolver.resolve(group_name)
-        if not global_indices:
-            logger.warning(f"No atoms found for group '{group_name}' - skipping")
-            return False
+        itp_paths = self._find_component_itps(output_dir, prefix, component_type)
+        if not itp_paths:
+            logger.warning(
+                f"Cannot find valid ITP files for {component_type} - skipping position restraints"
+            )
+            return 0
+
+        count = 0
+        for itp_path in itp_paths:
+            local_indices = self._get_local_atom_indices_from_itp(itp_path, group_name)
+            if not local_indices:
+                logger.warning(f"No local indices for group '{group_name}' in {itp_path.name}")
+                continue
+
+            atom_count = self._get_atom_count_from_itp(itp_path)
+            if atom_count <= 0 or max(local_indices) > atom_count:
+                logger.warning(
+                    f"Skipping {itp_path.name}: restraint indices for '{group_name}' exceed "
+                    f"the ITP atom count ({atom_count})"
+                )
+                continue
+
+            self._append_posres_to_itp(
+                itp_path, local_indices, force_constant, posres_define, group_name
+            )
+            count += 1
+            logger.info(
+                f"Added {len(local_indices)} position restraints to "
+                f"{itp_path.name} (#ifdef {posres_define})"
+            )
+
+        return count
+
+    def _find_component_itps(
+        self,
+        output_dir: Path,
+        prefix: str,
+        component_type: str,
+    ) -> List[Path]:
+        """Find ITP files assigned to a component.
+
+        The topology layout path is preferred because it can distinguish
+        homodimers from ligand or polymer molecule types. If no topology file is
+        available, this method falls back to the historical filename-order
+        helpers.
+
+        Parameters
+        ----------
+        output_dir : Path
+            Directory containing exported topology and ITP files.
+        prefix : str
+            Export filename prefix.
+        component_type : str
+            Component type to locate.
+
+        Returns
+        -------
+        list[Path]
+            ITP paths for the requested component.
+        """
+        assignments = self._classify_itps_by_topology_layout(output_dir, prefix)
+        if assignments is not None:
+            component_itps = []
+            seen_itps = set()
+            for assignment in assignments.get(component_type, []):
+                if assignment.itp_path in seen_itps:
+                    continue
+                seen_itps.add(assignment.itp_path)
+                component_itps.append(assignment.itp_path)
+            return component_itps
+
+        if component_type == "polymer":
+            return self._find_all_polymer_itps(output_dir, prefix)
 
         itp_path = self._find_single_itp(output_dir, prefix, component_type)
-        if itp_path is None:
+        return [itp_path] if itp_path is not None else []
+
+    def _classify_itps_by_topology_layout(
+        self,
+        output_dir: Path,
+        prefix: str,
+    ) -> Dict[str, List[_ComponentItpAssignment]] | None:
+        """Classify component ITPs from topology order and atom counts.
+
+        Parameters
+        ----------
+        output_dir : Path
+            Directory containing ``{prefix}.top`` and molecule ITP files.
+        prefix : str
+            Export filename prefix.
+
+        Returns
+        -------
+        dict[str, list[_ComponentItpAssignment]] | None
+            Component assignments, or ``None`` when no topology layout is
+            available and fallback discovery should be used.
+        """
+        top_path = output_dir / f"{prefix}.top"
+        if not top_path.exists():
+            return None
+
+        mol_layout = GromacsExporter._parse_molecules_from_top(top_path)
+        if not mol_layout:
             logger.warning(
-                f"Cannot find ITP file for {component_type} - skipping position restraints"
+                f"No [ molecules ] layout found in {top_path.name} - skipping topology-based "
+                "position restraint classification"
             )
-            return False
+            return {"protein": [], "ligand": [], "polymer": []}
 
-        local_indices = self._global_to_local_indices(global_indices, component_type)
-        if not local_indices:
-            logger.warning(f"No local indices for group '{group_name}' - skipping")
-            return False
+        component_targets = self._component_atom_targets()
+        assignments: Dict[str, List[_ComponentItpAssignment]] = {
+            "protein": [],
+            "ligand": [],
+            "polymer": [],
+        }
+        if not component_targets:
+            return assignments
 
-        self._append_posres_to_itp(
-            itp_path, local_indices, force_constant, posres_define, group_name
-        )
-        logger.info(
-            f"Added {len(local_indices)} position restraints to "
-            f"{itp_path.name} (#ifdef {posres_define})"
-        )
-        return True
+        target_idx = 0
+        remaining = component_targets[target_idx][1]
+
+        for mol_name, n_copies in mol_layout:
+            if target_idx >= len(component_targets):
+                break
+
+            while remaining == 0:
+                target_idx += 1
+                if target_idx >= len(component_targets):
+                    break
+                remaining = component_targets[target_idx][1]
+            if target_idx >= len(component_targets):
+                break
+
+            itp_path = output_dir / f"{prefix}_{mol_name}.itp"
+            if not itp_path.exists():
+                logger.warning(
+                    f"Cannot classify {mol_name}: missing ITP file {itp_path.name}. "
+                    "Skipping remaining topology-based position restraints"
+                )
+                return assignments
+
+            atom_count = self._get_atom_count_from_itp(itp_path)
+            entry_atoms = atom_count * n_copies
+            if atom_count <= 0 or entry_atoms <= 0:
+                logger.warning(
+                    f"Cannot classify {mol_name}: invalid atom count in {itp_path.name}. "
+                    "Skipping remaining topology-based position restraints"
+                )
+                return assignments
+
+            component_type, component_atoms = component_targets[target_idx]
+            if entry_atoms > remaining:
+                logger.warning(
+                    f"Topology/count mismatch while classifying {mol_name}: entry has "
+                    f"{entry_atoms} atoms but {remaining}/{component_atoms} atoms remain for "
+                    f"{component_type}. Skipping questionable component restraints"
+                )
+                assignments[component_type] = []
+                return assignments
+
+            assignments[component_type].append(
+                _ComponentItpAssignment(
+                    component_type=component_type,
+                    mol_name=mol_name,
+                    itp_path=itp_path,
+                    atom_count=atom_count,
+                    n_copies=n_copies,
+                )
+            )
+            remaining -= entry_atoms
+
+        while target_idx < len(component_targets) and remaining == 0:
+            target_idx += 1
+            if target_idx < len(component_targets):
+                remaining = component_targets[target_idx][1]
+
+        if target_idx < len(component_targets):
+            incomplete_component, component_atoms = component_targets[target_idx]
+            if remaining > 0:
+                logger.warning(
+                    f"Topology/count mismatch: {remaining}/{component_atoms} atoms remain "
+                    f"unmatched for {incomplete_component}. Skipping its restraints"
+                )
+                assignments[incomplete_component] = []
+
+        return assignments
+
+    def _component_atom_targets(self) -> List[Tuple[str, int]]:
+        """Return non-empty component atom targets in topology order.
+
+        Returns
+        -------
+        list[tuple[str, int]]
+            Component names and atom counts in PolyzyMD build order.
+        """
+        return [
+            (component_type, atom_count)
+            for component_type, atom_count in (
+                ("protein", getattr(self._component_info, "n_protein_atoms", 0)),
+                ("ligand", getattr(self._component_info, "n_substrate_atoms", 0)),
+                ("polymer", getattr(self._component_info, "n_polymer_atoms", 0)),
+            )
+            if atom_count > 0
+        ]
 
     def _find_single_itp(
         self,
         output_dir: Path,
         prefix: str,
         component_type: str,
-    ) -> Optional[Path]:
-        """Find the ITP file for a single-instance component (protein or ligand).
+    ) -> Path | None:
+        """Find a component ITP by historical filename order.
 
-        OpenFF Interchange names molecule types MOL0, MOL1, ... based on
-        PolyzyMD's building order:
-        - MOL0 = protein
-        - MOL1 = substrate/ligand (if protein present, else MOL0)
+        This fallback is used only when ``{prefix}.top`` is unavailable. When
+        the topology layout exists, component classification uses molecule
+        order and atom counts instead.
 
-        Args:
-            output_dir: Directory containing ITP files.
-            prefix: Filename prefix.
-            component_type: "protein" or "ligand"
+        Parameters
+        ----------
+        output_dir : Path
+            Directory containing ITP files.
+        prefix : str
+            Filename prefix.
+        component_type : str
+            Component type, either ``"protein"`` or ``"ligand"``.
 
-        Returns:
-            Path to the ITP file, or None if not found.
+        Returns
+        -------
+        Path | None
+            Path to the ITP file, or ``None`` if not found.
         """
         if component_type == "protein":
             mol_index = 0
@@ -950,37 +1172,6 @@ class PositionRestraintGenerator:
         logger.warning(f"ITP file not found: {itp_path}")
         return None
 
-    def _global_to_local_indices(
-        self,
-        global_indices: List[int],
-        component_type: str,
-    ) -> List[int]:
-        """Convert global atom indices to local 1-indexed indices.
-
-        Args:
-            global_indices: 0-indexed global atom indices.
-            component_type: "protein" or "ligand"
-
-        Returns:
-            Sorted list of 1-indexed local atom indices for GROMACS.
-        """
-        if component_type == "protein":
-            start_index = 0
-            n_atoms = self._component_info.n_protein_atoms
-        elif component_type == "ligand":
-            start_index = self._component_info.n_protein_atoms
-            n_atoms = self._component_info.n_substrate_atoms
-        else:
-            return []
-
-        end_index = start_index + n_atoms
-        local_indices = [
-            global_idx - start_index + 1
-            for global_idx in global_indices
-            if start_index <= global_idx < end_index
-        ]
-        return sorted(local_indices)
-
     # ------------------------------------------------------------------
     # Multi-ITP path (polymers)
     # ------------------------------------------------------------------
@@ -993,29 +1184,31 @@ class PositionRestraintGenerator:
         posres_define: str,
         group_name: str,
     ) -> int:
-        """Add position restraints to ALL polymer ITP files.
+        """Add position restraints to polymer ITP files.
 
-        OpenFF Interchange creates one molecule type (and ITP file) per unique
-        polymer sequence. For random copolymers, 25 chains might produce 12+
-        unique molecule types. Every polymer ITP needs its own position
-        restraints.
+        This compatibility helper uses topology-based component classification
+        when possible and falls back to historical polymer discovery only when
+        the topology layout is unavailable.
 
-        Instead of mapping global indices (which requires knowing the exact
-        molecule ordering), this method parses each ITP's [ atoms ] section
-        directly and identifies heavy atoms by atom name (names NOT starting
-        with 'H' are heavy atoms).
+        Parameters
+        ----------
+        output_dir : Path
+            Directory containing ITP files.
+        prefix : str
+            Filename prefix.
+        force_constant : float
+            Position restraint force constant in kJ/mol/nm^2.
+        posres_define : str
+            POSRES define name, such as ``"POSRES_POLYMER"``.
+        group_name : str
+            Atom group name for comment headers.
 
-        Args:
-            output_dir: Directory containing ITP files.
-            prefix: Filename prefix.
-            force_constant: Force constant in kJ/mol/nm^2.
-            posres_define: POSRES define name (e.g., "POSRES_POLYMER").
-            group_name: Atom group name for comment headers.
-
-        Returns:
+        Returns
+        -------
+        int
             Number of ITP files that received position restraints.
         """
-        polymer_itps = self._find_all_polymer_itps(output_dir, prefix)
+        polymer_itps = self._find_component_itps(output_dir, prefix, "polymer")
         if not polymer_itps:
             logger.warning("No polymer ITP files found - skipping polymer position restraints")
             return 0
@@ -1044,18 +1237,24 @@ class PositionRestraintGenerator:
         output_dir: Path,
         prefix: str,
     ) -> List[Path]:
-        """Discover all polymer molecule ITP files in the output directory.
+        """Discover polymer molecule ITP files without topology classification.
 
-        Polymer ITPs start at the first MOL index after protein and ligand.
-        We glob for all ``{prefix}_MOL*.itp`` files, exclude known non-polymer
-        molecules (water, ions), and return the rest sorted by MOL index.
+        This fallback is used only when ``{prefix}.top`` is unavailable. When
+        the topology layout exists, polymer ITPs are classified by molecule
+        order and SystemComponentInfo atom counts to avoid treating retained
+        protein ITPs as polymer.
 
-        Args:
-            output_dir: Directory containing ITP files.
-            prefix: Filename prefix (e.g., "FnIII_OEGMA-SBMA-1-1").
+        Parameters
+        ----------
+        output_dir : Path
+            Directory containing ITP files.
+        prefix : str
+            Filename prefix.
 
-        Returns:
-            Sorted list of polymer ITP file paths.
+        Returns
+        -------
+        list[Path]
+            Sorted list of fallback-discovered polymer ITP file paths.
         """
         # Determine the first polymer MOL index
         first_polymer_mol = 0
@@ -1141,10 +1340,12 @@ class PositionRestraintGenerator:
         """Parse an ITP file and return 1-indexed local indices of heavy atoms.
 
         Heavy atoms are identified by atom name: any atom whose name does NOT
-        start with 'H' is considered heavy. This convention is universal across
-        AMBER, CHARMM, OPLS, and SMIRNOFF force fields. It is also invariant
-        to hydrogen mass repartitioning (HMR), which changes atom masses but
-        never changes atom names.
+        start with ``H`` after stripping leading digits is considered heavy.
+        This handles digit-prefixed hydrogen names such as ``1H``, ``2HA``,
+        and ``3HD1``. This convention is universal across AMBER, CHARMM, OPLS,
+        and SMIRNOFF force fields. It is also invariant to hydrogen mass
+        repartitioning (HMR), which changes atom masses but never changes atom
+        names.
 
         The ITP [ atoms ] section format (from OpenFF Interchange) is::
 
@@ -1152,13 +1353,18 @@ class PositionRestraintGenerator:
                  1 MOL2_0       1 RES1     C1      1  -0.123456789012  12.010780000000
 
         Column indices (0-based, whitespace-split):
+
         - 0: atom index (1-indexed)
         - 4: atom name
 
-        Args:
-            itp_path: Path to the ITP file.
+        Parameters
+        ----------
+        itp_path : Path
+            Path to the ITP file.
 
-        Returns:
+        Returns
+        -------
+        list[int]
             Sorted list of 1-indexed atom indices for non-hydrogen atoms.
         """
         heavy_indices: List[int] = []
@@ -1182,9 +1388,81 @@ class PositionRestraintGenerator:
                 if len(parts) >= 5 and parts[0].isdigit():
                     atom_index = int(parts[0])
                     atom_name = parts[4]
-                    if not atom_name.startswith("H"):
+                    if not _is_hydrogen_atom_name(atom_name):
                         heavy_indices.append(atom_index)
         return sorted(heavy_indices)
+
+    @classmethod
+    def _get_local_atom_indices_from_itp(cls, itp_path: Path, group_name: str) -> List[int]:
+        """Parse local atom indices for a restraint group from one ITP.
+
+        Parameters
+        ----------
+        itp_path : Path
+            Path to the molecule ITP file.
+        group_name : str
+            Restraint group name such as ``"protein_heavy"``,
+            ``"protein_backbone"``, or ``"ligand_heavy"``.
+
+        Returns
+        -------
+        list[int]
+            Sorted 1-indexed atom indices local to the ITP molecule type.
+        """
+        if group_name.endswith("_heavy"):
+            return cls._get_heavy_atom_indices_from_itp(itp_path)
+
+        atom_indices: List[int] = []
+        for atom_index, atom_name in cls._iter_itp_atom_names(itp_path):
+            atom_name_upper = atom_name.upper()
+            if group_name == "protein_backbone" and atom_name_upper in {
+                "N",
+                "CA",
+                "C",
+                "O",
+                "OXT",
+            }:
+                atom_indices.append(atom_index)
+            elif group_name == "protein_calpha" and atom_name_upper == "CA":
+                atom_indices.append(atom_index)
+
+        return sorted(atom_indices)
+
+    @staticmethod
+    def _iter_itp_atom_names(itp_path: Path) -> List[Tuple[int, str]]:
+        """Return local atom indices and names from an ITP [ atoms ] section.
+
+        Parameters
+        ----------
+        itp_path : Path
+            Path to the molecule ITP file.
+
+        Returns
+        -------
+        list[tuple[int, str]]
+            Pairs of 1-indexed atom index and atom name.
+        """
+        atom_names: List[Tuple[int, str]] = []
+        try:
+            lines = itp_path.read_text().splitlines()
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.warning(f"Failed to read ITP file {itp_path}: {exc}")
+            return atom_names
+
+        in_atoms_section = False
+        for line in lines:
+            stripped = line.strip()
+            if not stripped or stripped.startswith(";"):
+                continue
+            if stripped.startswith("["):
+                section = stripped.strip("[] \t").lower()
+                in_atoms_section = section == "atoms"
+                continue
+            if in_atoms_section:
+                parts = stripped.split()
+                if len(parts) >= 5 and parts[0].isdigit():
+                    atom_names.append((int(parts[0]), parts[4]))
+        return atom_names
 
     # ------------------------------------------------------------------
     # Shared helpers

--- a/tests/builders/test_system_builder.py
+++ b/tests/builders/test_system_builder.py
@@ -1,0 +1,214 @@
+"""Regression tests for system builder molecule bookkeeping."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from polyzymd.builders.system_builder import SystemBuilder
+
+
+class FakeAtom:
+    """Minimal atom object with mutable OpenFF-style metadata."""
+
+    def __init__(self, residue_number: str = "1") -> None:
+        """Initialize a fake atom.
+
+        Parameters
+        ----------
+        residue_number : str, optional
+            Initial residue number metadata, by default "1".
+        """
+        self.metadata = {"residue_number": residue_number}
+
+
+class FakeMolecule:
+    """Minimal molecule object used by fake topologies."""
+
+    def __init__(self, name: str, n_atoms: int = 2) -> None:
+        """Initialize a fake molecule.
+
+        Parameters
+        ----------
+        name : str
+            Identifier used by assertions.
+        n_atoms : int, optional
+            Number of fake atoms to create, by default 2.
+        """
+        self.name = name
+        self.atoms = [FakeAtom(str(i + 1)) for i in range(n_atoms)]
+
+    @property
+    def n_atoms(self) -> int:
+        """Return the number of fake atoms."""
+        return len(self.atoms)
+
+
+class FakeTopology:
+    """Minimal OpenFF Topology replacement for system builder tests."""
+
+    def __init__(self, molecules: list[FakeMolecule]) -> None:
+        """Initialize a fake topology.
+
+        Parameters
+        ----------
+        molecules : list of FakeMolecule
+            Molecules in topology order.
+        """
+        self._molecules = list(molecules)
+
+    @classmethod
+    def from_molecules(cls, molecules: list[FakeMolecule]) -> FakeTopology:
+        """Create a fake topology from molecules.
+
+        Parameters
+        ----------
+        molecules : list of FakeMolecule
+            Molecules to include.
+
+        Returns
+        -------
+        FakeTopology
+            Topology preserving molecule order.
+        """
+        return cls(list(molecules))
+
+    @property
+    def molecules(self) -> list[FakeMolecule]:
+        """Return topology molecules in order."""
+        return self._molecules
+
+    @property
+    def n_molecules(self) -> int:
+        """Return molecule count."""
+        return len(self._molecules)
+
+    @property
+    def n_atoms(self) -> int:
+        """Return total atom count."""
+        return sum(molecule.n_atoms for molecule in self._molecules)
+
+    def molecule(self, index: int) -> FakeMolecule:
+        """Return a molecule by index.
+
+        Parameters
+        ----------
+        index : int
+            Molecule index.
+
+        Returns
+        -------
+        FakeMolecule
+            Selected fake molecule.
+        """
+        return self._molecules[index]
+
+
+@pytest.fixture
+def fake_openff_topology(monkeypatch: pytest.MonkeyPatch) -> type[FakeTopology]:
+    """Install a lightweight ``openff.toolkit.Topology`` fake."""
+    openff_module = types.ModuleType("openff")
+    toolkit_module = types.ModuleType("openff.toolkit")
+    toolkit_module.Topology = FakeTopology
+    openff_module.toolkit = toolkit_module
+    monkeypatch.setitem(sys.modules, "openff", openff_module)
+    monkeypatch.setitem(sys.modules, "openff.toolkit", toolkit_module)
+    return FakeTopology
+
+
+class TestSystemBuilderHomodimerRetention:
+    """Tests for retaining multi-molecule enzyme topologies."""
+
+    def test_build_enzyme_records_actual_molecule_count(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """build_enzyme should retain the OpenFF enzyme molecule count."""
+        builder = SystemBuilder()
+        enzyme_topology = FakeTopology([FakeMolecule("enzyme_1"), FakeMolecule("enzyme_2")])
+        monkeypatch.setattr(builder._enzyme_builder, "build", lambda _path: enzyme_topology)
+
+        with caplog.at_level(logging.INFO, logger="polyzymd.builders.system_builder"):
+            topology = builder.build_enzyme(Path("enzyme.pdb"))
+
+        assert topology is enzyme_topology
+        assert builder._n_enzyme_molecules == 2
+        assert "retaining all on chain A" in caplog.text
+
+    def test_build_enzyme_rejects_empty_topology(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """build_enzyme should reject an OpenFF topology with no molecules."""
+        builder = SystemBuilder()
+        monkeypatch.setattr(builder._enzyme_builder, "build", lambda _path: FakeTopology([]))
+
+        with pytest.raises(RuntimeError, match="contains no molecules"):
+            builder.build_enzyme(Path("empty.pdb"))
+
+    def test_combine_solutes_preserves_all_enzyme_molecules_before_substrate(
+        self,
+        fake_openff_topology: type[FakeTopology],
+    ) -> None:
+        """Combined topology order should be enzyme1, enzyme2, then substrate."""
+        del fake_openff_topology
+        builder = SystemBuilder()
+        enzyme_1 = FakeMolecule("enzyme_1")
+        enzyme_2 = FakeMolecule("enzyme_2")
+        substrate = FakeMolecule("substrate")
+        builder._enzyme_topology = FakeTopology([enzyme_1, enzyme_2])
+        builder._n_enzyme_molecules = 2
+        builder._substrate_molecule = substrate
+        builder._n_substrate_molecules = 1
+
+        combined = builder.combine_solutes()
+
+        assert combined.molecules == [enzyme_1, enzyme_2, substrate]
+        assert builder._n_enzyme_molecules == 2
+
+    def test_assign_pdb_identifiers_keeps_all_enzyme_molecules_on_chain_a(
+        self,
+        fake_openff_topology: type[FakeTopology],
+    ) -> None:
+        """Both protein molecules should be chain A while substrate remains chain B."""
+        del fake_openff_topology
+        builder = SystemBuilder()
+        enzyme_1 = FakeMolecule("enzyme_1")
+        enzyme_2 = FakeMolecule("enzyme_2")
+        substrate = FakeMolecule("substrate")
+        builder._enzyme_topology = FakeTopology([enzyme_1, enzyme_2])
+        builder._n_enzyme_molecules = 2
+        builder._substrate_molecule = substrate
+        builder._n_substrate_molecules = 1
+        builder._solvated_topology = builder.combine_solutes()
+
+        builder._assign_pdb_identifiers()
+
+        assert {atom.metadata["chain_id"] for atom in enzyme_1.atoms} == {"A"}
+        assert {atom.metadata["chain_id"] for atom in enzyme_2.atoms} == {"A"}
+        assert {atom.metadata["chain_id"] for atom in substrate.atoms} == {"B"}
+
+    def test_component_info_counts_all_enzyme_molecule_atoms(
+        self,
+        fake_openff_topology: type[FakeTopology],
+    ) -> None:
+        """Component metadata should count every retained protein molecule."""
+        del fake_openff_topology
+        builder = SystemBuilder()
+        enzyme_1 = FakeMolecule("enzyme_1", n_atoms=3)
+        enzyme_2 = FakeMolecule("enzyme_2", n_atoms=4)
+        substrate = FakeMolecule("substrate", n_atoms=2)
+        builder._enzyme_topology = FakeTopology([enzyme_1, enzyme_2])
+        builder._n_enzyme_molecules = 2
+        builder._substrate_molecule = substrate
+        builder._n_substrate_molecules = 1
+        builder._solvated_topology = builder.combine_solutes()
+
+        component_info = builder.get_component_info()
+
+        assert component_info.n_protein_atoms == 7
+        assert component_info.n_substrate_atoms == 2
+        assert component_info.protein_chain_id == "A"
+        assert component_info.substrate_chain_id == "B"

--- a/tests/exporters/test_gromacs.py
+++ b/tests/exporters/test_gromacs.py
@@ -14,6 +14,7 @@ Covers:
 
 from importlib import resources
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -92,12 +93,99 @@ water           2
      1      1    0.09572    0.15139
 """
 
+LIGAND_ITP_TEMPLATE = """\
+[ moleculetype ]
+{mol_name}           3
+
+[ atoms ]
+     1 {mol_name}_0       1 LIG      C1      1  -0.100000000000  12.010780000000
+     2 {mol_name}_1       1 LIG      O1      2  -0.200000000000  15.999430000000
+     3 {mol_name}_2       1 LIG      H1      3   0.100000000000   1.007940000000
+     4 {mol_name}_3       1 LIG      N1      4  -0.100000000000  14.006720000000
+
+[ bonds ]
+     1      2      1    0.14900  224262.400
+"""
+
 
 def _write_itp(directory: Path, prefix: str, mol_name: str, content: str) -> Path:
     """Write an ITP file and return its path."""
     path = directory / f"{prefix}_{mol_name}.itp"
     path.write_text(content)
     return path
+
+
+def _write_top(directory: Path, prefix: str, molecules: list[tuple[str, int]]) -> Path:
+    """Write a minimal topology file with a [ molecules ] layout."""
+    molecule_lines = [f"{mol_name}    {count}" for mol_name, count in molecules]
+    path = directory / f"{prefix}.top"
+    path.write_text("[ system ]\ntest\n\n[ molecules ]\n" + "\n".join(molecule_lines) + "\n")
+    return path
+
+
+def _protein_itp_content(mol_name: str) -> str:
+    """Return the synthetic protein ITP content with the requested molecule name."""
+    return PROTEIN_ITP_CONTENT.replace("MOL0", mol_name)
+
+
+def _posres_config(groups: list[str]) -> SimpleNamespace:
+    """Build a minimal config object with position restraint groups."""
+    restraints = [SimpleNamespace(group=group, force_constant=1000.0) for group in groups]
+    stage = SimpleNamespace(position_restraints=restraints)
+    return SimpleNamespace(simulation_phases=SimpleNamespace(equilibration_stages=[stage]))
+
+
+def _component_info(
+    n_protein_atoms: int = 0,
+    n_substrate_atoms: int = 0,
+    n_polymer_atoms: int = 0,
+) -> SimpleNamespace:
+    """Build minimal SystemComponentInfo-like counts for synthetic tests."""
+    return SimpleNamespace(
+        n_protein_atoms=n_protein_atoms,
+        n_substrate_atoms=n_substrate_atoms,
+        n_polymer_atoms=n_polymer_atoms,
+        has_protein=n_protein_atoms > 0,
+        has_substrate=n_substrate_atoms > 0,
+        has_polymers=n_polymer_atoms > 0,
+    )
+
+
+def _posres_generator(component_info: SimpleNamespace) -> PositionRestraintGenerator:
+    """Create a PositionRestraintGenerator without OpenMM topology dependencies."""
+    generator = PositionRestraintGenerator.__new__(PositionRestraintGenerator)
+    generator._component_info = component_info
+    return generator
+
+
+def _posres_indices(itp_path: Path, define: str) -> list[int]:
+    """Read local atom indices from a generated position restraint block."""
+    indices = []
+    in_define = False
+    in_posres = False
+    for line in itp_path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped == f"#ifdef {define}":
+            in_define = True
+            continue
+        if in_define and stripped == "#endif":
+            break
+        if in_define and stripped.startswith("["):
+            in_posres = stripped.strip("[] ").lower() == "position_restraints"
+            continue
+        if in_define and in_posres and stripped and not stripped.startswith(";"):
+            parts = stripped.split()
+            if parts and parts[0].isdigit():
+                indices.append(int(parts[0]))
+    return indices
+
+
+def _assert_posres_indices_within_atom_count(itp_path: Path, define: str) -> None:
+    """Assert generated position restraint indices are local to their ITP."""
+    indices = _posres_indices(itp_path, define)
+    atom_count = PositionRestraintGenerator._get_atom_count_from_itp(itp_path)
+    assert indices
+    assert max(indices) <= atom_count
 
 
 # ---------------------------------------------------------------------------
@@ -127,6 +215,29 @@ class TestGetHeavyAtomIndicesFromItp:
         # OW(1), HW1(2), HW2(3) -> non-H: 1 only
         # Wait — HW1 starts with 'H', so only OW is heavy
         assert heavy == [1]
+
+    def test_digit_prefixed_hydrogen_names_are_excluded(self, tmp_path):
+        content = """\
+[ moleculetype ]
+MOLX           3
+
+[ atoms ]
+     1 MOLX_0       1 RES      H       1   0.100000000000   1.007940000000
+     2 MOLX_1       1 RES      1H      2   0.100000000000   1.007940000000
+     3 MOLX_2       1 RES      2HA     3   0.100000000000   1.007940000000
+     4 MOLX_3       1 RES      3HD1    4   0.100000000000   1.007940000000
+     5 MOLX_4       1 RES      C1      5  -0.100000000000  12.010780000000
+     6 MOLX_5       1 RES      O1      6  -0.200000000000  15.999430000000
+     7 MOLX_6       1 RES      1C      7  -0.100000000000  12.010780000000
+
+[ bonds ]
+     1      5      1    0.10900  284512.000
+"""
+        itp = _write_itp(tmp_path, "sys", "MOLX", content)
+
+        heavy = PositionRestraintGenerator._get_heavy_atom_indices_from_itp(itp)
+
+        assert heavy == [5, 6, 7]
 
     def test_nonexistent_file(self, tmp_path):
         path = tmp_path / "nope.itp"
@@ -244,6 +355,116 @@ class TestFindAllPolymerItps:
         gen._component_info = component_info
         itps = gen._find_all_polymer_itps(tmp_path, "sys")
         assert itps == []
+
+
+class TestTopologyLayoutPositionRestraints:
+    """Topology layout classification keeps homodimer restraints local and typed."""
+
+    def test_identical_homodimer_mol0_two_plus_ligand(self, tmp_path):
+        """MOL0 with two copies should be one protein ITP, not protein plus ligand."""
+        prefix = "sys"
+        protein_itp = _write_itp(tmp_path, prefix, "MOL0", _protein_itp_content("MOL0"))
+        ligand_itp = _write_itp(
+            tmp_path,
+            prefix,
+            "MOL1",
+            LIGAND_ITP_TEMPLATE.format(mol_name="MOL1"),
+        )
+        _write_top(tmp_path, prefix, [("MOL0", 2), ("MOL1", 1)])
+
+        generator = _posres_generator(_component_info(n_protein_atoms=12, n_substrate_atoms=4))
+        defines = generator.add_posres_to_itp_files(
+            _posres_config(["protein_heavy", "ligand_heavy"]),
+            tmp_path,
+            prefix,
+        )
+
+        assert defines == {"protein": "POSRES_PROTEIN", "ligand": "POSRES_LIGAND"}
+        assert _posres_indices(protein_itp, "POSRES_PROTEIN") == [1, 2, 4, 5]
+        assert _posres_indices(ligand_itp, "POSRES_LIGAND") == [1, 2, 4]
+        _assert_posres_indices_within_atom_count(protein_itp, "POSRES_PROTEIN")
+        _assert_posres_indices_within_atom_count(ligand_itp, "POSRES_LIGAND")
+
+    def test_distinct_dimer_mol0_mol1_plus_ligand_mol2(self, tmp_path):
+        """Distinct protein ITPs should both receive protein restraints."""
+        prefix = "sys"
+        protein_a = _write_itp(tmp_path, prefix, "MOL0", _protein_itp_content("MOL0"))
+        protein_b = _write_itp(tmp_path, prefix, "MOL1", _protein_itp_content("MOL1"))
+        ligand_itp = _write_itp(
+            tmp_path,
+            prefix,
+            "MOL2",
+            LIGAND_ITP_TEMPLATE.format(mol_name="MOL2"),
+        )
+        _write_top(tmp_path, prefix, [("MOL0", 1), ("MOL1", 1), ("MOL2", 1)])
+
+        generator = _posres_generator(_component_info(n_protein_atoms=12, n_substrate_atoms=4))
+        defines = generator.add_posres_to_itp_files(
+            _posres_config(["protein_heavy", "ligand_heavy"]),
+            tmp_path,
+            prefix,
+        )
+
+        assert defines == {"protein": "POSRES_PROTEIN", "ligand": "POSRES_LIGAND"}
+        assert _posres_indices(protein_a, "POSRES_PROTEIN") == [1, 2, 4, 5]
+        assert _posres_indices(protein_b, "POSRES_PROTEIN") == [1, 2, 4, 5]
+        assert _posres_indices(ligand_itp, "POSRES_LIGAND") == [1, 2, 4]
+        for itp_path, define in (
+            (protein_a, "POSRES_PROTEIN"),
+            (protein_b, "POSRES_PROTEIN"),
+            (ligand_itp, "POSRES_LIGAND"),
+        ):
+            _assert_posres_indices_within_atom_count(itp_path, define)
+
+    def test_ligand_after_multiple_proteins_is_not_second_protein(self, tmp_path):
+        """Ligand restraints should start after all topology-classified proteins."""
+        prefix = "sys"
+        protein_a = _write_itp(tmp_path, prefix, "MOL0", _protein_itp_content("MOL0"))
+        protein_b = _write_itp(tmp_path, prefix, "MOL1", _protein_itp_content("MOL1"))
+        ligand_itp = _write_itp(
+            tmp_path,
+            prefix,
+            "MOL2",
+            LIGAND_ITP_TEMPLATE.format(mol_name="MOL2"),
+        )
+        _write_top(tmp_path, prefix, [("MOL0", 1), ("MOL1", 1), ("MOL2", 1)])
+
+        generator = _posres_generator(_component_info(n_protein_atoms=12, n_substrate_atoms=4))
+        defines = generator.add_posres_to_itp_files(
+            _posres_config(["ligand_heavy"]),
+            tmp_path,
+            prefix,
+        )
+
+        assert defines == {"ligand": "POSRES_LIGAND"}
+        assert "POSRES_LIGAND" not in protein_a.read_text()
+        assert "POSRES_LIGAND" not in protein_b.read_text()
+        assert _posres_indices(ligand_itp, "POSRES_LIGAND") == [1, 2, 4]
+        _assert_posres_indices_within_atom_count(ligand_itp, "POSRES_LIGAND")
+
+    def test_polymer_after_multiple_proteins_is_not_second_protein(self, tmp_path):
+        """Polymer discovery should not classify retained protein ITPs as polymer."""
+        prefix = "sys"
+        protein_itp = _write_itp(tmp_path, prefix, "MOL0", _protein_itp_content("MOL0"))
+        polymer_itp = _write_itp(
+            tmp_path,
+            prefix,
+            "MOL1",
+            POLYMER_ITP_TEMPLATE.format(mol_name="MOL1"),
+        )
+        _write_top(tmp_path, prefix, [("MOL0", 2), ("MOL1", 1)])
+
+        generator = _posres_generator(_component_info(n_protein_atoms=12, n_polymer_atoms=10))
+        defines = generator.add_posres_to_itp_files(
+            _posres_config(["polymer_heavy"]),
+            tmp_path,
+            prefix,
+        )
+
+        assert defines == {"polymer": "POSRES_POLYMER"}
+        assert "POSRES_POLYMER" not in protein_itp.read_text()
+        assert _posres_indices(polymer_itp, "POSRES_POLYMER") == [1, 3, 4, 6, 8, 10]
+        _assert_posres_indices_within_atom_count(polymer_itp, "POSRES_POLYMER")
 
 
 class TestAppendPosresToItp:


### PR DESCRIPTION
## Summary
A bug was discovered when a user submitted a homodimer enzyme structure, made of two protein chains that were identical. We previously only kept the first molecule in the Protein Topology, thus accidentally deleting any other disconnected protein fragments that may be in the box. This PR fixes this.