### PR TITLE
Fix polymer sequence mapping

### DIFF
--- a/src/polyzymd/builders/polymer.py
+++ b/src/polyzymd/builders/polymer.py
@@ -175,6 +175,7 @@ class PolymerBuilder:
 
         # Validate dynamic mode requirements
         if self._generation_mode == "dynamic":
+            self._validate_dynamic_length()
             if not self._monomer_smiles:
                 raise ValueError("Dynamic generation mode requires monomer_smiles")
             if not self._monomer_names:
@@ -230,6 +231,9 @@ class PolymerBuilder:
         Raises:
             FileNotFoundError: If SDF file not found and generation not allowed.
         """
+        if self._generation_mode == "dynamic":
+            self._validate_dynamic_length()
+
         if seed is not None:
             random.seed(seed)
 
@@ -308,6 +312,9 @@ class PolymerBuilder:
         self._charger_type = config.charger.value
         self._max_retries = config.max_retries
 
+        if self._generation_mode == "dynamic":
+            self._validate_dynamic_length()
+
         # Extract monomer-related mappings for dynamic mode
         if config.generation_mode.value == "dynamic":
             # Build monomer_smiles: name -> SMILES
@@ -354,20 +361,29 @@ class PolymerBuilder:
         if sequence in self._loaded_molecules:
             return self._loaded_molecules[sequence]
 
-        # Try to load from SDF directory (checked first in ALL modes)
+        # User-provided dynamic SDFs are allowed only when they do not resemble cache artifacts
         if self._sdf_directory:
             sdf_path = self._get_sdf_path(sequence, self._sdf_directory)
             if sdf_path.exists():
-                return self._load_from_sdf(sdf_path)
+                if self._generation_mode == "dynamic" and self._is_dynamic_cache_like_sdf(
+                    sdf_path, sequence
+                ):
+                    if self._dynamic_sdf_metadata_matches(sdf_path, sequence):
+                        return self._load_from_sdf(sdf_path)
+                    LOGGER.info(
+                        "Regenerating dynamic SDF with missing or stale metadata: %s", sdf_path
+                    )
+                else:
+                    return self._load_from_sdf(sdf_path)
 
-        # Try to load from cache directory (checked in ALL modes)
+        # Dynamic cache entries need metadata validation before reuse
+        if self._generation_mode == "dynamic":
+            return self._generate_polymer(sequence)
+
+        # Try to load from cache directory in cached mode
         cache_path = self._get_sdf_path(sequence, self._cache_directory)
         if cache_path.exists():
             return self._load_from_sdf(cache_path)
-
-        # Dynamic mode: Generate polymers using FragmentGenerator and PolymerGenerator
-        if self._generation_mode == "dynamic":
-            return self._generate_polymer(sequence)
 
         # Generate if allowed (cached mode fallback)
         if self._allow_generation:
@@ -385,6 +401,20 @@ class PolymerBuilder:
             f"Set allow_generation=True to generate missing polymers."
         )
 
+    def _validate_dynamic_length(self) -> None:
+        """Validate the configured dynamic polymer length.
+
+        Raises
+        ------
+        ValueError
+            If dynamic generation is configured with a length below three.
+        """
+        if self._length < 3:
+            raise ValueError(
+                "Dynamic polymer generation requires length >= 3 because Polymerist requires "
+                "a non-empty middle sequence"
+            )
+
     def _get_sdf_path(self, sequence: str, directory: Path) -> Path:
         """Get the expected SDF file path for a sequence.
 
@@ -398,6 +428,103 @@ class PolymerBuilder:
         # Format: {type_prefix}_seq={sequence}_{length}-mer_charged.sdf
         filename = f"{self._type_prefix}_seq={sequence}_{self._length}-mer_charged.sdf"
         return directory / filename
+
+    def _is_dynamic_cache_like_sdf(self, sdf_path: Path, sequence: str) -> bool:
+        """Return whether an SDF path looks like a generated dynamic cache artifact.
+
+        Parameters
+        ----------
+        sdf_path : Path
+            Candidate SDF path.
+        sequence : str
+            Canonical polymer sequence.
+
+        Returns
+        -------
+        bool
+            True when the path should be routed through dynamic cache validation.
+        """
+        if self._same_directory(sdf_path.parent, self._cache_directory):
+            return True
+
+        if self._get_dynamic_cache_metadata_path(sdf_path).exists():
+            return True
+
+        return self._has_generated_dynamic_cache_name(sdf_path, sequence)
+
+    def _same_directory(self, path_a: Path, path_b: Path) -> bool:
+        """Return whether two paths identify the same directory.
+
+        Parameters
+        ----------
+        path_a : Path
+            First path.
+        path_b : Path
+            Second path.
+
+        Returns
+        -------
+        bool
+            True when both paths resolve to the same directory.
+        """
+        return path_a.resolve(strict=False) == path_b.resolve(strict=False)
+
+    def _dynamic_sdf_metadata_matches(self, sdf_path: Path, sequence: str) -> bool:
+        """Return whether a dynamic SDF sidecar matches current metadata.
+
+        Parameters
+        ----------
+        sdf_path : Path
+            Candidate generated-style SDF path.
+        sequence : str
+            Canonical polymer sequence.
+
+        Returns
+        -------
+        bool
+            True when the SDF may be loaded directly.
+        """
+        self._ensure_generators_initialized()
+        residue_names = self._residue_names if self._residue_names else None
+        return self._polymer_generator._dynamic_cache_metadata_matches(
+            sdf_path,
+            sequence,
+            self._monomer_names,
+            residue_names,
+        )
+
+    def _get_dynamic_cache_metadata_path(self, sdf_path: Path) -> Path:
+        """Get the dynamic cache metadata sidecar path for an SDF.
+
+        Parameters
+        ----------
+        sdf_path : Path
+            SDF path.
+
+        Returns
+        -------
+        Path
+            Expected metadata sidecar path.
+        """
+        return sdf_path.with_name(f"{sdf_path.name}.metadata.json")
+
+    def _has_generated_dynamic_cache_name(self, sdf_path: Path, sequence: str) -> bool:
+        """Return whether a filename follows the generated dynamic cache pattern.
+
+        Parameters
+        ----------
+        sdf_path : Path
+            Candidate SDF path.
+        sequence : str
+            Canonical polymer sequence.
+
+        Returns
+        -------
+        bool
+            True when the filename has PolyzyMD's generated dynamic cache shape.
+        """
+        suffix = f"_seq={sequence}_{self._length}-mer_charged.sdf"
+        return sdf_path.name.endswith(suffix) and len(sdf_path.name) > len(suffix)
 
     def _load_from_sdf(self, sdf_path: Path) -> Molecule:
         """Load a polymer molecule from an SDF file.
@@ -441,6 +568,8 @@ class PolymerBuilder:
                 f"Polymer generation not available in cached mode for sequence '{sequence}'. "
                 f"Either provide pre-built SDF files or switch to dynamic generation mode."
             )
+
+        self._validate_dynamic_length()
 
         # Ensure generators are initialized
         self._ensure_generators_initialized()

--- a/src/polyzymd/builders/polymer_generator.py
+++ b/src/polyzymd/builders/polymer_generator.py
@@ -13,7 +13,6 @@ The workflow mirrors the notebook process:
 - Assign partial charges with NAGL, Espaloma, or AM1BCC
 - Cache the charged SDF with a validation sidecar
 
-Made by PolyzyMD, by Joseph R. Laforet Jr.
 """
 
 from __future__ import annotations

--- a/src/polyzymd/builders/polymer_generator.py
+++ b/src/polyzymd/builders/polymer_generator.py
@@ -1,83 +1,262 @@
-"""
-Polymer generator for dynamic polymer generation.
+"""Polymer generator for dynamic polymer generation.
 
-This module handles the building of complete polymer chains from MonomerGroup
-fragments, including 3D structure generation, ring-piercing validation,
-and partial charge assignment.
+This module builds complete polymer chains from MonomerGroup fragments,
+including 3D structure generation, ring-piercing validation, partial charge
+assignment, and metadata-validated dynamic caching.
 
 The workflow mirrors the notebook process:
-1. Set terminal orientations based on sequence head/tail
-2. Call build_linear_polymer() with middle sequence
-3. Validate no ring-piercing (retry up to max_retries times)
-4. Create OpenFF Topology and partition
-5. Assign partial charges (NAGL/Espaloma/AM1BCC)
-6. Cache as charged SDF
+
+- Set terminal orientations based on sequence head and tail
+- Call ``build_linear_polymer()`` with the middle sequence
+- Validate no ring-piercing and retry up to ``max_retries`` times
+- Create an OpenFF topology and partition it
+- Assign partial charges with NAGL, Espaloma, or AM1BCC
+- Cache the charged SDF with a validation sidecar
 
 Made by PolyzyMD, by Joseph R. Laforet Jr.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
-
-from polymerist.genutils.fileutils.pathutils import assemble_path
-from polymerist.mdtools.openfftools.partition import partition
-from polymerist.mdtools.openfftools.topology import (
-    get_largest_offmol,
-    topology_from_sdf,
-    topology_to_sdf,
-)
-from polymerist.polymers.building import build_linear_polymer, mbmol_to_openmm_pdb, mbmol_to_rdmol
-from polymerist.polymers.monomers import MonomerGroup
-from polymerist.rdutils.rdcoords.piercing import summarize_ring_piercing
-from rdkit import Chem
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from openff.toolkit import Molecule as OFFMolecule
     from openff.toolkit import Topology as OFFTopology
+    from polymerist.polymers.monomers import MonomerGroup
 
 logger = logging.getLogger(__name__)
+
+DYNAMIC_CACHE_SCHEMA_VERSION = 3
+
+
+def _build_linear_polymer(**kwargs: Any) -> Any:
+    """Build a linear polymer through Polymerist.
+
+    Parameters
+    ----------
+    **kwargs : Any
+        Keyword arguments forwarded to Polymerist.
+
+    Returns
+    -------
+    Any
+        Polymerist chain object.
+    """
+    from polymerist.polymers.building import build_linear_polymer
+
+    return build_linear_polymer(**kwargs)
+
+
+def _make_monomer_group(monomers: dict[str, Any]) -> "MonomerGroup":
+    """Create a Polymerist MonomerGroup lazily.
+
+    Parameters
+    ----------
+    monomers : dict[str, Any]
+        Mapping of fragment names to fragment chemistry objects.
+
+    Returns
+    -------
+    MonomerGroup
+        Polymerist monomer group containing the supplied fragments.
+    """
+    from polymerist.polymers.monomers import MonomerGroup
+
+    return MonomerGroup(monomers=monomers)
+
+
+def _mbmol_to_openmm_pdb(pdb_path: Path, chain: Any, resname_map: dict[str, str]) -> None:
+    """Write a Polymerist chain to an OpenMM-compatible PDB lazily.
+
+    Parameters
+    ----------
+    pdb_path : Path
+        Destination PDB path.
+    chain : Any
+        Polymerist chain object.
+    resname_map : dict[str, str]
+        Fragment-to-residue-name mapping.
+    """
+    from polymerist.polymers.building import mbmol_to_openmm_pdb
+
+    mbmol_to_openmm_pdb(pdb_path, chain, resname_map=resname_map)
+
+
+def _mbmol_to_rdmol(chain: Any) -> Any:
+    """Convert a Polymerist chain to an RDKit molecule lazily.
+
+    Parameters
+    ----------
+    chain : Any
+        Polymerist chain object.
+
+    Returns
+    -------
+    Any
+        RDKit molecule-like object.
+    """
+    from polymerist.polymers.building import mbmol_to_rdmol
+
+    return mbmol_to_rdmol(chain)
+
+
+def _summarize_ring_piercing(mol: Any) -> dict[str, Any]:
+    """Summarize ring-piercing events through Polymerist lazily.
+
+    Parameters
+    ----------
+    mol : Any
+        RDKit molecule-like object.
+
+    Returns
+    -------
+    dict[str, Any]
+        Ring-piercing summary from Polymerist.
+    """
+    from polymerist.rdutils.rdcoords.piercing import summarize_ring_piercing
+
+    return summarize_ring_piercing(mol)
+
+
+def _topology_from_sdf(sdf_path: Path) -> Any:
+    """Load an OpenFF topology from SDF through Polymerist lazily.
+
+    Parameters
+    ----------
+    sdf_path : Path
+        Source SDF path.
+
+    Returns
+    -------
+    Any
+        OpenFF topology-like object.
+    """
+    from polymerist.mdtools.openfftools.topology import topology_from_sdf
+
+    return topology_from_sdf(sdf_path)
+
+
+def _topology_to_sdf(sdf_path: Path, topology: Any) -> None:
+    """Write an OpenFF topology to SDF through Polymerist lazily.
+
+    Parameters
+    ----------
+    sdf_path : Path
+        Destination SDF path.
+    topology : Any
+        OpenFF topology-like object.
+    """
+    from polymerist.mdtools.openfftools.topology import topology_to_sdf
+
+    topology_to_sdf(sdf_path, topology)
+
+
+def _get_largest_offmol(topology: Any) -> "OFFMolecule":
+    """Extract the largest OpenFF molecule through Polymerist lazily.
+
+    Parameters
+    ----------
+    topology : Any
+        OpenFF topology-like object.
+
+    Returns
+    -------
+    OFFMolecule
+        Largest molecule in the topology.
+    """
+    from polymerist.mdtools.openfftools.topology import get_largest_offmol
+
+    return get_largest_offmol(topology)
+
+
+def _partition(topology: "OFFTopology") -> bool:
+    """Partition an OpenFF topology through Polymerist lazily.
+
+    Parameters
+    ----------
+    topology : OFFTopology
+        OpenFF topology to partition.
+
+    Returns
+    -------
+    bool
+        True when partitioning succeeds.
+    """
+    from polymerist.mdtools.openfftools.partition import partition
+
+    return partition(topology)
 
 
 class PolymerGenerationError(Exception):
     """Raised when polymer generation fails after all retries."""
 
-    pass
+
+def _validate_dynamic_sequence_labels(sequence: str, monomer_names: dict[str, str]) -> list[str]:
+    """Validate labels used by a dynamic polymer sequence.
+
+    Parameters
+    ----------
+    sequence : str
+        Polymer sequence string to validate.
+    monomer_names : dict[str, str]
+        Mapping of sequence labels to monomer names.
+
+    Returns
+    -------
+    list[str]
+        Unique sequence labels in first-seen order.
+
+    Raises
+    ------
+    ValueError
+        If any sequence label does not have a configured monomer name.
+    """
+    labels_used = []
+    for label in sequence:
+        if label not in monomer_names:
+            raise ValueError(f"No monomer name configured for sequence label: {label}")
+        if label not in labels_used:
+            labels_used.append(label)
+
+    return labels_used
 
 
 class PolymerGenerator:
     """Generates complete polymer chains from MonomerGroup fragments.
 
     This class handles the full polymer building workflow:
-    1. Building 3D structures using Polymerist's build_linear_polymer
-    2. Validating no ring-piercing events occur
-    3. Creating OpenFF topologies
-    4. Assigning partial charges
-    5. Caching results as SDF files
 
-    Attributes:
-        monomer_group: MonomerGroup containing polymer fragments
-        cache_directory: Directory for caching generated polymers
-        max_retries: Maximum attempts for building a valid polymer
-        charger_type: Method for partial charge assignment
+    - Building 3D structures using Polymerist's ``build_linear_polymer``
+    - Validating no ring-piercing events occur
+    - Creating OpenFF topologies
+    - Assigning partial charges
+    - Caching results as SDF files guarded by deterministic metadata
     """
 
     def __init__(
         self,
-        monomer_group: MonomerGroup,
+        monomer_group: "MonomerGroup",
         cache_directory: Path,
         max_retries: int = 10,
         charger_type: str = "nagl",
     ):
         """Initialize the polymer generator.
 
-        Args:
-            monomer_group: MonomerGroup containing all named fragments
-            cache_directory: Directory for caching polymer SDF files
-            max_retries: Maximum attempts for building (ring-piercing failures)
-            charger_type: Charge method ("nagl", "espaloma", "am1bcc")
+        Parameters
+        ----------
+        monomer_group : MonomerGroup
+            MonomerGroup containing all named fragments.
+        cache_directory : Path
+            Directory for caching polymer SDF files.
+        max_retries : int, optional
+            Maximum attempts for building after ring-piercing failures, by default 10.
+        charger_type : str, optional
+            Charge method, by default "nagl".
         """
         self.monomer_group = monomer_group
         self.cache_directory = Path(cache_directory)
@@ -92,13 +271,30 @@ class PolymerGenerator:
 
     @property
     def charger(self):
-        """Get the molecular charger (lazy-loaded)."""
+        """Get the molecular charger lazily.
+
+        Returns
+        -------
+        Any
+            Molecular charger for the configured charge method.
+        """
         if self._charger is None:
             self._charger = self._create_charger()
         return self._charger
 
     def _create_charger(self):
-        """Create the appropriate charger based on charger_type."""
+        """Create the appropriate charger based on ``charger_type``.
+
+        Returns
+        -------
+        Any
+            Polymerist molecular charger.
+
+        Raises
+        ------
+        ValueError
+            If ``charger_type`` is unknown.
+        """
         if self.charger_type == "nagl":
             from polymerist.mdtools.openfftools.partialcharge.molchargers import (
                 NAGLCharger,
@@ -123,63 +319,585 @@ class PolymerGenerator:
     def _get_terminal_fragment_name(self, monomer_name: str) -> str:
         """Get the 1-site fragment name for a monomer (terminal position).
 
-        Args:
-            monomer_name: Base monomer name (e.g., "SBMA")
+        Parameters
+        ----------
+        monomer_name : str
+            Base monomer name, such as "SBMA".
 
-        Returns:
-            Fragment name for 1-site (e.g., "SBMA_1-site")
+        Returns
+        -------
+        str
+            Fragment name for 1-site, such as "SBMA_1-site".
+
+        Raises
+        ------
+        ValueError
+            If the terminal fragment is unavailable.
         """
-        # Look for matching 1-site fragment in monomer_group
-        for frag_name in self.monomer_group.monomers.keys():
-            if frag_name.startswith(monomer_name) and "_1-site" in frag_name:
-                return frag_name
+        frag_name = f"{monomer_name}_1-site"
+        if frag_name in self.monomer_group.monomers:
+            return frag_name
 
         raise ValueError(f"No 1-site terminal fragment found for monomer: {monomer_name}")
 
     def _get_middle_fragment_name(self, monomer_name: str) -> str:
         """Get the 2-site fragment name for a monomer (middle position).
 
-        Args:
-            monomer_name: Base monomer name (e.g., "SBMA")
+        Parameters
+        ----------
+        monomer_name : str
+            Base monomer name, such as "SBMA".
 
-        Returns:
-            Fragment name for 2-site (e.g., "SBMA_2-site")
+        Returns
+        -------
+        str
+            Fragment name for 2-site, such as "SBMA_2-site".
+
+        Raises
+        ------
+        ValueError
+            If the middle fragment is unavailable.
         """
-        # Look for matching 2-site fragment in monomer_group
-        for frag_name in self.monomer_group.monomers.keys():
-            if frag_name.startswith(monomer_name) and "_2-site" in frag_name:
-                return frag_name
+        frag_name = f"{monomer_name}_2-site"
+        if frag_name in self.monomer_group.monomers:
+            return frag_name
 
         raise ValueError(f"No 2-site middle fragment found for monomer: {monomer_name}")
+
+    def _build_middle_sequence_map(
+        self,
+        middle_sequence: str,
+        monomer_names: dict[str, str],
+    ) -> dict[str, str]:
+        """Build an explicit Polymerist sequence map for middle monomers.
+
+        Parameters
+        ----------
+        middle_sequence : str
+            Sequence labels excluding terminal monomers.
+        monomer_names : dict[str, str]
+            Mapping of sequence labels to monomer names.
+
+        Returns
+        -------
+        dict[str, str]
+            Mapping of middle sequence labels to exact 2-site fragment names.
+
+        Raises
+        ------
+        ValueError
+            If a sequence label or fragment is unavailable.
+        """
+        labels_used = _validate_dynamic_sequence_labels(middle_sequence, monomer_names)
+        sequence_map = {}
+        for label in labels_used:
+            sequence_map[label] = self._get_middle_fragment_name(monomer_names[label])
+
+        return sequence_map
+
+    def _build_dynamic_cache_metadata(
+        self,
+        sequence: str,
+        monomer_names: dict[str, str],
+        residue_names: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Build dynamic-cache metadata for a generated charged polymer.
+
+        Parameters
+        ----------
+        sequence : str
+            Polymer sequence string.
+        monomer_names : dict[str, str]
+            Mapping of sequence labels to monomer names.
+        residue_names : dict[str, str] | None, optional
+            Optional mapping of monomer names to residue names.
+
+        Returns
+        -------
+        dict[str, Any]
+            Metadata payload used to validate dynamic cached SDF files.
+        """
+        self._validate_dynamic_sequence_length(sequence)
+        head_label = sequence[0]
+        tail_label = sequence[-1]
+        middle_sequence = sequence[1:-1] if len(sequence) > 2 else ""
+        labels_used = _validate_dynamic_sequence_labels(sequence, monomer_names)
+
+        head_monomer = monomer_names[head_label]
+        tail_monomer = monomer_names[tail_label]
+        sequence_map = self._build_middle_sequence_map(middle_sequence, monomer_names)
+        terminal_fragments = {
+            "head": self._get_terminal_fragment_name(head_monomer),
+            "tail": self._get_terminal_fragment_name(tail_monomer),
+        }
+        used_fragment_names = sorted(set(terminal_fragments.values()) | set(sequence_map.values()))
+        monomer_names_used = {label: monomer_names[label] for label in labels_used}
+        residue_names_used = self._build_used_residue_names(monomer_names_used, residue_names)
+
+        return {
+            "schema_version": DYNAMIC_CACHE_SCHEMA_VERSION,
+            "charger_type": self.charger_type,
+            "sequence": sequence,
+            "middle_sequence": middle_sequence,
+            "monomer_names_used": monomer_names_used,
+            "residue_names_used": residue_names_used,
+            "terminal_fragments": terminal_fragments,
+            "sequence_map": sequence_map,
+            "used_fragment_names": used_fragment_names,
+            "monomer_group_fingerprint": self._build_monomer_group_fingerprint(),
+        }
+
+    def _validate_dynamic_sequence_length(self, sequence: str) -> None:
+        """Validate that a sequence can be generated through Polymerist.
+
+        Parameters
+        ----------
+        sequence : str
+            Polymer sequence string to validate.
+
+        Raises
+        ------
+        ValueError
+            If ``sequence`` is too short for dynamic generation.
+        """
+        if len(sequence) < 3:
+            raise ValueError(
+                "Dynamic polymer generation requires sequence length >= 3 because Polymerist "
+                "requires a non-empty middle sequence"
+            )
+
+    def _build_used_residue_names(
+        self,
+        monomer_names_used: dict[str, str],
+        residue_names: dict[str, str] | None,
+    ) -> dict[str, str]:
+        """Build a metadata subset of residue names used by a sequence.
+
+        Parameters
+        ----------
+        monomer_names_used : dict[str, str]
+            Sequence-label-to-monomer-name mapping for labels used by a sequence.
+        residue_names : dict[str, str] | None
+            Optional monomer-name-to-residue-name mapping.
+
+        Returns
+        -------
+        dict[str, str]
+            Residue names keyed by monomer name for used monomers.
+        """
+        if residue_names is None:
+            return {}
+
+        used_monomers = set(monomer_names_used.values())
+        return {
+            monomer_name: residue_name
+            for monomer_name, residue_name in sorted(residue_names.items())
+            if monomer_name in used_monomers
+        }
+
+    def _build_monomer_group_fingerprint(self) -> dict[str, Any]:
+        """Build a deterministic fingerprint for MonomerGroup contents.
+
+        The fingerprint is based on sorted fragment names and deterministic
+        chemistry representations where available, rather than object identity
+        or Python's process-randomized ``hash()``.
+
+        Returns
+        -------
+        dict[str, Any]
+            Fingerprint payload with algorithm, digest, and fragment entries.
+        """
+        fragment_entries = {
+            fragment_name: self._fingerprint_fragment(fragment)
+            for fragment_name, fragment in sorted(self.monomer_group.monomers.items())
+        }
+        digest_payload = json.dumps(fragment_entries, sort_keys=True, separators=(",", ":"))
+
+        return {
+            "algorithm": "polyzymd-monomer-group-sha256-v2",
+            "digest": hashlib.sha256(digest_payload.encode("utf-8")).hexdigest(),
+            "fragments": fragment_entries,
+        }
+
+    def _fingerprint_fragment(self, fragment: Any) -> dict[str, Any]:
+        """Build a deterministic fingerprint entry for one fragment.
+
+        Parameters
+        ----------
+        fragment : Any
+            Fragment chemistry object stored in a MonomerGroup.
+
+        Returns
+        -------
+        dict[str, Any]
+            Fragment fingerprint entry.
+        """
+        chemistry = self._fragment_chemistry_payload(fragment)
+        digest_payload = json.dumps(chemistry, sort_keys=True, separators=(",", ":"))
+        return {
+            "algorithm": "polyzymd-fragment-sha256-v2",
+            "digest": hashlib.sha256(digest_payload.encode("utf-8")).hexdigest(),
+            "chemistry": chemistry,
+        }
+
+    def _fragment_chemistry_payload(self, fragment: Any) -> dict[str, Any]:
+        """Convert a fragment object into deterministic chemistry metadata.
+
+        Parameters
+        ----------
+        fragment : Any
+            Fragment chemistry object stored in a MonomerGroup.
+
+        Returns
+        -------
+        dict[str, Any]
+            Deterministic chemistry payload suitable for JSON hashing.
+        """
+        if self._is_json_fingerprint_value(fragment):
+            return {
+                "kind": "json_value",
+                "value": self._to_json_stable(fragment),
+            }
+
+        rdkit_payload = self._rdkit_mol_payload(fragment)
+        if rdkit_payload is not None:
+            return rdkit_payload
+
+        for method_name in ("to_smiles", "to_smiles_explicit_hydrogens"):
+            method = getattr(fragment, method_name, None)
+            if method is None:
+                continue
+            smiles = self._call_smiles_method(method)
+            if smiles:
+                return {
+                    "kind": method_name,
+                    "value": self._canonicalize_smiles(smiles) or smiles,
+                }
+
+        to_rdkit = getattr(fragment, "to_rdkit", None)
+        if to_rdkit is not None:
+            try:
+                rdkit_payload = self._rdkit_mol_payload(to_rdkit())
+            except (TypeError, ValueError, RuntimeError):
+                rdkit_payload = None
+            if rdkit_payload is not None:
+                return rdkit_payload
+
+        public_state = self._stable_public_state(fragment)
+        return {
+            "kind": "public_state",
+            "class": f"{type(fragment).__module__}.{type(fragment).__qualname__}",
+            "value": public_state,
+        }
+
+    def _is_json_fingerprint_value(self, value: Any) -> bool:
+        """Return whether a value can be fingerprinted as deterministic JSON.
+
+        Parameters
+        ----------
+        value : Any
+            Candidate fragment value.
+
+        Returns
+        -------
+        bool
+            True for recursively supported JSON-like values.
+        """
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return True
+        if isinstance(value, (list, tuple)):
+            return all(self._is_json_fingerprint_value(item) for item in value)
+        if isinstance(value, dict):
+            return all(
+                self._is_json_fingerprint_value(key) and self._is_json_fingerprint_value(item)
+                for key, item in value.items()
+            )
+        return False
+
+    def _canonicalize_smiles(self, smiles: str) -> str | None:
+        """Canonicalize a SMILES string when RDKit is available.
+
+        Parameters
+        ----------
+        smiles : str
+            SMILES string to canonicalize.
+
+        Returns
+        -------
+        str | None
+            Canonical isomeric SMILES, or None if canonicalization fails.
+        """
+        try:
+            from rdkit import Chem
+        except ImportError:
+            return None
+
+        try:
+            mol = Chem.MolFromSmiles(smiles)
+        except AttributeError:
+            return None
+        if mol is None:
+            return None
+        try:
+            return Chem.MolToSmiles(mol, canonical=True, isomericSmiles=True)
+        except AttributeError:
+            return None
+
+    def _rdkit_mol_payload(self, fragment: Any) -> dict[str, str] | None:
+        """Build a payload from an RDKit molecule-like object.
+
+        Parameters
+        ----------
+        fragment : Any
+            Potential RDKit molecule-like object.
+
+        Returns
+        -------
+        dict[str, str] | None
+            RDKit payload, or None when the object is not supported.
+        """
+        try:
+            from rdkit import Chem
+        except ImportError:
+            return None
+
+        if not hasattr(fragment, "GetNumAtoms"):
+            return None
+
+        try:
+            smiles = Chem.MolToSmiles(fragment, canonical=True, isomericSmiles=True)
+        except (AttributeError, TypeError, ValueError, RuntimeError):
+            return None
+
+        return {"kind": "rdkit_mol", "value": smiles}
+
+    def _call_smiles_method(self, method: Any) -> str | None:
+        """Call a fragment SMILES method using common OpenFF signatures.
+
+        Parameters
+        ----------
+        method : Any
+            Bound SMILES-producing method.
+
+        Returns
+        -------
+        str | None
+            SMILES string, or None if no supported call succeeds.
+        """
+        call_kwargs = (
+            {"mapped": False, "isomeric": True, "explicit_hydrogens": True},
+            {"isomeric": True, "explicit_hydrogens": True},
+            {},
+        )
+        for kwargs in call_kwargs:
+            try:
+                smiles = method(**kwargs)
+            except (TypeError, ValueError, RuntimeError):
+                continue
+            if isinstance(smiles, str) and smiles:
+                return smiles
+        return None
+
+    def _stable_public_state(self, fragment: Any) -> Any:
+        """Extract JSON-stable public state from a fragment object.
+
+        Parameters
+        ----------
+        fragment : Any
+            Fragment object without an available chemistry serializer.
+
+        Returns
+        -------
+        Any
+            JSON-stable public state used as a deterministic fallback.
+        """
+        try:
+            state = vars(fragment)
+        except TypeError:
+            return str(type(fragment))
+
+        public_state = {
+            key: self._to_json_stable(value)
+            for key, value in sorted(state.items())
+            if not key.startswith("_")
+        }
+        return public_state
+
+    def _to_json_stable(self, value: Any) -> Any:
+        """Convert a value into a JSON-stable representation.
+
+        Parameters
+        ----------
+        value : Any
+            Value from public fragment state.
+
+        Returns
+        -------
+        Any
+            JSON-serializable representation without memory addresses.
+        """
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, Path):
+            return str(value)
+        if isinstance(value, dict):
+            return {
+                str(key): self._to_json_stable(item)
+                for key, item in sorted(value.items(), key=lambda entry: str(entry[0]))
+            }
+        if isinstance(value, (list, tuple)):
+            return [self._to_json_stable(item) for item in value]
+        if isinstance(value, set):
+            return sorted(self._to_json_stable(item) for item in value)
+        return f"{type(value).__module__}.{type(value).__qualname__}"
+
+    def _get_dynamic_cache_metadata_path(self, charged_sdf_path: Path) -> Path:
+        """Get the metadata sidecar path for a dynamic cached charged SDF.
+
+        Parameters
+        ----------
+        charged_sdf_path : Path
+            Path to a charged dynamic-cache SDF file.
+
+        Returns
+        -------
+        Path
+            Path to the JSON metadata sidecar.
+        """
+        return charged_sdf_path.with_name(f"{charged_sdf_path.name}.metadata.json")
+
+    def _dynamic_cache_metadata_matches(
+        self,
+        charged_sdf_path: Path,
+        sequence: str,
+        monomer_names: dict[str, str],
+        residue_names: dict[str, str] | None = None,
+    ) -> bool:
+        """Return whether a dynamic charged SDF has matching metadata.
+
+        Parameters
+        ----------
+        charged_sdf_path : Path
+            Path to a charged dynamic-cache SDF file.
+        sequence : str
+            Polymer sequence string.
+        monomer_names : dict[str, str]
+            Mapping of sequence labels to monomer names.
+        residue_names : dict[str, str] | None, optional
+            Optional mapping of monomer names to residue names.
+
+        Returns
+        -------
+        bool
+            True if the metadata sidecar exists and exactly matches expectations.
+        """
+        metadata_path = self._get_dynamic_cache_metadata_path(charged_sdf_path)
+        if not metadata_path.exists():
+            logger.warning(
+                "Ignoring dynamic polymer cache without metadata sidecar: %s",
+                charged_sdf_path,
+            )
+            return False
+
+        try:
+            cached_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            logger.warning(
+                "Ignoring dynamic polymer cache with invalid metadata: %s", metadata_path
+            )
+            return False
+        if not isinstance(cached_metadata, dict):
+            logger.warning(
+                "Ignoring dynamic polymer cache with non-object metadata: %s", metadata_path
+            )
+            return False
+
+        expected_metadata = self._build_dynamic_cache_metadata(
+            sequence,
+            monomer_names,
+            residue_names,
+        )
+        if cached_metadata != expected_metadata:
+            mismatched_fields = sorted(
+                field
+                for field in set(cached_metadata) | set(expected_metadata)
+                if cached_metadata.get(field) != expected_metadata.get(field)
+            )
+            logger.warning(
+                "Ignoring dynamic polymer cache with mismatched metadata fields %s: %s",
+                mismatched_fields,
+                metadata_path,
+            )
+            return False
+
+        return True
+
+    def _write_dynamic_cache_metadata(
+        self,
+        charged_sdf_path: Path,
+        sequence: str,
+        monomer_names: dict[str, str],
+        residue_names: dict[str, str] | None = None,
+    ) -> None:
+        """Write metadata for a dynamic cached charged SDF.
+
+        Parameters
+        ----------
+        charged_sdf_path : Path
+            Path to a charged dynamic-cache SDF file.
+        sequence : str
+            Polymer sequence string.
+        monomer_names : dict[str, str]
+            Mapping of sequence labels to monomer names.
+        residue_names : dict[str, str] | None, optional
+            Optional mapping of monomer names to residue names.
+        """
+        metadata_path = self._get_dynamic_cache_metadata_path(charged_sdf_path)
+        metadata = self._build_dynamic_cache_metadata(sequence, monomer_names, residue_names)
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
 
     def _build_polymer_structure(
         self,
         sequence: str,
-        monomer_names: Dict[str, str],
-        residue_names: Optional[Dict[str, str]] = None,
-    ) -> Tuple[any, Path]:
+        monomer_names: dict[str, str],
+        residue_names: dict[str, str] | None = None,
+    ) -> tuple[Any, Path]:
         """Build a polymer 3D structure from sequence.
 
         The sequence parameter should be a string of block identifiers (e.g., "ABCAB")
         where each character maps to a monomer via the monomer_names dict.
 
         Polymerist's build_linear_polymer expects:
+
         - Terminal fragments set via monogrp.term_orient (head/tail)
         - A middle sequence of block identifiers (omitting head/tail)
-        - The block identifiers are mapped to 2-site fragments by Polymerist
-          via zip ordering with MonomerGroup iteration
+        - An explicit sequence_map that maps middle labels to 2-site fragments
 
-        Args:
-            sequence: Polymer sequence string (e.g., "ABCAB")
-            monomer_names: Mapping of sequence labels to monomer names
-            residue_names: Optional mapping of monomer names to 3-char residue names
+        Parameters
+        ----------
+        sequence : str
+            Polymer sequence string, such as "ABCAB".
+        monomer_names : dict[str, str]
+            Mapping of sequence labels to monomer names.
+        residue_names : dict[str, str] | None, optional
+            Optional mapping of monomer names to 3-char residue names.
 
-        Returns:
-            Tuple of (mbuild compound, path to PDB file)
+        Returns
+        -------
+        tuple[Any, Path]
+            Tuple of the mBuild compound and path to the PDB file.
 
-        Raises:
-            PolymerGenerationError: If building fails after max_retries
+        Raises
+        ------
+        PolymerGenerationError
+            If building fails after ``max_retries``.
         """
+        self._validate_dynamic_sequence_length(sequence)
+        _validate_dynamic_sequence_labels(sequence, monomer_names)
+
         # Parse sequence - head and tail are terminals, middle is for repeating
         head_label = sequence[0]
         tail_label = sequence[-1]
@@ -189,34 +907,38 @@ class PolymerGenerator:
         tail_monomer = monomer_names[tail_label]
 
         # Set terminal orientations - these determine the 1-site end groups
-        monogrp_local = MonomerGroup(monomers=self.monomer_group.monomers)
+        monogrp_local = _make_monomer_group(self.monomer_group.monomers)
         monogrp_local.term_orient = {
             "head": self._get_terminal_fragment_name(head_monomer),
             "tail": self._get_terminal_fragment_name(tail_monomer),
         }
+        sequence_map = self._build_middle_sequence_map(middle_sequence, monomer_names)
 
         logger.debug(
-            f"Terminal orientations: head={monogrp_local.term_orient['head']}, tail={monogrp_local.term_orient['tail']}"
+            "Terminal orientations: head=%s, tail=%s",
+            monogrp_local.term_orient["head"],
+            monogrp_local.term_orient["tail"],
         )
         logger.debug(f"Middle sequence (block identifiers): {middle_sequence}")
+        logger.debug(f"Middle sequence map: {sequence_map}")
 
         # Attempt building with retries for ring-piercing
         for attempt in range(self.max_retries):
             logger.debug(f"Building polymer attempt {attempt + 1}/{self.max_retries}")
 
-            # Pass the raw middle sequence - Polymerist will map block identifiers
-            # to 2-site fragments based on zip ordering with MonomerGroup iteration
-            chain = build_linear_polymer(
+            # Pin label-to-fragment mapping because Polymerist defaults are order-dependent
+            chain = _build_linear_polymer(
                 monomers=monogrp_local,
                 n_monomers=len(sequence),
                 sequence=middle_sequence,
+                sequence_map=sequence_map,
                 energy_minimize=True,
                 allow_partial_sequences=True,
             )
 
             # Check for ring-piercing
-            poly_mol = mbmol_to_rdmol(chain)
-            piercing_summary = summarize_ring_piercing(poly_mol)
+            poly_mol = _mbmol_to_rdmol(chain)
+            piercing_summary = _summarize_ring_piercing(poly_mol)
 
             if not piercing_summary:
                 logger.info(f"Polymer built successfully on attempt {attempt + 1}")
@@ -235,24 +957,29 @@ class PolymerGenerator:
         pdb_path = self.cache_directory / f"{pdb_filename}.pdb"
 
         resname_map = self._build_resname_map(monomer_names, residue_names)
-        mbmol_to_openmm_pdb(pdb_path, chain, resname_map=resname_map)
+        _mbmol_to_openmm_pdb(pdb_path, chain, resname_map=resname_map)
         logger.info(f"Saved polymer PDB: {pdb_path}")
 
         return chain, pdb_path
 
     def _build_resname_map(
         self,
-        monomer_names: Dict[str, str],
-        residue_names: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, str]:
+        monomer_names: dict[str, str],
+        residue_names: dict[str, str] | None = None,
+    ) -> dict[str, str]:
         """Build residue name mapping for PDB output.
 
-        Args:
-            monomer_names: Mapping of labels to monomer names
-            residue_names: Optional custom residue names
+        Parameters
+        ----------
+        monomer_names : dict[str, str]
+            Mapping of labels to monomer names.
+        residue_names : dict[str, str] | None, optional
+            Optional custom residue names.
 
-        Returns:
-            Mapping of fragment names to 3-char residue names
+        Returns
+        -------
+        dict[str, str]
+            Mapping of fragment names to 3-char residue names.
         """
         resname_map = {}
         for label, monomer_name in monomer_names.items():
@@ -275,24 +1002,26 @@ class PolymerGenerator:
     def _make_polymer_filename(
         self,
         sequence: str,
-        monomer_names: Dict[str, str],
+        monomer_names: dict[str, str],
         charged: bool = True,
     ) -> str:
         """Create a descriptive filename for a polymer.
 
-        Args:
-            sequence: Polymer sequence string
-            monomer_names: Mapping of labels to monomer names
-            charged: Whether this is a charged structure
+        Parameters
+        ----------
+        sequence : str
+            Polymer sequence string.
+        monomer_names : dict[str, str]
+            Mapping of labels to monomer names.
+        charged : bool, optional
+            Whether this is a charged structure, by default True.
 
-        Returns:
-            Filename without extension
+        Returns
+        -------
+        str
+            Filename without extension.
         """
-        # Get unique monomers in sequence order
-        unique_labels = []
-        for label in sequence:
-            if label not in unique_labels:
-                unique_labels.append(label)
+        unique_labels = _validate_dynamic_sequence_labels(sequence, monomer_names)
 
         # Build monomer prefix
         monomers_used = [monomer_names[label] for label in unique_labels]
@@ -308,41 +1037,63 @@ class PolymerGenerator:
     def generate_polymer(
         self,
         sequence: str,
-        monomer_names: Dict[str, str],
-        residue_names: Optional[Dict[str, str]] = None,
+        monomer_names: dict[str, str],
+        residue_names: dict[str, str] | None = None,
         force_regenerate: bool = False,
     ) -> "OFFMolecule":
         """Generate a complete, charged polymer molecule.
 
         This method handles the full workflow:
-        1. Check cache for existing charged SDF
-        2. Build 3D structure if needed
-        3. Create OpenFF topology
-        4. Assign partial charges
-        5. Cache the result
 
-        Args:
-            sequence: Polymer sequence string (e.g., "ABCAB")
-            monomer_names: Mapping of sequence labels to monomer names
-            residue_names: Optional mapping of monomer names to 3-char residue names
-            force_regenerate: If True, regenerate even if cached
+        - Check cache for an existing charged SDF
+        - Build a 3D structure if needed
+        - Create an OpenFF topology
+        - Assign partial charges
+        - Cache the result
 
-        Returns:
-            OpenFF Molecule with partial charges assigned
+        Parameters
+        ----------
+        sequence : str
+            Polymer sequence string, such as "ABCAB".
+        monomer_names : dict[str, str]
+            Mapping of sequence labels to monomer names.
+        residue_names : dict[str, str] | None, optional
+            Optional mapping of monomer names to 3-char residue names.
+        force_regenerate : bool, optional
+            If True, regenerate even if cached, by default False.
 
-        Raises:
-            PolymerGenerationError: If generation fails
+        Returns
+        -------
+        OFFMolecule
+            OpenFF Molecule with partial charges assigned.
+
+        Raises
+        ------
+        PolymerGenerationError
+            If generation fails.
         """
+        self._validate_dynamic_sequence_length(sequence)
+        _validate_dynamic_sequence_labels(sequence, monomer_names)
+
         from openff.toolkit import Topology as OFFTopology
 
         # Check cache
         charged_filename = self._make_polymer_filename(sequence, monomer_names, charged=True)
         charged_sdf_path = self.cache_directory / f"{charged_filename}.sdf"
 
-        if charged_sdf_path.exists() and not force_regenerate:
+        if (
+            charged_sdf_path.exists()
+            and not force_regenerate
+            and self._dynamic_cache_metadata_matches(
+                charged_sdf_path,
+                sequence,
+                monomer_names,
+                residue_names,
+            )
+        ):
             logger.info(f"Loading cached polymer from {charged_sdf_path}")
-            off_top = topology_from_sdf(charged_sdf_path)
-            return get_largest_offmol(off_top)
+            off_top = _topology_from_sdf(charged_sdf_path)
+            return _get_largest_offmol(off_top)
 
         # Build structure
         chain, pdb_path = self._build_polymer_structure(sequence, monomer_names, residue_names)
@@ -355,7 +1106,7 @@ class PolymerGenerator:
         off_top = OFFTopology.from_pdb(
             str(pdb_path), _custom_substructures=self.monomer_group.monomers
         )
-        was_partitioned = partition(off_top)
+        was_partitioned = _partition(off_top)
         if not was_partitioned:
             raise PolymerGenerationError("Failed to partition polymer topology")
 
@@ -367,36 +1118,43 @@ class PolymerGenerator:
                     atom.metadata["residue_name"] = atom.metadata["residue_name"][:3]
 
         # Save uncharged SDF
-        topology_to_sdf(uncharged_sdf_path, off_top)
+        _topology_to_sdf(uncharged_sdf_path, off_top)
         logger.info(f"Saved uncharged SDF: {uncharged_sdf_path}")
 
         # Assign partial charges
         logger.info(f"Assigning partial charges using {self.charger_type}...")
-        off_mol = get_largest_offmol(off_top)
+        off_mol = _get_largest_offmol(off_top)
         charged_mol = self.charger.charge_molecule(off_mol)
 
         # Save charged SDF
         charged_top = charged_mol.to_topology()
-        topology_to_sdf(charged_sdf_path, charged_top)
+        _topology_to_sdf(charged_sdf_path, charged_top)
+        self._write_dynamic_cache_metadata(charged_sdf_path, sequence, monomer_names, residue_names)
         logger.info(f"Saved charged SDF: {charged_sdf_path}")
 
         return charged_mol
 
     def generate_polymers_batch(
         self,
-        sequences: List[str],
-        monomer_names: Dict[str, str],
-        residue_names: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, "OFFMolecule"]:
+        sequences: list[str],
+        monomer_names: dict[str, str],
+        residue_names: dict[str, str] | None = None,
+    ) -> dict[str, "OFFMolecule"]:
         """Generate multiple polymers (sequential processing).
 
-        Args:
-            sequences: List of polymer sequences to generate
-            monomer_names: Mapping of sequence labels to monomer names
-            residue_names: Optional mapping of monomer names to 3-char residue names
+        Parameters
+        ----------
+        sequences : list[str]
+            List of polymer sequences to generate.
+        monomer_names : dict[str, str]
+            Mapping of sequence labels to monomer names.
+        residue_names : dict[str, str] | None, optional
+            Optional mapping of monomer names to 3-char residue names.
 
-        Returns:
-            Dictionary mapping sequence -> OpenFF Molecule
+        Returns
+        -------
+        dict[str, OFFMolecule]
+            Dictionary mapping sequence to OpenFF Molecule.
         """
         results = {}
         for i, sequence in enumerate(sequences):
@@ -413,22 +1171,38 @@ class PolymerGenerator:
     def get_cached_polymer(
         self,
         sequence: str,
-        monomer_names: Dict[str, str],
-    ) -> Optional["OFFMolecule"]:
+        monomer_names: dict[str, str],
+        residue_names: dict[str, str] | None = None,
+    ) -> "OFFMolecule" | None:
         """Load a polymer from cache if it exists.
 
-        Args:
-            sequence: Polymer sequence string
-            monomer_names: Mapping of labels to monomer names
+        Parameters
+        ----------
+        sequence : str
+            Polymer sequence string.
+        monomer_names : dict[str, str]
+            Mapping of labels to monomer names.
+        residue_names : dict[str, str] | None, optional
+            Optional mapping of monomer names to residue names.
 
-        Returns:
-            OpenFF Molecule if cached, None otherwise
+        Returns
+        -------
+        OFFMolecule | None
+            OpenFF Molecule if cached, otherwise None.
         """
+        self._validate_dynamic_sequence_length(sequence)
+        _validate_dynamic_sequence_labels(sequence, monomer_names)
+
         charged_filename = self._make_polymer_filename(sequence, monomer_names, charged=True)
         charged_sdf_path = self.cache_directory / f"{charged_filename}.sdf"
 
-        if charged_sdf_path.exists():
-            off_top = topology_from_sdf(charged_sdf_path)
-            return get_largest_offmol(off_top)
+        if charged_sdf_path.exists() and self._dynamic_cache_metadata_matches(
+            charged_sdf_path,
+            sequence,
+            monomer_names,
+            residue_names,
+        ):
+            off_top = _topology_from_sdf(charged_sdf_path)
+            return _get_largest_offmol(off_top)
 
         return None

--- a/src/polyzymd/config/schema.py
+++ b/src/polyzymd/config/schema.py
@@ -421,6 +421,12 @@ class PolymerConfig(BaseModel):
             return self
 
         if self.generation_mode == PolymerGenerationMode.DYNAMIC:
+            if self.length < 3:
+                raise ValueError(
+                    "Dynamic generation mode requires 'length' >= 3 because Polymerist "
+                    "requires a non-empty middle sequence"
+                )
+
             # Dynamic mode requires SMILES for all monomers
             missing_smiles = [m.label for m in self.monomers if m.smiles is None]
             if missing_smiles:

--- a/tests/builders/_polymer_generator_helpers.py
+++ b/tests/builders/_polymer_generator_helpers.py
@@ -1,0 +1,150 @@
+"""Shared helpers for polymer generator tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import polyzymd.builders.polymer_generator as polymer_generator_module
+from polyzymd.builders.polymer_generator import PolymerGenerator
+
+
+class FakeMonomerGroup:
+    """Minimal MonomerGroup stand-in for local unit tests."""
+
+    def __init__(self, monomers: dict[str, object]) -> None:
+        """Initialize the fake group with named fragments.
+
+        Parameters
+        ----------
+        monomers : dict[str, object]
+            Fragment payloads keyed by Polymerist-style fragment names.
+        """
+        self.monomers = monomers
+        self.term_orient: dict[str, str] = {}
+
+
+def make_generator(tmp_path: Path, fragment_names: list[str]) -> PolymerGenerator:
+    """Create a PolymerGenerator with fake fragment objects.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary cache directory.
+    fragment_names : list[str]
+        Fragment names to expose through the fake MonomerGroup.
+
+    Returns
+    -------
+    PolymerGenerator
+        Generator configured with a fake MonomerGroup.
+    """
+    monomer_group = FakeMonomerGroup({name: [f"{name}:smarts"] for name in fragment_names})
+    return PolymerGenerator(monomer_group=monomer_group, cache_directory=tmp_path)
+
+
+def make_list_fragment_group(overrides: dict[str, list[str]] | None = None) -> FakeMonomerGroup:
+    """Create a fake MonomerGroup with Polymerist-like list fragment entries.
+
+    Parameters
+    ----------
+    overrides : dict[str, list[str]] | None, optional
+        Fragment payloads to merge into the default fake fragments.
+
+    Returns
+    -------
+    FakeMonomerGroup
+        Fake group with deterministic list-backed fragment values.
+    """
+    fragments = {
+        "EGMA_1-site": ["[C:1]=[C:2]", "[O:3]"],
+        "EGMA_2-site": ["[C:1]-[C:2]", "[O:3]"],
+    }
+    fragments.update(overrides or {})
+    return FakeMonomerGroup(fragments)
+
+
+def patch_structure_build(
+    monkeypatch: pytest.MonkeyPatch,
+    calls: list[dict[str, object]],
+) -> None:
+    """Patch Polymerist structure helpers to capture PolyzyMD boundary calls.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Pytest monkeypatch fixture.
+    calls : list[dict[str, object]]
+        Mutable list that receives keyword arguments passed to the build wrapper.
+    """
+
+    def fake_build_linear_polymer(**kwargs: Any) -> object:
+        """Capture the Polymerist build arguments.
+
+        Parameters
+        ----------
+        **kwargs : Any
+            Keyword arguments from PolyzyMD's Polymerist wrapper.
+
+        Returns
+        -------
+        object
+            Sentinel chain object.
+        """
+        calls.append(kwargs)
+        return object()
+
+    def fake_write_pdb(pdb_path: Path, chain: object, resname_map: dict[str, str]) -> None:
+        """Create the expected PDB output without invoking OpenMM writers.
+
+        Parameters
+        ----------
+        pdb_path : Path
+            Destination PDB path.
+        chain : object
+            Ignored chain sentinel.
+        resname_map : dict[str, str]
+            Ignored residue-name mapping.
+        """
+        pdb_path.write_text("MODEL\nEND\n", encoding="utf-8")
+
+    monkeypatch.setattr(polymer_generator_module, "_make_monomer_group", FakeMonomerGroup)
+    monkeypatch.setattr(
+        polymer_generator_module, "_build_linear_polymer", fake_build_linear_polymer
+    )
+    monkeypatch.setattr(polymer_generator_module, "_mbmol_to_rdmol", lambda chain: object())
+    monkeypatch.setattr(polymer_generator_module, "_summarize_ring_piercing", lambda mol: {})
+    monkeypatch.setattr(polymer_generator_module, "_mbmol_to_openmm_pdb", fake_write_pdb)
+
+
+def write_metadata(
+    generator: PolymerGenerator,
+    sdf_path: Path,
+    sequence: str,
+    monomer_names: dict[str, str],
+    overrides: dict[str, object] | None = None,
+) -> None:
+    """Write dynamic cache metadata with optional top-level overrides.
+
+    Parameters
+    ----------
+    generator : PolymerGenerator
+        Generator used to build the expected metadata payload.
+    sdf_path : Path
+        Charged SDF path whose sidecar should be written.
+    sequence : str
+        Polymer sequence for metadata validation.
+    monomer_names : dict[str, str]
+        Mapping from sequence labels to monomer names.
+    overrides : dict[str, object] | None, optional
+        Values to merge into the generated metadata payload.
+    """
+    metadata = generator._build_dynamic_cache_metadata(sequence, monomer_names)
+    metadata.update(overrides or {})
+    generator._get_dynamic_cache_metadata_path(sdf_path).write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/tests/builders/test_polymer_builder_dynamic_cache.py
+++ b/tests/builders/test_polymer_builder_dynamic_cache.py
@@ -1,0 +1,247 @@
+"""Tests for PolymerBuilder dynamic cache routing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from _polymer_generator_helpers import FakeMonomerGroup, write_metadata
+
+from polyzymd.builders.polymer import PolymerBuilder
+from polyzymd.builders.polymer_generator import PolymerGenerator
+
+
+@pytest.mark.parametrize("length", [1, 2])
+def test_dynamic_builder_rejects_short_lengths(length: int, tmp_path: Path) -> None:
+    """Dynamic builder configuration should reject lengths below three early."""
+    with pytest.raises(ValueError, match="requires length >= 3"):
+        PolymerBuilder(
+            characters=["A"],
+            probabilities=[1.0],
+            length=length,
+            type_prefix="EGMA",
+            cache_directory=tmp_path / "cache",
+            generation_mode="dynamic",
+            monomer_smiles={"EGMA": "CO"},
+            monomer_names={"A": "EGMA"},
+            reactions=object(),
+        )
+
+
+def test_dynamic_builder_routes_cache_directory_hits_through_generator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic mode should not load cache-directory SDFs without metadata validation."""
+    cache_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
+    cache_path.write_text("stale cache", encoding="utf-8")
+    sentinel = object()
+    builder = PolymerBuilder(
+        characters=["A", "B"],
+        probabilities=[0.0, 1.0],
+        length=5,
+        type_prefix="PEGMA",
+        cache_directory=tmp_path,
+        generation_mode="dynamic",
+        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
+        monomer_names={"A": "SBMA", "B": "PEGMA"},
+        reactions=object(),
+    )
+
+    def fail_load_cache(path: Path) -> object:
+        """Fail if PolymerBuilder bypasses dynamic cache validation.
+
+        Parameters
+        ----------
+        path : Path
+            Unexpected cache path.
+
+        Returns
+        -------
+        object
+            Never returned because the test fails first.
+        """
+        pytest.fail(f"Dynamic builder loaded cache directly: {path}")
+
+    monkeypatch.setattr(builder, "_load_from_sdf", fail_load_cache)
+    monkeypatch.setattr(builder, "_generate_polymer", lambda sequence: sentinel)
+
+    assert builder._get_or_create_molecule("BBBBB") is sentinel
+
+
+def test_dynamic_builder_routes_sdf_directory_generated_artifact_through_generator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic mode should not directly load generated-style SDF directory hits."""
+    sdf_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
+    sdf_path.write_text("stale generated artifact", encoding="utf-8")
+    sentinel = object()
+    builder = PolymerBuilder(
+        characters=["A", "B"],
+        probabilities=[0.0, 1.0],
+        length=5,
+        type_prefix="PEGMA",
+        sdf_directory=tmp_path,
+        cache_directory=tmp_path / "cache",
+        generation_mode="dynamic",
+        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
+        monomer_names={"A": "SBMA", "B": "PEGMA"},
+        reactions=object(),
+    )
+    builder._fragment_generator = object()
+    builder._polymer_generator = PolymerGenerator(
+        monomer_group=FakeMonomerGroup(
+            {
+                "SBMA_1-site": ["sbma-terminal"],
+                "SBMA_2-site": ["sbma-middle"],
+                "PEGMA_1-site": ["pegma-terminal"],
+                "PEGMA_2-site": ["pegma-middle"],
+            }
+        ),
+        cache_directory=tmp_path / "cache",
+    )
+
+    def fail_load_cache(path: Path) -> object:
+        """Fail if generated-style SDF loading bypasses validation.
+
+        Parameters
+        ----------
+        path : Path
+            Unexpected cache path.
+
+        Returns
+        -------
+        object
+            Never returned because the test fails first.
+        """
+        pytest.fail(f"Dynamic builder loaded generated-style SDF directly: {path}")
+
+    monkeypatch.setattr(builder, "_load_from_sdf", fail_load_cache)
+    monkeypatch.setattr(builder, "_generate_polymer", lambda sequence: sentinel)
+
+    assert builder._get_or_create_molecule("BBBBB") is sentinel
+
+
+def test_dynamic_builder_loads_generated_sdf_directory_hit_when_metadata_matches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic mode should load generated-style SDF hits with matching metadata."""
+    sdf_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
+    sdf_path.write_text("validated generated artifact", encoding="utf-8")
+    sentinel = object()
+    monomer_group = FakeMonomerGroup(
+        {
+            "SBMA_1-site": ["sbma-terminal"],
+            "SBMA_2-site": ["sbma-middle"],
+            "PEGMA_1-site": ["pegma-terminal"],
+            "PEGMA_2-site": ["pegma-middle"],
+        }
+    )
+    generator = PolymerGenerator(monomer_group=monomer_group, cache_directory=tmp_path / "cache")
+    write_metadata(generator, sdf_path, "BBBBB", {"A": "SBMA", "B": "PEGMA"})
+    builder = PolymerBuilder(
+        characters=["A", "B"],
+        probabilities=[0.0, 1.0],
+        length=5,
+        type_prefix="PEGMA",
+        sdf_directory=tmp_path,
+        cache_directory=tmp_path / "cache",
+        generation_mode="dynamic",
+        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
+        monomer_names={"A": "SBMA", "B": "PEGMA"},
+        reactions=object(),
+    )
+    builder._fragment_generator = object()
+    builder._polymer_generator = generator
+
+    monkeypatch.setattr(builder, "_load_from_sdf", lambda path: sentinel)
+    monkeypatch.setattr(
+        builder,
+        "_generate_polymer",
+        lambda sequence: pytest.fail("Validated generated SDF was not loaded"),
+    )
+
+    assert builder._get_or_create_molecule("BBBBB") is sentinel
+
+
+def test_dynamic_builder_regenerates_generated_sdf_directory_hit_with_stale_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic mode should regenerate generated-style SDF hits with stale metadata."""
+    sdf_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
+    sdf_path.write_text("stale generated artifact", encoding="utf-8")
+    current_group = FakeMonomerGroup(
+        {
+            "SBMA_1-site": ["sbma-terminal"],
+            "SBMA_2-site": ["sbma-middle"],
+            "PEGMA_1-site": ["pegma-terminal"],
+            "PEGMA_2-site": ["pegma-middle"],
+        }
+    )
+    stale_group = FakeMonomerGroup(
+        {
+            "SBMA_1-site": ["sbma-terminal"],
+            "SBMA_2-site": ["sbma-middle"],
+            "PEGMA_1-site": ["pegma-terminal"],
+            "PEGMA_2-site": ["stale-pegma-middle"],
+        }
+    )
+    write_metadata(
+        PolymerGenerator(monomer_group=stale_group, cache_directory=tmp_path / "stale"),
+        sdf_path,
+        "BBBBB",
+        {"A": "SBMA", "B": "PEGMA"},
+    )
+    sentinel = object()
+    builder = PolymerBuilder(
+        characters=["A", "B"],
+        probabilities=[0.0, 1.0],
+        length=5,
+        type_prefix="PEGMA",
+        sdf_directory=tmp_path,
+        cache_directory=tmp_path / "cache",
+        generation_mode="dynamic",
+        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
+        monomer_names={"A": "SBMA", "B": "PEGMA"},
+        reactions=object(),
+    )
+    builder._fragment_generator = object()
+    builder._polymer_generator = PolymerGenerator(
+        monomer_group=current_group,
+        cache_directory=tmp_path / "cache",
+    )
+
+    monkeypatch.setattr(
+        builder,
+        "_load_from_sdf",
+        lambda path: pytest.fail("Stale generated SDF was loaded directly"),
+    )
+    monkeypatch.setattr(builder, "_generate_polymer", lambda sequence: sentinel)
+
+    assert builder._get_or_create_molecule("BBBBB") is sentinel
+
+
+def test_cached_builder_loads_sdf_directory_hit_without_dynamic_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cached mode should continue to load user-provided SDF directory hits."""
+    sdf_path = tmp_path / "EGMA_seq=A_1-mer_charged.sdf"
+    sdf_path.write_text("curated user structure", encoding="utf-8")
+    sentinel = object()
+    builder = PolymerBuilder(
+        characters=["A"],
+        probabilities=[1.0],
+        length=1,
+        type_prefix="EGMA",
+        sdf_directory=tmp_path,
+        cache_directory=tmp_path / "cache",
+        generation_mode="cached",
+    )
+
+    monkeypatch.setattr(builder, "_load_from_sdf", lambda path: sentinel)
+
+    assert builder._get_or_create_molecule("A") is sentinel

--- a/tests/builders/test_polymer_generator.py
+++ b/tests/builders/test_polymer_generator.py
@@ -1,195 +1,21 @@
-"""Regression tests for dynamic polymer generation mapping."""
+"""Pure PolyzyMD unit tests for dynamic polymer generation mapping."""
 
-import importlib
-import importlib.util
-import sys
+from __future__ import annotations
+
+import json
 from pathlib import Path
-from types import ModuleType
 
 import pytest
+from _polymer_generator_helpers import (
+    FakeMonomerGroup,
+    make_generator,
+    make_list_fragment_group,
+    patch_structure_build,
+    write_metadata,
+)
 
-from polyzymd.builders.polymer import PolymerBuilder
-
-REAL_POLYMERIST_AVAILABLE = importlib.util.find_spec("polymerist") is not None
-
-
-def _make_stub_package(name: str) -> ModuleType:
-    """Create a package-like module stub for optional chemistry dependencies."""
-    module = ModuleType(name)
-    module.__path__ = []
-    return module
-
-
-def _install_polymerist_stubs() -> None:
-    """Install minimal Polymerist stubs when the optional dependency is absent."""
-    if importlib.util.find_spec("polymerist") is not None:
-        return
-
-    package_names = [
-        "polymerist",
-        "polymerist.genutils",
-        "polymerist.genutils.fileutils",
-        "polymerist.mdtools",
-        "polymerist.mdtools.openfftools",
-        "polymerist.polymers",
-        "polymerist.rdutils",
-        "polymerist.rdutils.rdcoords",
-    ]
-    for name in package_names:
-        sys.modules.setdefault(name, _make_stub_package(name))
-
-    pathutils = ModuleType("polymerist.genutils.fileutils.pathutils")
-    pathutils.assemble_path = lambda *args, **kwargs: Path(*args)
-    sys.modules.setdefault("polymerist.genutils.fileutils.pathutils", pathutils)
-
-    partition = ModuleType("polymerist.mdtools.openfftools.partition")
-    partition.partition = lambda topology: True
-    sys.modules.setdefault("polymerist.mdtools.openfftools.partition", partition)
-
-    topology = ModuleType("polymerist.mdtools.openfftools.topology")
-    topology.get_largest_offmol = lambda topology: object()
-    topology.topology_from_sdf = lambda path: object()
-    topology.topology_to_sdf = lambda path, topology: None
-    sys.modules.setdefault("polymerist.mdtools.openfftools.topology", topology)
-
-    building = ModuleType("polymerist.polymers.building")
-    building.build_linear_polymer = lambda **kwargs: object()
-    building.mbmol_to_openmm_pdb = lambda *args, **kwargs: None
-    building.mbmol_to_rdmol = lambda chain: object()
-    sys.modules.setdefault("polymerist.polymers.building", building)
-
-    monomers = ModuleType("polymerist.polymers.monomers")
-    monomers.MonomerGroup = FakeMonomerGroup
-    sys.modules.setdefault("polymerist.polymers.monomers", monomers)
-
-    piercing = ModuleType("polymerist.rdutils.rdcoords.piercing")
-    piercing.summarize_ring_piercing = lambda mol: {}
-    sys.modules.setdefault("polymerist.rdutils.rdcoords.piercing", piercing)
-
-
-def _install_rdkit_stubs() -> None:
-    """Install minimal RDKit stubs when the optional dependency is absent."""
-    if importlib.util.find_spec("rdkit") is not None:
-        return
-
-    rdkit = _make_stub_package("rdkit")
-    chem = ModuleType("rdkit.Chem")
-    rdkit.Chem = chem
-    sys.modules.setdefault("rdkit", rdkit)
-    sys.modules.setdefault("rdkit.Chem", chem)
-
-
-class FakeMonomerGroup:
-    """Minimal MonomerGroup stand-in for Polymerist call capture."""
-
-    def __init__(self, monomers: dict[str, object]) -> None:
-        """Initialize the fake group with named fragments."""
-        self.monomers = monomers
-        self.term_orient: dict[str, str] = {}
-
-
-_install_polymerist_stubs()
-_install_rdkit_stubs()
-
-polymer_generator_module = importlib.import_module("polyzymd.builders.polymer_generator")
-PolymerGenerator = polymer_generator_module.PolymerGenerator
-
-
-def _make_generator(tmp_path: Path, fragment_names: list[str]) -> PolymerGenerator:
-    """Create a PolymerGenerator with fake fragment objects."""
-    monomer_group = FakeMonomerGroup({name: [f"{name}:smarts"] for name in fragment_names})
-    return PolymerGenerator(monomer_group=monomer_group, cache_directory=tmp_path)
-
-
-def _make_list_fragment_group(overrides: dict[str, list[str]] | None = None) -> FakeMonomerGroup:
-    """Create a fake MonomerGroup with Polymerist-like list fragment entries."""
-    fragments = {
-        "EGMA_1-site": ["[C:1]=[C:2]", "[O:3]"],
-        "EGMA_2-site": ["[C:1]-[C:2]", "[O:3]"],
-    }
-    fragments.update(overrides or {})
-    return FakeMonomerGroup(fragments)
-
-
-def _require_real_polymerist() -> None:
-    """Skip when Polymerist is not installed and tests use local stubs."""
-    if not REAL_POLYMERIST_AVAILABLE:
-        pytest.skip("Polymerist is not available")
-
-
-def _real_halogen_fragments() -> dict[str, list[str]]:
-    """Create valid Polymerist SMARTS fragments with PolyzyMD monomer names."""
-    _require_real_polymerist()
-
-    from polymerist.polymers.monomers.fragments import HALOGENATED_HYDROCARBON_FRAGMENTS
-
-    return {
-        "SBMA_1-site": HALOGENATED_HYDROCARBON_FRAGMENTS["chlor_term_1"],
-        "SBMA_2-site": HALOGENATED_HYDROCARBON_FRAGMENTS["chlor_mid_1"],
-        "PEGMA_1-site": HALOGENATED_HYDROCARBON_FRAGMENTS["brom_term_1"],
-        "PEGMA_2-site": HALOGENATED_HYDROCARBON_FRAGMENTS["brom_mid_1"],
-    }
-
-
-def _make_real_halogen_monomer_group(overrides: dict[str, list[str]] | None = None):
-    """Create a real Polymerist MonomerGroup backed by list SMARTS data."""
-    _require_real_polymerist()
-
-    from polymerist.polymers.monomers import MonomerGroup
-
-    fragments = _real_halogen_fragments()
-    fragments.update(overrides or {})
-    return MonomerGroup(monomers=fragments)
-
-
-def _count_chain_halogens(chain: object) -> dict[str, int]:
-    """Count diagnostic halogens in a real Polymerist-built chain."""
-    _require_real_polymerist()
-
-    from polymerist.polymers.building import mbmol_to_rdmol
-
-    mol = mbmol_to_rdmol(chain)
-    return {
-        "Br": sum(1 for atom in mol.GetAtoms() if atom.GetSymbol() == "Br"),
-        "Cl": sum(1 for atom in mol.GetAtoms() if atom.GetSymbol() == "Cl"),
-    }
-
-
-def _patch_structure_build(monkeypatch: pytest.MonkeyPatch, calls: list[dict[str, object]]) -> None:
-    """Patch Polymerist structure helpers to avoid chemistry work."""
-
-    def fake_build_linear_polymer(**kwargs):
-        """Capture the Polymerist build arguments."""
-        calls.append(kwargs)
-        return object()
-
-    def fake_write_pdb(pdb_path: Path, chain: object, resname_map: dict[str, str]) -> None:
-        """Create the expected PDB output without invoking OpenMM writers."""
-        pdb_path.write_text("MODEL\nEND\n", encoding="utf-8")
-
-    monkeypatch.setattr(polymer_generator_module, "_make_monomer_group", FakeMonomerGroup)
-    monkeypatch.setattr(
-        polymer_generator_module, "_build_linear_polymer", fake_build_linear_polymer
-    )
-    monkeypatch.setattr(polymer_generator_module, "_mbmol_to_rdmol", lambda chain: object())
-    monkeypatch.setattr(polymer_generator_module, "_summarize_ring_piercing", lambda mol: {})
-    monkeypatch.setattr(polymer_generator_module, "_mbmol_to_openmm_pdb", fake_write_pdb)
-
-
-def _write_metadata(
-    generator: PolymerGenerator,
-    sdf_path: Path,
-    sequence: str,
-    monomer_names: dict[str, str],
-    overrides: dict[str, object] | None = None,
-) -> None:
-    """Write dynamic cache metadata with optional top-level overrides."""
-    metadata = generator._build_dynamic_cache_metadata(sequence, monomer_names)
-    metadata.update(overrides or {})
-    generator._get_dynamic_cache_metadata_path(sdf_path).write_text(
-        polymer_generator_module.json.dumps(metadata, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+import polyzymd.builders.polymer_generator as polymer_generator_module
+from polyzymd.builders.polymer_generator import PolymerGenerator
 
 
 def test_two_monomer_b_sequence_uses_explicit_pegma_middle_mapping(
@@ -198,8 +24,8 @@ def test_two_monomer_b_sequence_uses_explicit_pegma_middle_mapping(
 ) -> None:
     """BBBBB should pass BBB and map B to the PEGMA 2-site fragment."""
     calls: list[dict[str, object]] = []
-    _patch_structure_build(monkeypatch, calls)
-    generator = _make_generator(
+    patch_structure_build(monkeypatch, calls)
+    generator = make_generator(
         tmp_path,
         ["SBMA_1-site", "SBMA_2-site", "PEGMA_1-site", "PEGMA_2-site"],
     )
@@ -216,8 +42,8 @@ def test_two_monomer_b_sequence_uses_pegma_terminal_fragments(
 ) -> None:
     """BBBBB should set both terminal orientations to PEGMA 1-site fragments."""
     calls: list[dict[str, object]] = []
-    _patch_structure_build(monkeypatch, calls)
-    generator = _make_generator(
+    patch_structure_build(monkeypatch, calls)
+    generator = make_generator(
         tmp_path,
         ["SBMA_1-site", "SBMA_2-site", "PEGMA_1-site", "PEGMA_2-site"],
     )
@@ -229,54 +55,14 @@ def test_two_monomer_b_sequence_uses_pegma_terminal_fragments(
     assert monomer_group.term_orient == {"head": "PEGMA_1-site", "tail": "PEGMA_1-site"}
 
 
-def test_real_polymerist_sequence_map_keeps_b_middle_on_pegma_fragment(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """BBBBB should build with PEGMA middle fragments through real Polymerist."""
-    _require_real_polymerist()
-
-    from polymerist.polymers.building import build_linear_polymer
-
-    def fake_write_pdb(pdb_path: Path, chain: object, resname_map: dict[str, str]) -> None:
-        """Create the expected PDB output after the real chain build."""
-        pdb_path.write_text("MODEL\nEND\n", encoding="utf-8")
-
-    unmapped_group = _make_real_halogen_monomer_group()
-    unmapped_group.term_orient = {"head": "PEGMA_1-site", "tail": "PEGMA_1-site"}
-    unmapped_chain = build_linear_polymer(
-        monomers=unmapped_group,
-        n_monomers=5,
-        sequence="BBB",
-        energy_minimize=False,
-        allow_partial_sequences=True,
-    )
-    assert _count_chain_halogens(unmapped_chain) == {"Br": 2, "Cl": 3}
-
-    monkeypatch.setattr(polymer_generator_module, "_mbmol_to_openmm_pdb", fake_write_pdb)
-    generator = PolymerGenerator(
-        monomer_group=_make_real_halogen_monomer_group(),
-        cache_directory=tmp_path,
-        max_retries=1,
-    )
-
-    chain, pdb_path = generator._build_polymer_structure(
-        "BBBBB",
-        {"A": "SBMA", "B": "PEGMA"},
-    )
-
-    assert pdb_path.exists()
-    assert _count_chain_halogens(chain) == {"Br": 5, "Cl": 0}
-
-
 def test_single_monomer_sequence_uses_explicit_egma_middle_mapping(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """AAAAA should pass an explicit EGMA mapping instead of Polymerist defaults."""
     calls: list[dict[str, object]] = []
-    _patch_structure_build(monkeypatch, calls)
-    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+    patch_structure_build(monkeypatch, calls)
+    generator = make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
 
     generator._build_polymer_structure("AAAAA", {"A": "EGMA"})
 
@@ -289,12 +75,23 @@ def test_stale_dynamic_cache_without_metadata_is_not_loaded(
     tmp_path: Path,
 ) -> None:
     """A dynamic charged SDF without metadata should not be directly reused."""
-    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+    generator = make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
     cache_path = tmp_path / "EGMA_seq=AAAAA_5-mer_charged.sdf"
     cache_path.write_text("stale cache", encoding="utf-8")
 
     def fail_load_cache(path: Path) -> object:
-        """Fail if stale SDF loading is attempted."""
+        """Fail if stale SDF loading is attempted.
+
+        Parameters
+        ----------
+        path : Path
+            Unexpected cache path.
+
+        Returns
+        -------
+        object
+            Never returned because the test fails first.
+        """
         pytest.fail(f"Stale dynamic cache was loaded directly: {path}")
 
     monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
@@ -309,16 +106,27 @@ def test_dynamic_cache_rejects_non_object_json_metadata(
     tmp_path: Path,
 ) -> None:
     """Dynamic cache metadata sidecars must contain a JSON object."""
-    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+    generator = make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
     cache_path = tmp_path / "EGMA_seq=AAAAA_5-mer_charged.sdf"
     cache_path.write_text("stale cache", encoding="utf-8")
     generator._get_dynamic_cache_metadata_path(cache_path).write_text(
-        polymer_generator_module.json.dumps(metadata),
+        json.dumps(metadata),
         encoding="utf-8",
     )
 
     def fail_load_cache(path: Path) -> object:
-        """Fail if non-object metadata cache loading is attempted."""
+        """Fail if non-object metadata cache loading is attempted.
+
+        Parameters
+        ----------
+        path : Path
+            Unexpected cache path.
+
+        Returns
+        -------
+        object
+            Never returned because the test fails first.
+        """
         pytest.fail(f"Non-object metadata dynamic cache was loaded directly: {path}")
 
     monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
@@ -331,10 +139,10 @@ def test_dynamic_cache_rejects_charger_mismatch(
     tmp_path: Path,
 ) -> None:
     """Dynamic cache metadata must include and validate the charger type."""
-    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+    generator = make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
     cache_path = tmp_path / "EGMA_seq=AAAAA_5-mer_charged.sdf"
     cache_path.write_text("stale cache", encoding="utf-8")
-    _write_metadata(
+    write_metadata(
         generator,
         cache_path,
         "AAAAA",
@@ -343,7 +151,18 @@ def test_dynamic_cache_rejects_charger_mismatch(
     )
 
     def fail_load_cache(path: Path) -> object:
-        """Fail if mismatched dynamic cache loading is attempted."""
+        """Fail if mismatched dynamic cache loading is attempted.
+
+        Parameters
+        ----------
+        path : Path
+            Unexpected cache path.
+
+        Returns
+        -------
+        object
+            Never returned because the test fails first.
+        """
         pytest.fail(f"Mismatched dynamic cache was loaded directly: {path}")
 
     monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
@@ -357,19 +176,30 @@ def test_dynamic_cache_rejects_fragment_fingerprint_mismatch(
 ) -> None:
     """Dynamic cache metadata must validate MonomerGroup fragment chemistry."""
     current_generator = PolymerGenerator(
-        monomer_group=_make_list_fragment_group(),
+        monomer_group=make_list_fragment_group(),
         cache_directory=tmp_path,
     )
     stale_generator = PolymerGenerator(
-        monomer_group=_make_list_fragment_group({"EGMA_2-site": ["[C:1]-[C:2]", "[N:3]"]}),
+        monomer_group=make_list_fragment_group({"EGMA_2-site": ["[C:1]-[C:2]", "[N:3]"]}),
         cache_directory=tmp_path,
     )
     cache_path = tmp_path / "EGMA_seq=AAAAA_5-mer_charged.sdf"
     cache_path.write_text("stale cache", encoding="utf-8")
-    _write_metadata(stale_generator, cache_path, "AAAAA", {"A": "EGMA"})
+    write_metadata(stale_generator, cache_path, "AAAAA", {"A": "EGMA"})
 
     def fail_load_cache(path: Path) -> object:
-        """Fail if fingerprint-mismatched cache loading is attempted."""
+        """Fail if fingerprint-mismatched cache loading is attempted.
+
+        Parameters
+        ----------
+        path : Path
+            Unexpected cache path.
+
+        Returns
+        -------
+        object
+            Never returned because the test fails first.
+        """
         pytest.fail(f"Fingerprint-mismatched dynamic cache was loaded directly: {path}")
 
     monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
@@ -380,11 +210,11 @@ def test_dynamic_cache_rejects_fragment_fingerprint_mismatch(
 def test_list_fragment_contents_affect_monomer_group_fingerprint(tmp_path: Path) -> None:
     """Same fragment keys with different list contents should not share a digest."""
     first_generator = PolymerGenerator(
-        monomer_group=_make_list_fragment_group(),
+        monomer_group=make_list_fragment_group(),
         cache_directory=tmp_path / "first",
     )
     second_generator = PolymerGenerator(
-        monomer_group=_make_list_fragment_group({"EGMA_2-site": ["[C:1]-[C:2]", "[N:3]"]}),
+        monomer_group=make_list_fragment_group({"EGMA_2-site": ["[C:1]-[C:2]", "[N:3]"]}),
         cache_directory=tmp_path / "second",
     )
 
@@ -393,258 +223,19 @@ def test_list_fragment_contents_affect_monomer_group_fingerprint(tmp_path: Path)
 
     assert first_fingerprint["algorithm"] == "polyzymd-monomer-group-sha256-v2"
     assert first_fingerprint["digest"] != second_fingerprint["digest"]
-
-
-def test_real_monomer_group_list_contents_affect_fingerprint(tmp_path: Path) -> None:
-    """Real Polymerist list-backed fragment content should affect the digest."""
-    fragments = _real_halogen_fragments()
-    first_generator = PolymerGenerator(
-        monomer_group=_make_real_halogen_monomer_group(),
-        cache_directory=tmp_path / "first",
-    )
-    second_generator = PolymerGenerator(
-        monomer_group=_make_real_halogen_monomer_group({"PEGMA_2-site": fragments["SBMA_2-site"]}),
-        cache_directory=tmp_path / "second",
-    )
-
-    first_fingerprint = first_generator._build_monomer_group_fingerprint()
-    second_fingerprint = second_generator._build_monomer_group_fingerprint()
-
-    assert first_fingerprint["algorithm"] == "polyzymd-monomer-group-sha256-v2"
-    assert first_fingerprint["digest"] != second_fingerprint["digest"]
-
-
-def test_real_monomer_group_list_content_change_rejects_cache_metadata(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Dynamic cache validation should reject changed real fragment lists."""
-    fragments = _real_halogen_fragments()
-    current_generator = PolymerGenerator(
-        monomer_group=_make_real_halogen_monomer_group(),
-        cache_directory=tmp_path,
-    )
-    stale_generator = PolymerGenerator(
-        monomer_group=_make_real_halogen_monomer_group({"PEGMA_2-site": fragments["SBMA_2-site"]}),
-        cache_directory=tmp_path,
-    )
-    cache_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
-    cache_path.write_text("stale cache", encoding="utf-8")
-    _write_metadata(stale_generator, cache_path, "BBBBB", {"A": "SBMA", "B": "PEGMA"})
-
-    def fail_load_cache(path: Path) -> object:
-        """Fail if fingerprint-mismatched cache loading is attempted."""
-        pytest.fail(f"Fingerprint-mismatched dynamic cache was loaded directly: {path}")
-
-    monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
-
-    assert current_generator.get_cached_polymer("BBBBB", {"A": "SBMA", "B": "PEGMA"}) is None
 
 
 def test_dynamic_generator_rejects_short_sequences(tmp_path: Path) -> None:
     """Lower-level dynamic generation should reject sequences shorter than three."""
-    generator = PolymerGenerator(
-        monomer_group=_make_list_fragment_group(), cache_directory=tmp_path
-    )
+    generator = PolymerGenerator(monomer_group=make_list_fragment_group(), cache_directory=tmp_path)
 
     with pytest.raises(ValueError, match="requires sequence length >= 3"):
         generator.generate_polymer("AA", {"A": "EGMA"})
 
 
-@pytest.mark.parametrize("length", [1, 2])
-def test_dynamic_builder_rejects_short_lengths(length: int, tmp_path: Path) -> None:
-    """Dynamic builder configuration should reject lengths below three early."""
-    with pytest.raises(ValueError, match="requires length >= 3"):
-        PolymerBuilder(
-            characters=["A"],
-            probabilities=[1.0],
-            length=length,
-            type_prefix="EGMA",
-            cache_directory=tmp_path / "cache",
-            generation_mode="dynamic",
-            monomer_smiles={"EGMA": "CO"},
-            monomer_names={"A": "EGMA"},
-            reactions=object(),
-        )
-
-
-def test_dynamic_builder_routes_cache_directory_hits_through_generator(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Dynamic mode should not load cache-directory SDFs without metadata validation."""
-    cache_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
-    cache_path.write_text("stale cache", encoding="utf-8")
-    sentinel = object()
-    builder = PolymerBuilder(
-        characters=["A", "B"],
-        probabilities=[0.0, 1.0],
-        length=5,
-        type_prefix="PEGMA",
-        cache_directory=tmp_path,
-        generation_mode="dynamic",
-        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
-        monomer_names={"A": "SBMA", "B": "PEGMA"},
-        reactions=object(),
-    )
-
-    def fail_load_cache(path: Path) -> object:
-        """Fail if PolymerBuilder bypasses dynamic cache validation."""
-        pytest.fail(f"Dynamic builder loaded cache directly: {path}")
-
-    monkeypatch.setattr(builder, "_load_from_sdf", fail_load_cache)
-    monkeypatch.setattr(builder, "_generate_polymer", lambda sequence: sentinel)
-
-    assert builder._get_or_create_molecule("BBBBB") is sentinel
-
-
-def test_dynamic_builder_routes_sdf_directory_generated_artifact_through_generator(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Dynamic mode should not directly load generated-style SDF directory hits."""
-    sdf_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
-    sdf_path.write_text("stale generated artifact", encoding="utf-8")
-    sentinel = object()
-    builder = PolymerBuilder(
-        characters=["A", "B"],
-        probabilities=[0.0, 1.0],
-        length=5,
-        type_prefix="PEGMA",
-        sdf_directory=tmp_path,
-        cache_directory=tmp_path / "cache",
-        generation_mode="dynamic",
-        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
-        monomer_names={"A": "SBMA", "B": "PEGMA"},
-        reactions=object(),
-    )
-    builder._fragment_generator = object()
-    builder._polymer_generator = PolymerGenerator(
-        monomer_group=FakeMonomerGroup(
-            {
-                "SBMA_1-site": ["sbma-terminal"],
-                "SBMA_2-site": ["sbma-middle"],
-                "PEGMA_1-site": ["pegma-terminal"],
-                "PEGMA_2-site": ["pegma-middle"],
-            }
-        ),
-        cache_directory=tmp_path / "cache",
-    )
-
-    def fail_load_cache(path: Path) -> object:
-        """Fail if generated-style SDF loading bypasses validation."""
-        pytest.fail(f"Dynamic builder loaded generated-style SDF directly: {path}")
-
-    monkeypatch.setattr(builder, "_load_from_sdf", fail_load_cache)
-    monkeypatch.setattr(builder, "_generate_polymer", lambda sequence: sentinel)
-
-    assert builder._get_or_create_molecule("BBBBB") is sentinel
-
-
-def test_dynamic_builder_loads_generated_sdf_directory_hit_when_metadata_matches(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Dynamic mode should load generated-style SDF hits with matching metadata."""
-    sdf_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
-    sdf_path.write_text("validated generated artifact", encoding="utf-8")
-    sentinel = object()
-    monomer_group = FakeMonomerGroup(
-        {
-            "SBMA_1-site": ["sbma-terminal"],
-            "SBMA_2-site": ["sbma-middle"],
-            "PEGMA_1-site": ["pegma-terminal"],
-            "PEGMA_2-site": ["pegma-middle"],
-        }
-    )
-    generator = PolymerGenerator(monomer_group=monomer_group, cache_directory=tmp_path / "cache")
-    _write_metadata(generator, sdf_path, "BBBBB", {"A": "SBMA", "B": "PEGMA"})
-    builder = PolymerBuilder(
-        characters=["A", "B"],
-        probabilities=[0.0, 1.0],
-        length=5,
-        type_prefix="PEGMA",
-        sdf_directory=tmp_path,
-        cache_directory=tmp_path / "cache",
-        generation_mode="dynamic",
-        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
-        monomer_names={"A": "SBMA", "B": "PEGMA"},
-        reactions=object(),
-    )
-    builder._fragment_generator = object()
-    builder._polymer_generator = generator
-
-    monkeypatch.setattr(builder, "_load_from_sdf", lambda path: sentinel)
-    monkeypatch.setattr(
-        builder,
-        "_generate_polymer",
-        lambda sequence: pytest.fail("Validated generated SDF was not loaded"),
-    )
-
-    assert builder._get_or_create_molecule("BBBBB") is sentinel
-
-
-def test_dynamic_builder_regenerates_generated_sdf_directory_hit_with_stale_metadata(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Dynamic mode should regenerate generated-style SDF hits with stale metadata."""
-    sdf_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
-    sdf_path.write_text("stale generated artifact", encoding="utf-8")
-    current_group = FakeMonomerGroup(
-        {
-            "SBMA_1-site": ["sbma-terminal"],
-            "SBMA_2-site": ["sbma-middle"],
-            "PEGMA_1-site": ["pegma-terminal"],
-            "PEGMA_2-site": ["pegma-middle"],
-        }
-    )
-    stale_group = FakeMonomerGroup(
-        {
-            "SBMA_1-site": ["sbma-terminal"],
-            "SBMA_2-site": ["sbma-middle"],
-            "PEGMA_1-site": ["pegma-terminal"],
-            "PEGMA_2-site": ["stale-pegma-middle"],
-        }
-    )
-    _write_metadata(
-        PolymerGenerator(monomer_group=stale_group, cache_directory=tmp_path / "stale"),
-        sdf_path,
-        "BBBBB",
-        {"A": "SBMA", "B": "PEGMA"},
-    )
-    sentinel = object()
-    builder = PolymerBuilder(
-        characters=["A", "B"],
-        probabilities=[0.0, 1.0],
-        length=5,
-        type_prefix="PEGMA",
-        sdf_directory=tmp_path,
-        cache_directory=tmp_path / "cache",
-        generation_mode="dynamic",
-        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
-        monomer_names={"A": "SBMA", "B": "PEGMA"},
-        reactions=object(),
-    )
-    builder._fragment_generator = object()
-    builder._polymer_generator = PolymerGenerator(
-        monomer_group=current_group,
-        cache_directory=tmp_path / "cache",
-    )
-
-    monkeypatch.setattr(
-        builder,
-        "_load_from_sdf",
-        lambda path: pytest.fail("Stale generated SDF was loaded directly"),
-    )
-    monkeypatch.setattr(builder, "_generate_polymer", lambda sequence: sentinel)
-
-    assert builder._get_or_create_molecule("BBBBB") is sentinel
-
-
 def test_dynamic_filename_rejects_unknown_sequence_label(tmp_path: Path) -> None:
     """Filename construction should reject unknown labels with ValueError."""
-    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+    generator = make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
 
     with pytest.raises(ValueError, match="No monomer name configured for sequence label: X"):
         generator._make_polymer_filename("AXA", {"A": "EGMA"})
@@ -652,7 +243,7 @@ def test_dynamic_filename_rejects_unknown_sequence_label(tmp_path: Path) -> None
 
 def test_dynamic_structure_build_rejects_unknown_sequence_label(tmp_path: Path) -> None:
     """Structure building should reject unknown labels before direct mapping lookup."""
-    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+    generator = make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
 
     with pytest.raises(ValueError, match="No monomer name configured for sequence label: X"):
         generator._build_polymer_structure("AXA", {"A": "EGMA"})
@@ -660,30 +251,7 @@ def test_dynamic_structure_build_rejects_unknown_sequence_label(tmp_path: Path) 
 
 def test_dynamic_generation_rejects_unknown_sequence_label(tmp_path: Path) -> None:
     """Generation should reject unknown labels before importing OpenFF topology."""
-    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+    generator = make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
 
     with pytest.raises(ValueError, match="No monomer name configured for sequence label: X"):
         generator.generate_polymer("AXA", {"A": "EGMA"})
-
-
-def test_cached_builder_loads_sdf_directory_hit_without_dynamic_metadata(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Cached mode should continue to load user-provided SDF directory hits."""
-    sdf_path = tmp_path / "EGMA_seq=A_1-mer_charged.sdf"
-    sdf_path.write_text("curated user structure", encoding="utf-8")
-    sentinel = object()
-    builder = PolymerBuilder(
-        characters=["A"],
-        probabilities=[1.0],
-        length=1,
-        type_prefix="EGMA",
-        sdf_directory=tmp_path,
-        cache_directory=tmp_path / "cache",
-        generation_mode="cached",
-    )
-
-    monkeypatch.setattr(builder, "_load_from_sdf", lambda path: sentinel)
-
-    assert builder._get_or_create_molecule("A") is sentinel

--- a/tests/builders/test_polymer_generator.py
+++ b/tests/builders/test_polymer_generator.py
@@ -1,0 +1,689 @@
+"""Regression tests for dynamic polymer generation mapping."""
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from polyzymd.builders.polymer import PolymerBuilder
+
+REAL_POLYMERIST_AVAILABLE = importlib.util.find_spec("polymerist") is not None
+
+
+def _make_stub_package(name: str) -> ModuleType:
+    """Create a package-like module stub for optional chemistry dependencies."""
+    module = ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def _install_polymerist_stubs() -> None:
+    """Install minimal Polymerist stubs when the optional dependency is absent."""
+    if importlib.util.find_spec("polymerist") is not None:
+        return
+
+    package_names = [
+        "polymerist",
+        "polymerist.genutils",
+        "polymerist.genutils.fileutils",
+        "polymerist.mdtools",
+        "polymerist.mdtools.openfftools",
+        "polymerist.polymers",
+        "polymerist.rdutils",
+        "polymerist.rdutils.rdcoords",
+    ]
+    for name in package_names:
+        sys.modules.setdefault(name, _make_stub_package(name))
+
+    pathutils = ModuleType("polymerist.genutils.fileutils.pathutils")
+    pathutils.assemble_path = lambda *args, **kwargs: Path(*args)
+    sys.modules.setdefault("polymerist.genutils.fileutils.pathutils", pathutils)
+
+    partition = ModuleType("polymerist.mdtools.openfftools.partition")
+    partition.partition = lambda topology: True
+    sys.modules.setdefault("polymerist.mdtools.openfftools.partition", partition)
+
+    topology = ModuleType("polymerist.mdtools.openfftools.topology")
+    topology.get_largest_offmol = lambda topology: object()
+    topology.topology_from_sdf = lambda path: object()
+    topology.topology_to_sdf = lambda path, topology: None
+    sys.modules.setdefault("polymerist.mdtools.openfftools.topology", topology)
+
+    building = ModuleType("polymerist.polymers.building")
+    building.build_linear_polymer = lambda **kwargs: object()
+    building.mbmol_to_openmm_pdb = lambda *args, **kwargs: None
+    building.mbmol_to_rdmol = lambda chain: object()
+    sys.modules.setdefault("polymerist.polymers.building", building)
+
+    monomers = ModuleType("polymerist.polymers.monomers")
+    monomers.MonomerGroup = FakeMonomerGroup
+    sys.modules.setdefault("polymerist.polymers.monomers", monomers)
+
+    piercing = ModuleType("polymerist.rdutils.rdcoords.piercing")
+    piercing.summarize_ring_piercing = lambda mol: {}
+    sys.modules.setdefault("polymerist.rdutils.rdcoords.piercing", piercing)
+
+
+def _install_rdkit_stubs() -> None:
+    """Install minimal RDKit stubs when the optional dependency is absent."""
+    if importlib.util.find_spec("rdkit") is not None:
+        return
+
+    rdkit = _make_stub_package("rdkit")
+    chem = ModuleType("rdkit.Chem")
+    rdkit.Chem = chem
+    sys.modules.setdefault("rdkit", rdkit)
+    sys.modules.setdefault("rdkit.Chem", chem)
+
+
+class FakeMonomerGroup:
+    """Minimal MonomerGroup stand-in for Polymerist call capture."""
+
+    def __init__(self, monomers: dict[str, object]) -> None:
+        """Initialize the fake group with named fragments."""
+        self.monomers = monomers
+        self.term_orient: dict[str, str] = {}
+
+
+_install_polymerist_stubs()
+_install_rdkit_stubs()
+
+polymer_generator_module = importlib.import_module("polyzymd.builders.polymer_generator")
+PolymerGenerator = polymer_generator_module.PolymerGenerator
+
+
+def _make_generator(tmp_path: Path, fragment_names: list[str]) -> PolymerGenerator:
+    """Create a PolymerGenerator with fake fragment objects."""
+    monomer_group = FakeMonomerGroup({name: [f"{name}:smarts"] for name in fragment_names})
+    return PolymerGenerator(monomer_group=monomer_group, cache_directory=tmp_path)
+
+
+def _make_list_fragment_group(overrides: dict[str, list[str]] | None = None) -> FakeMonomerGroup:
+    """Create a fake MonomerGroup with Polymerist-like list fragment entries."""
+    fragments = {
+        "EGMA_1-site": ["[C:1]=[C:2]", "[O:3]"],
+        "EGMA_2-site": ["[C:1]-[C:2]", "[O:3]"],
+    }
+    fragments.update(overrides or {})
+    return FakeMonomerGroup(fragments)
+
+
+def _require_real_polymerist() -> None:
+    """Skip when Polymerist is not installed and tests use local stubs."""
+    if not REAL_POLYMERIST_AVAILABLE:
+        pytest.skip("Polymerist is not available")
+
+
+def _real_halogen_fragments() -> dict[str, list[str]]:
+    """Create valid Polymerist SMARTS fragments with PolyzyMD monomer names."""
+    _require_real_polymerist()
+
+    from polymerist.polymers.monomers.fragments import HALOGENATED_HYDROCARBON_FRAGMENTS
+
+    return {
+        "SBMA_1-site": HALOGENATED_HYDROCARBON_FRAGMENTS["chlor_term_1"],
+        "SBMA_2-site": HALOGENATED_HYDROCARBON_FRAGMENTS["chlor_mid_1"],
+        "PEGMA_1-site": HALOGENATED_HYDROCARBON_FRAGMENTS["brom_term_1"],
+        "PEGMA_2-site": HALOGENATED_HYDROCARBON_FRAGMENTS["brom_mid_1"],
+    }
+
+
+def _make_real_halogen_monomer_group(overrides: dict[str, list[str]] | None = None):
+    """Create a real Polymerist MonomerGroup backed by list SMARTS data."""
+    _require_real_polymerist()
+
+    from polymerist.polymers.monomers import MonomerGroup
+
+    fragments = _real_halogen_fragments()
+    fragments.update(overrides or {})
+    return MonomerGroup(monomers=fragments)
+
+
+def _count_chain_halogens(chain: object) -> dict[str, int]:
+    """Count diagnostic halogens in a real Polymerist-built chain."""
+    _require_real_polymerist()
+
+    from polymerist.polymers.building import mbmol_to_rdmol
+
+    mol = mbmol_to_rdmol(chain)
+    return {
+        "Br": sum(1 for atom in mol.GetAtoms() if atom.GetSymbol() == "Br"),
+        "Cl": sum(1 for atom in mol.GetAtoms() if atom.GetSymbol() == "Cl"),
+    }
+
+
+def _patch_structure_build(monkeypatch: pytest.MonkeyPatch, calls: list[dict[str, object]]) -> None:
+    """Patch Polymerist structure helpers to avoid chemistry work."""
+
+    def fake_build_linear_polymer(**kwargs):
+        """Capture the Polymerist build arguments."""
+        calls.append(kwargs)
+        return object()
+
+    def fake_write_pdb(pdb_path: Path, chain: object, resname_map: dict[str, str]) -> None:
+        """Create the expected PDB output without invoking OpenMM writers."""
+        pdb_path.write_text("MODEL\nEND\n", encoding="utf-8")
+
+    monkeypatch.setattr(polymer_generator_module, "_make_monomer_group", FakeMonomerGroup)
+    monkeypatch.setattr(
+        polymer_generator_module, "_build_linear_polymer", fake_build_linear_polymer
+    )
+    monkeypatch.setattr(polymer_generator_module, "_mbmol_to_rdmol", lambda chain: object())
+    monkeypatch.setattr(polymer_generator_module, "_summarize_ring_piercing", lambda mol: {})
+    monkeypatch.setattr(polymer_generator_module, "_mbmol_to_openmm_pdb", fake_write_pdb)
+
+
+def _write_metadata(
+    generator: PolymerGenerator,
+    sdf_path: Path,
+    sequence: str,
+    monomer_names: dict[str, str],
+    overrides: dict[str, object] | None = None,
+) -> None:
+    """Write dynamic cache metadata with optional top-level overrides."""
+    metadata = generator._build_dynamic_cache_metadata(sequence, monomer_names)
+    metadata.update(overrides or {})
+    generator._get_dynamic_cache_metadata_path(sdf_path).write_text(
+        polymer_generator_module.json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_two_monomer_b_sequence_uses_explicit_pegma_middle_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """BBBBB should pass BBB and map B to the PEGMA 2-site fragment."""
+    calls: list[dict[str, object]] = []
+    _patch_structure_build(monkeypatch, calls)
+    generator = _make_generator(
+        tmp_path,
+        ["SBMA_1-site", "SBMA_2-site", "PEGMA_1-site", "PEGMA_2-site"],
+    )
+
+    generator._build_polymer_structure("BBBBB", {"A": "SBMA", "B": "PEGMA"})
+
+    assert calls[0]["sequence"] == "BBB"
+    assert calls[0]["sequence_map"] == {"B": "PEGMA_2-site"}
+
+
+def test_two_monomer_b_sequence_uses_pegma_terminal_fragments(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """BBBBB should set both terminal orientations to PEGMA 1-site fragments."""
+    calls: list[dict[str, object]] = []
+    _patch_structure_build(monkeypatch, calls)
+    generator = _make_generator(
+        tmp_path,
+        ["SBMA_1-site", "SBMA_2-site", "PEGMA_1-site", "PEGMA_2-site"],
+    )
+
+    generator._build_polymer_structure("BBBBB", {"A": "SBMA", "B": "PEGMA"})
+
+    monomer_group = calls[0]["monomers"]
+    assert isinstance(monomer_group, FakeMonomerGroup)
+    assert monomer_group.term_orient == {"head": "PEGMA_1-site", "tail": "PEGMA_1-site"}
+
+
+def test_real_polymerist_sequence_map_keeps_b_middle_on_pegma_fragment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """BBBBB should build with PEGMA middle fragments through real Polymerist."""
+    _require_real_polymerist()
+
+    from polymerist.polymers.building import build_linear_polymer
+
+    def fake_write_pdb(pdb_path: Path, chain: object, resname_map: dict[str, str]) -> None:
+        """Create the expected PDB output after the real chain build."""
+        pdb_path.write_text("MODEL\nEND\n", encoding="utf-8")
+
+    unmapped_group = _make_real_halogen_monomer_group()
+    unmapped_group.term_orient = {"head": "PEGMA_1-site", "tail": "PEGMA_1-site"}
+    unmapped_chain = build_linear_polymer(
+        monomers=unmapped_group,
+        n_monomers=5,
+        sequence="BBB",
+        energy_minimize=False,
+        allow_partial_sequences=True,
+    )
+    assert _count_chain_halogens(unmapped_chain) == {"Br": 2, "Cl": 3}
+
+    monkeypatch.setattr(polymer_generator_module, "_mbmol_to_openmm_pdb", fake_write_pdb)
+    generator = PolymerGenerator(
+        monomer_group=_make_real_halogen_monomer_group(),
+        cache_directory=tmp_path,
+        max_retries=1,
+    )
+
+    chain, pdb_path = generator._build_polymer_structure(
+        "BBBBB",
+        {"A": "SBMA", "B": "PEGMA"},
+    )
+
+    assert pdb_path.exists()
+    assert _count_chain_halogens(chain) == {"Br": 5, "Cl": 0}
+
+
+def test_single_monomer_sequence_uses_explicit_egma_middle_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AAAAA should pass an explicit EGMA mapping instead of Polymerist defaults."""
+    calls: list[dict[str, object]] = []
+    _patch_structure_build(monkeypatch, calls)
+    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+
+    generator._build_polymer_structure("AAAAA", {"A": "EGMA"})
+
+    assert calls[0]["sequence"] == "AAA"
+    assert calls[0]["sequence_map"] == {"A": "EGMA_2-site"}
+
+
+def test_stale_dynamic_cache_without_metadata_is_not_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A dynamic charged SDF without metadata should not be directly reused."""
+    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+    cache_path = tmp_path / "EGMA_seq=AAAAA_5-mer_charged.sdf"
+    cache_path.write_text("stale cache", encoding="utf-8")
+
+    def fail_load_cache(path: Path) -> object:
+        """Fail if stale SDF loading is attempted."""
+        pytest.fail(f"Stale dynamic cache was loaded directly: {path}")
+
+    monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
+
+    assert generator.get_cached_polymer("AAAAA", {"A": "EGMA"}) is None
+
+
+@pytest.mark.parametrize("metadata", [[], "stale", 1])
+def test_dynamic_cache_rejects_non_object_json_metadata(
+    metadata: object,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic cache metadata sidecars must contain a JSON object."""
+    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+    cache_path = tmp_path / "EGMA_seq=AAAAA_5-mer_charged.sdf"
+    cache_path.write_text("stale cache", encoding="utf-8")
+    generator._get_dynamic_cache_metadata_path(cache_path).write_text(
+        polymer_generator_module.json.dumps(metadata),
+        encoding="utf-8",
+    )
+
+    def fail_load_cache(path: Path) -> object:
+        """Fail if non-object metadata cache loading is attempted."""
+        pytest.fail(f"Non-object metadata dynamic cache was loaded directly: {path}")
+
+    monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
+
+    assert generator.get_cached_polymer("AAAAA", {"A": "EGMA"}) is None
+
+
+def test_dynamic_cache_rejects_charger_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic cache metadata must include and validate the charger type."""
+    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+    cache_path = tmp_path / "EGMA_seq=AAAAA_5-mer_charged.sdf"
+    cache_path.write_text("stale cache", encoding="utf-8")
+    _write_metadata(
+        generator,
+        cache_path,
+        "AAAAA",
+        {"A": "EGMA"},
+        overrides={"charger_type": "espaloma"},
+    )
+
+    def fail_load_cache(path: Path) -> object:
+        """Fail if mismatched dynamic cache loading is attempted."""
+        pytest.fail(f"Mismatched dynamic cache was loaded directly: {path}")
+
+    monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
+
+    assert generator.get_cached_polymer("AAAAA", {"A": "EGMA"}) is None
+
+
+def test_dynamic_cache_rejects_fragment_fingerprint_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic cache metadata must validate MonomerGroup fragment chemistry."""
+    current_generator = PolymerGenerator(
+        monomer_group=_make_list_fragment_group(),
+        cache_directory=tmp_path,
+    )
+    stale_generator = PolymerGenerator(
+        monomer_group=_make_list_fragment_group({"EGMA_2-site": ["[C:1]-[C:2]", "[N:3]"]}),
+        cache_directory=tmp_path,
+    )
+    cache_path = tmp_path / "EGMA_seq=AAAAA_5-mer_charged.sdf"
+    cache_path.write_text("stale cache", encoding="utf-8")
+    _write_metadata(stale_generator, cache_path, "AAAAA", {"A": "EGMA"})
+
+    def fail_load_cache(path: Path) -> object:
+        """Fail if fingerprint-mismatched cache loading is attempted."""
+        pytest.fail(f"Fingerprint-mismatched dynamic cache was loaded directly: {path}")
+
+    monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
+
+    assert current_generator.get_cached_polymer("AAAAA", {"A": "EGMA"}) is None
+
+
+def test_list_fragment_contents_affect_monomer_group_fingerprint(tmp_path: Path) -> None:
+    """Same fragment keys with different list contents should not share a digest."""
+    first_generator = PolymerGenerator(
+        monomer_group=_make_list_fragment_group(),
+        cache_directory=tmp_path / "first",
+    )
+    second_generator = PolymerGenerator(
+        monomer_group=_make_list_fragment_group({"EGMA_2-site": ["[C:1]-[C:2]", "[N:3]"]}),
+        cache_directory=tmp_path / "second",
+    )
+
+    first_fingerprint = first_generator._build_monomer_group_fingerprint()
+    second_fingerprint = second_generator._build_monomer_group_fingerprint()
+
+    assert first_fingerprint["algorithm"] == "polyzymd-monomer-group-sha256-v2"
+    assert first_fingerprint["digest"] != second_fingerprint["digest"]
+
+
+def test_real_monomer_group_list_contents_affect_fingerprint(tmp_path: Path) -> None:
+    """Real Polymerist list-backed fragment content should affect the digest."""
+    fragments = _real_halogen_fragments()
+    first_generator = PolymerGenerator(
+        monomer_group=_make_real_halogen_monomer_group(),
+        cache_directory=tmp_path / "first",
+    )
+    second_generator = PolymerGenerator(
+        monomer_group=_make_real_halogen_monomer_group({"PEGMA_2-site": fragments["SBMA_2-site"]}),
+        cache_directory=tmp_path / "second",
+    )
+
+    first_fingerprint = first_generator._build_monomer_group_fingerprint()
+    second_fingerprint = second_generator._build_monomer_group_fingerprint()
+
+    assert first_fingerprint["algorithm"] == "polyzymd-monomer-group-sha256-v2"
+    assert first_fingerprint["digest"] != second_fingerprint["digest"]
+
+
+def test_real_monomer_group_list_content_change_rejects_cache_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic cache validation should reject changed real fragment lists."""
+    fragments = _real_halogen_fragments()
+    current_generator = PolymerGenerator(
+        monomer_group=_make_real_halogen_monomer_group(),
+        cache_directory=tmp_path,
+    )
+    stale_generator = PolymerGenerator(
+        monomer_group=_make_real_halogen_monomer_group({"PEGMA_2-site": fragments["SBMA_2-site"]}),
+        cache_directory=tmp_path,
+    )
+    cache_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
+    cache_path.write_text("stale cache", encoding="utf-8")
+    _write_metadata(stale_generator, cache_path, "BBBBB", {"A": "SBMA", "B": "PEGMA"})
+
+    def fail_load_cache(path: Path) -> object:
+        """Fail if fingerprint-mismatched cache loading is attempted."""
+        pytest.fail(f"Fingerprint-mismatched dynamic cache was loaded directly: {path}")
+
+    monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
+
+    assert current_generator.get_cached_polymer("BBBBB", {"A": "SBMA", "B": "PEGMA"}) is None
+
+
+def test_dynamic_generator_rejects_short_sequences(tmp_path: Path) -> None:
+    """Lower-level dynamic generation should reject sequences shorter than three."""
+    generator = PolymerGenerator(
+        monomer_group=_make_list_fragment_group(), cache_directory=tmp_path
+    )
+
+    with pytest.raises(ValueError, match="requires sequence length >= 3"):
+        generator.generate_polymer("AA", {"A": "EGMA"})
+
+
+@pytest.mark.parametrize("length", [1, 2])
+def test_dynamic_builder_rejects_short_lengths(length: int, tmp_path: Path) -> None:
+    """Dynamic builder configuration should reject lengths below three early."""
+    with pytest.raises(ValueError, match="requires length >= 3"):
+        PolymerBuilder(
+            characters=["A"],
+            probabilities=[1.0],
+            length=length,
+            type_prefix="EGMA",
+            cache_directory=tmp_path / "cache",
+            generation_mode="dynamic",
+            monomer_smiles={"EGMA": "CO"},
+            monomer_names={"A": "EGMA"},
+            reactions=object(),
+        )
+
+
+def test_dynamic_builder_routes_cache_directory_hits_through_generator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic mode should not load cache-directory SDFs without metadata validation."""
+    cache_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
+    cache_path.write_text("stale cache", encoding="utf-8")
+    sentinel = object()
+    builder = PolymerBuilder(
+        characters=["A", "B"],
+        probabilities=[0.0, 1.0],
+        length=5,
+        type_prefix="PEGMA",
+        cache_directory=tmp_path,
+        generation_mode="dynamic",
+        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
+        monomer_names={"A": "SBMA", "B": "PEGMA"},
+        reactions=object(),
+    )
+
+    def fail_load_cache(path: Path) -> object:
+        """Fail if PolymerBuilder bypasses dynamic cache validation."""
+        pytest.fail(f"Dynamic builder loaded cache directly: {path}")
+
+    monkeypatch.setattr(builder, "_load_from_sdf", fail_load_cache)
+    monkeypatch.setattr(builder, "_generate_polymer", lambda sequence: sentinel)
+
+    assert builder._get_or_create_molecule("BBBBB") is sentinel
+
+
+def test_dynamic_builder_routes_sdf_directory_generated_artifact_through_generator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic mode should not directly load generated-style SDF directory hits."""
+    sdf_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
+    sdf_path.write_text("stale generated artifact", encoding="utf-8")
+    sentinel = object()
+    builder = PolymerBuilder(
+        characters=["A", "B"],
+        probabilities=[0.0, 1.0],
+        length=5,
+        type_prefix="PEGMA",
+        sdf_directory=tmp_path,
+        cache_directory=tmp_path / "cache",
+        generation_mode="dynamic",
+        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
+        monomer_names={"A": "SBMA", "B": "PEGMA"},
+        reactions=object(),
+    )
+    builder._fragment_generator = object()
+    builder._polymer_generator = PolymerGenerator(
+        monomer_group=FakeMonomerGroup(
+            {
+                "SBMA_1-site": ["sbma-terminal"],
+                "SBMA_2-site": ["sbma-middle"],
+                "PEGMA_1-site": ["pegma-terminal"],
+                "PEGMA_2-site": ["pegma-middle"],
+            }
+        ),
+        cache_directory=tmp_path / "cache",
+    )
+
+    def fail_load_cache(path: Path) -> object:
+        """Fail if generated-style SDF loading bypasses validation."""
+        pytest.fail(f"Dynamic builder loaded generated-style SDF directly: {path}")
+
+    monkeypatch.setattr(builder, "_load_from_sdf", fail_load_cache)
+    monkeypatch.setattr(builder, "_generate_polymer", lambda sequence: sentinel)
+
+    assert builder._get_or_create_molecule("BBBBB") is sentinel
+
+
+def test_dynamic_builder_loads_generated_sdf_directory_hit_when_metadata_matches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic mode should load generated-style SDF hits with matching metadata."""
+    sdf_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
+    sdf_path.write_text("validated generated artifact", encoding="utf-8")
+    sentinel = object()
+    monomer_group = FakeMonomerGroup(
+        {
+            "SBMA_1-site": ["sbma-terminal"],
+            "SBMA_2-site": ["sbma-middle"],
+            "PEGMA_1-site": ["pegma-terminal"],
+            "PEGMA_2-site": ["pegma-middle"],
+        }
+    )
+    generator = PolymerGenerator(monomer_group=monomer_group, cache_directory=tmp_path / "cache")
+    _write_metadata(generator, sdf_path, "BBBBB", {"A": "SBMA", "B": "PEGMA"})
+    builder = PolymerBuilder(
+        characters=["A", "B"],
+        probabilities=[0.0, 1.0],
+        length=5,
+        type_prefix="PEGMA",
+        sdf_directory=tmp_path,
+        cache_directory=tmp_path / "cache",
+        generation_mode="dynamic",
+        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
+        monomer_names={"A": "SBMA", "B": "PEGMA"},
+        reactions=object(),
+    )
+    builder._fragment_generator = object()
+    builder._polymer_generator = generator
+
+    monkeypatch.setattr(builder, "_load_from_sdf", lambda path: sentinel)
+    monkeypatch.setattr(
+        builder,
+        "_generate_polymer",
+        lambda sequence: pytest.fail("Validated generated SDF was not loaded"),
+    )
+
+    assert builder._get_or_create_molecule("BBBBB") is sentinel
+
+
+def test_dynamic_builder_regenerates_generated_sdf_directory_hit_with_stale_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic mode should regenerate generated-style SDF hits with stale metadata."""
+    sdf_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
+    sdf_path.write_text("stale generated artifact", encoding="utf-8")
+    current_group = FakeMonomerGroup(
+        {
+            "SBMA_1-site": ["sbma-terminal"],
+            "SBMA_2-site": ["sbma-middle"],
+            "PEGMA_1-site": ["pegma-terminal"],
+            "PEGMA_2-site": ["pegma-middle"],
+        }
+    )
+    stale_group = FakeMonomerGroup(
+        {
+            "SBMA_1-site": ["sbma-terminal"],
+            "SBMA_2-site": ["sbma-middle"],
+            "PEGMA_1-site": ["pegma-terminal"],
+            "PEGMA_2-site": ["stale-pegma-middle"],
+        }
+    )
+    _write_metadata(
+        PolymerGenerator(monomer_group=stale_group, cache_directory=tmp_path / "stale"),
+        sdf_path,
+        "BBBBB",
+        {"A": "SBMA", "B": "PEGMA"},
+    )
+    sentinel = object()
+    builder = PolymerBuilder(
+        characters=["A", "B"],
+        probabilities=[0.0, 1.0],
+        length=5,
+        type_prefix="PEGMA",
+        sdf_directory=tmp_path,
+        cache_directory=tmp_path / "cache",
+        generation_mode="dynamic",
+        monomer_smiles={"SBMA": "C", "PEGMA": "CO"},
+        monomer_names={"A": "SBMA", "B": "PEGMA"},
+        reactions=object(),
+    )
+    builder._fragment_generator = object()
+    builder._polymer_generator = PolymerGenerator(
+        monomer_group=current_group,
+        cache_directory=tmp_path / "cache",
+    )
+
+    monkeypatch.setattr(
+        builder,
+        "_load_from_sdf",
+        lambda path: pytest.fail("Stale generated SDF was loaded directly"),
+    )
+    monkeypatch.setattr(builder, "_generate_polymer", lambda sequence: sentinel)
+
+    assert builder._get_or_create_molecule("BBBBB") is sentinel
+
+
+def test_dynamic_filename_rejects_unknown_sequence_label(tmp_path: Path) -> None:
+    """Filename construction should reject unknown labels with ValueError."""
+    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+
+    with pytest.raises(ValueError, match="No monomer name configured for sequence label: X"):
+        generator._make_polymer_filename("AXA", {"A": "EGMA"})
+
+
+def test_dynamic_structure_build_rejects_unknown_sequence_label(tmp_path: Path) -> None:
+    """Structure building should reject unknown labels before direct mapping lookup."""
+    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+
+    with pytest.raises(ValueError, match="No monomer name configured for sequence label: X"):
+        generator._build_polymer_structure("AXA", {"A": "EGMA"})
+
+
+def test_dynamic_generation_rejects_unknown_sequence_label(tmp_path: Path) -> None:
+    """Generation should reject unknown labels before importing OpenFF topology."""
+    generator = _make_generator(tmp_path, ["EGMA_1-site", "EGMA_2-site"])
+
+    with pytest.raises(ValueError, match="No monomer name configured for sequence label: X"):
+        generator.generate_polymer("AXA", {"A": "EGMA"})
+
+
+def test_cached_builder_loads_sdf_directory_hit_without_dynamic_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cached mode should continue to load user-provided SDF directory hits."""
+    sdf_path = tmp_path / "EGMA_seq=A_1-mer_charged.sdf"
+    sdf_path.write_text("curated user structure", encoding="utf-8")
+    sentinel = object()
+    builder = PolymerBuilder(
+        characters=["A"],
+        probabilities=[1.0],
+        length=1,
+        type_prefix="EGMA",
+        sdf_directory=tmp_path,
+        cache_directory=tmp_path / "cache",
+        generation_mode="cached",
+    )
+
+    monkeypatch.setattr(builder, "_load_from_sdf", lambda path: sentinel)
+
+    assert builder._get_or_create_molecule("A") is sentinel

--- a/tests/builders/test_polymer_generator_lazy_imports.py
+++ b/tests/builders/test_polymer_generator_lazy_imports.py
@@ -1,0 +1,105 @@
+"""Subprocess checks for polymer generator lazy imports."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def _run_import_guarded_script(script: str) -> subprocess.CompletedProcess[str]:
+    """Run a Python snippet with the repository source path available.
+
+    Parameters
+    ----------
+    script : str
+        Python source code to run in a subprocess.
+
+    Returns
+    -------
+    subprocess.CompletedProcess[str]
+        Completed subprocess result for assertions.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    src_path = str(repo_root / "src")
+    env["PYTHONPATH"] = (
+        src_path if not existing_pythonpath else os.pathsep.join([src_path, existing_pythonpath])
+    )
+
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        check=False,
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_polymer_generator_import_does_not_import_optional_chemistry_stack() -> None:
+    """Importing polymer_generator should not import optional chemistry dependencies."""
+    result = _run_import_guarded_script(
+        r"""
+        import importlib
+        import sys
+
+        blocked_prefixes = ("polymerist", "rdkit", "openff", "openmm")
+        before = {name for name in sys.modules if name.startswith(blocked_prefixes)}
+        module = importlib.import_module("polyzymd.builders.polymer_generator")
+        if module.PolymerGenerator.__name__ != "PolymerGenerator":
+            raise AssertionError("PolymerGenerator was not imported")
+        imported = sorted(
+            name for name in sys.modules if name.startswith(blocked_prefixes) and name not in before
+        )
+        if imported:
+            raise AssertionError(f"Optional dependencies imported eagerly: {imported}")
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_unknown_label_validation_runs_before_optional_dependency_imports() -> None:
+    """Unknown dynamic labels should fail before OpenFF or Polymerist imports are needed."""
+    result = _run_import_guarded_script(
+        r"""
+        import builtins
+        import importlib
+        import tempfile
+        from pathlib import Path
+
+        blocked_prefixes = ("polymerist", "rdkit", "openff", "openmm")
+        original_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name.startswith(blocked_prefixes):
+                raise RuntimeError(f"Unexpected optional dependency import: {name}")
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = guarded_import
+        module = importlib.import_module("polyzymd.builders.polymer_generator")
+
+        class FakeMonomerGroup:
+            def __init__(self):
+                self.monomers = {"EGMA_1-site": ["terminal"], "EGMA_2-site": ["middle"]}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generator = module.PolymerGenerator(
+                monomer_group=FakeMonomerGroup(),
+                cache_directory=Path(tmpdir),
+            )
+            try:
+                generator.generate_polymer("AXA", {"A": "EGMA"})
+            except ValueError as exc:
+                if "No monomer name configured for sequence label: X" not in str(exc):
+                    raise
+            else:
+                raise AssertionError("Unknown sequence label was accepted")
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/builders/test_polymer_generator_real_polymerist.py
+++ b/tests/builders/test_polymer_generator_real_polymerist.py
@@ -1,0 +1,202 @@
+"""Regression tests that exercise real Polymerist/RDKit polymer data paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import polyzymd.builders.polymer_generator as polymer_generator_module
+from polyzymd.builders.polymer_generator import PolymerGenerator
+
+pytest.importorskip("polymerist")
+pytest.importorskip("rdkit")
+
+
+def _real_halogen_fragments() -> dict[str, list[Any]]:
+    """Create valid Polymerist SMARTS fragments with PolyzyMD monomer names.
+
+    Returns
+    -------
+    dict[str, list[Any]]
+        Polymerist fragment payloads keyed by PolyzyMD fragment names.
+    """
+    from polymerist.polymers.monomers.fragments import HALOGENATED_HYDROCARBON_FRAGMENTS
+
+    return {
+        "SBMA_1-site": HALOGENATED_HYDROCARBON_FRAGMENTS["chlor_term_1"],
+        "SBMA_2-site": HALOGENATED_HYDROCARBON_FRAGMENTS["chlor_mid_1"],
+        "PEGMA_1-site": HALOGENATED_HYDROCARBON_FRAGMENTS["brom_term_1"],
+        "PEGMA_2-site": HALOGENATED_HYDROCARBON_FRAGMENTS["brom_mid_1"],
+    }
+
+
+def _make_real_halogen_monomer_group(overrides: dict[str, list[Any]] | None = None) -> Any:
+    """Create a real Polymerist MonomerGroup backed by list SMARTS data.
+
+    Parameters
+    ----------
+    overrides : dict[str, list[Any]] | None, optional
+        Fragment entries to merge into the default real fragments.
+
+    Returns
+    -------
+    Any
+        Polymerist MonomerGroup instance.
+    """
+    from polymerist.polymers.monomers import MonomerGroup
+
+    fragments = _real_halogen_fragments()
+    fragments.update(overrides or {})
+    return MonomerGroup(monomers=fragments)
+
+
+def _count_chain_halogens(chain: object) -> dict[str, int]:
+    """Count diagnostic halogens in a real Polymerist-built chain.
+
+    Parameters
+    ----------
+    chain : object
+        Polymerist chain object to inspect.
+
+    Returns
+    -------
+    dict[str, int]
+        Counts of bromine and chlorine atoms.
+    """
+    from polymerist.polymers.building import mbmol_to_rdmol
+
+    mol = mbmol_to_rdmol(chain)
+    return {
+        "Br": sum(1 for atom in mol.GetAtoms() if atom.GetSymbol() == "Br"),
+        "Cl": sum(1 for atom in mol.GetAtoms() if atom.GetSymbol() == "Cl"),
+    }
+
+
+def _write_metadata(
+    generator: PolymerGenerator,
+    sdf_path: Path,
+    sequence: str,
+    monomer_names: dict[str, str],
+) -> None:
+    """Write dynamic cache metadata for real Polymerist tests.
+
+    Parameters
+    ----------
+    generator : PolymerGenerator
+        Generator used to build the expected metadata payload.
+    sdf_path : Path
+        Charged SDF path whose sidecar should be written.
+    sequence : str
+        Polymer sequence for metadata validation.
+    monomer_names : dict[str, str]
+        Mapping from sequence labels to monomer names.
+    """
+    metadata = generator._build_dynamic_cache_metadata(sequence, monomer_names)
+    generator._get_dynamic_cache_metadata_path(sdf_path).write_text(
+        polymer_generator_module.json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_real_polymerist_sequence_map_keeps_b_middle_on_pegma_fragment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """BBBBB should build with PEGMA middle fragments through real Polymerist."""
+    from polymerist.polymers.building import build_linear_polymer
+
+    def fake_write_pdb(pdb_path: Path, chain: object, resname_map: dict[str, str]) -> None:
+        """Create the expected PDB output after the real chain build.
+
+        Parameters
+        ----------
+        pdb_path : Path
+            Destination PDB path.
+        chain : object
+            Polymerist chain object.
+        resname_map : dict[str, str]
+            Residue-name mapping passed by PolyzyMD.
+        """
+        pdb_path.write_text("MODEL\nEND\n", encoding="utf-8")
+
+    unmapped_group = _make_real_halogen_monomer_group()
+    unmapped_group.term_orient = {"head": "PEGMA_1-site", "tail": "PEGMA_1-site"}
+    unmapped_chain = build_linear_polymer(
+        monomers=unmapped_group,
+        n_monomers=5,
+        sequence="BBB",
+        energy_minimize=False,
+        allow_partial_sequences=True,
+    )
+    assert _count_chain_halogens(unmapped_chain) == {"Br": 2, "Cl": 3}
+
+    monkeypatch.setattr(polymer_generator_module, "_mbmol_to_openmm_pdb", fake_write_pdb)
+    generator = PolymerGenerator(
+        monomer_group=_make_real_halogen_monomer_group(),
+        cache_directory=tmp_path,
+        max_retries=1,
+    )
+
+    chain, pdb_path = generator._build_polymer_structure("BBBBB", {"A": "SBMA", "B": "PEGMA"})
+
+    assert pdb_path.exists()
+    assert _count_chain_halogens(chain) == {"Br": 5, "Cl": 0}
+
+
+def test_real_monomer_group_list_contents_affect_fingerprint(tmp_path: Path) -> None:
+    """Real Polymerist list-backed fragment content should affect the digest."""
+    fragments = _real_halogen_fragments()
+    first_generator = PolymerGenerator(
+        monomer_group=_make_real_halogen_monomer_group(),
+        cache_directory=tmp_path / "first",
+    )
+    second_generator = PolymerGenerator(
+        monomer_group=_make_real_halogen_monomer_group({"PEGMA_2-site": fragments["SBMA_2-site"]}),
+        cache_directory=tmp_path / "second",
+    )
+
+    first_fingerprint = first_generator._build_monomer_group_fingerprint()
+    second_fingerprint = second_generator._build_monomer_group_fingerprint()
+
+    assert first_fingerprint["algorithm"] == "polyzymd-monomer-group-sha256-v2"
+    assert first_fingerprint["digest"] != second_fingerprint["digest"]
+
+
+def test_real_monomer_group_list_content_change_rejects_cache_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dynamic cache validation should reject changed real fragment lists."""
+    fragments = _real_halogen_fragments()
+    current_generator = PolymerGenerator(
+        monomer_group=_make_real_halogen_monomer_group(),
+        cache_directory=tmp_path,
+    )
+    stale_generator = PolymerGenerator(
+        monomer_group=_make_real_halogen_monomer_group({"PEGMA_2-site": fragments["SBMA_2-site"]}),
+        cache_directory=tmp_path,
+    )
+    cache_path = tmp_path / "PEGMA_seq=BBBBB_5-mer_charged.sdf"
+    cache_path.write_text("stale cache", encoding="utf-8")
+    _write_metadata(stale_generator, cache_path, "BBBBB", {"A": "SBMA", "B": "PEGMA"})
+
+    def fail_load_cache(path: Path) -> object:
+        """Fail if fingerprint-mismatched cache loading is attempted.
+
+        Parameters
+        ----------
+        path : Path
+            Unexpected cache path.
+
+        Returns
+        -------
+        object
+            Never returned because the test fails first.
+        """
+        pytest.fail(f"Fingerprint-mismatched dynamic cache was loaded directly: {path}")
+
+    monkeypatch.setattr(polymer_generator_module, "_topology_from_sdf", fail_load_cache)
+
+    assert current_generator.get_cached_polymer("BBBBB", {"A": "SBMA", "B": "PEGMA"}) is None

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -133,6 +133,44 @@ class TestConfigValidation:
         )
         assert len(config.monomers) == 2
 
+    @pytest.mark.parametrize("length", [1, 2])
+    def test_dynamic_polymer_length_requires_non_empty_middle_sequence(self, length: int):
+        """Dynamic polymer configuration should reject lengths below three."""
+        from polyzymd.config.schema import MonomerSpec, PolymerConfig, ReactionConfig
+
+        reactions = ReactionConfig(
+            initiation=Path("initiation.rxn"),
+            polymerization=Path("polymerization.rxn"),
+            termination=Path("termination.rxn"),
+        )
+
+        with pytest.raises(ValidationError, match="length.*>= 3"):
+            PolymerConfig(
+                type_prefix="TEST",
+                generation_mode="dynamic",
+                monomers=[
+                    MonomerSpec(label="A", probability=1.0, name="EGMA", smiles="C=C"),
+                ],
+                length=length,
+                count=1,
+                reactions=reactions,
+            )
+
+    def test_cached_polymer_length_one_is_accepted(self):
+        """Cached polymer configuration should allow single-monomer SDF inputs."""
+        from polyzymd.config.schema import MonomerSpec, PolymerConfig
+
+        config = PolymerConfig(
+            type_prefix="TEST",
+            generation_mode="cached",
+            monomers=[MonomerSpec(label="A", probability=1.0, name="EGMA")],
+            length=1,
+            count=1,
+            sdf_directory=Path("/tmp/test"),
+        )
+
+        assert config.length == 1
+
     def test_thermodynamics_config(self):
         """Test ThermodynamicsConfig validation and defaults."""
         from pydantic import ValidationError


### PR DESCRIPTION
## Summary

This hotfix fixes dynamic polymer generation for multi-monomer configurations where one monomer has zero probability, but is still present in the configured monomer set.

The reported failure case was a 100% PEGMA configuration:

```yaml
monomers:
  - label: A
    probability: 0.0
    name: SBMA
  - label: B
    probability: 1.0
    name: PEGMA
```

PolyzyMD correctly generated the symbolic sequence `BBBBB`, but did not pass an explicit `sequence_map` to Polymerist. Polymerist then used its default order-based mapping and could map the middle `B` units to the first available 2-site fragment, e.g. `SBMA_2-site`, producing a nominal `PEGMA_seq=BBBBB` polymer contaminated with SBMA fragments.

## Changes

- Pass explicit Polymerist `sequence_map` for middle monomers.
  - Example: `B -> PEGMA_2-site`
- Keep terminal fragments explicit.
  - Example: `PEGMA_1-site` for head/tail PEGMA units
- Add dynamic polymer cache metadata sidecars containing:
  - schema version
  - charger type
  - sequence
  - middle sequence
  - sequence map
  - terminal fragments
  - used monomer/residue mappings
  - deterministic list-aware monomer-group fingerprint
- Reject dynamic cache entries with:
  - missing metadata
  - stale schema
  - mismatched sequence/mapping/charger/fingerprint
  - wrong-shaped JSON metadata, e.g. `[]`, `"stale"`, or `1`
- Metadata-gate generated-style dynamic SDFs in `sdf_directory`.
- Preserve cached-mode support for user-provided/short SDFs.
- Reject dynamic polymers with length `< 3` using clear validation, since the current Polymerist path requires a non-empty middle sequence.
- Add clear `ValueError` for unknown dynamic sequence labels instead of raw `KeyError`.
- Preserve lazy imports: importing `polyzymd.builders.polymer_generator` does not import Polymerist/OpenFF/OpenMM.
- Add regression tests, including tests that exercise real Polymerist data structures/code paths.

## Verification

Live clean dynamic regeneration from the reported user config:

```text
/projects/jola3134/Enzyme_Immobilization/SPUR_help/100pegma/config.yaml
```

now produces a pure PEGMA `BBBBB` polymer:

```text
sequence: BBBBB
sequence_map: {"B": "PEGMA_2-site"}
terminals: PEGMA_1-site / PEGMA_1-site
elements: C/H/O only
residues: PE1/PE2 only
metadata: PEGMA_1-site / PEGMA_2-site only
no SBMA/SBM/SB1/SB2
no N/S atoms
```

Final checks passed:

```text
ruff targeted files: PASS
black --check targeted files: PASS
pytest tests/builders/test_polymer_generator.py tests/config/test_schema.py -v
  79 passed
pytest tests/builders/ tests/config/ -v
  173 passed
lazy import check: PASS, heavy_modules=[]
```
