### PR TITLE
Phase 7: deduplicate relaxation helpers

### DIFF
--- a/src/polyzymd/builders/conjugation/relaxation/_diagnostics.py
+++ b/src/polyzymd/builders/conjugation/relaxation/_diagnostics.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import logging
 import math
 from typing import Any
 
 import numpy as np
 
-LOGGER = logging.getLogger(__name__)
-_POSITION_CONVERSION_ERRORS = (AttributeError, TypeError, ValueError)
+from polyzymd.builders.conjugation.relaxation.geometry import positions_to_numpy
 
 
 def validate_finite_energy(value: float, *, label: str = "energy") -> None:
@@ -57,7 +55,7 @@ def validate_finite_positions(
     float
         Maximum per-axis coordinate span in nanometers.
     """
-    array = _positions_to_numpy(positions, unit_module)
+    array = positions_to_numpy(positions, unit_module)
     if array.size == 0:
         raise RuntimeError(f"OpenMM relaxation produced empty {label}")
     if not np.all(np.isfinite(array)):
@@ -72,39 +70,3 @@ def validate_finite_positions(
             "Refusing to continue with expanded post-relaxation coordinates."
         )
     return span_nm
-
-
-def _positions_to_numpy(positions: Any, unit_module: Any | None) -> np.ndarray:
-    """Convert coordinate containers to a NumPy array for finite checks.
-
-    Parameters
-    ----------
-    positions : Any
-        Coordinate container or unit-bearing quantity.
-    unit_module : Any or None
-        OpenMM unit module used for nanometer conversion when available.
-
-    Returns
-    -------
-    numpy.ndarray
-        Coordinate array as floating-point nanometer values.
-    """
-    conversion_error: Exception | None = None
-    if unit_module is not None and hasattr(positions, "value_in_unit"):
-        try:
-            return np.asarray(positions.value_in_unit(unit_module.nanometer), dtype=float)
-        except _POSITION_CONVERSION_ERRORS as exc:
-            conversion_error = exc
-    if hasattr(positions, "m_as"):
-        try:
-            return np.asarray(positions.m_as("nanometer"), dtype=float)
-        except _POSITION_CONVERSION_ERRORS as exc:
-            conversion_error = exc
-    if conversion_error is not None:
-        LOGGER.warning(
-            "Falling back to raw np.asarray() for positions of type %s after unit-aware "
-            "coordinate conversion failed: %s",
-            type(positions).__name__,
-            conversion_error,
-        )
-    return np.asarray(positions, dtype=float)

--- a/src/polyzymd/builders/conjugation/relaxation/_openmm_system.py
+++ b/src/polyzymd/builders/conjugation/relaxation/_openmm_system.py
@@ -14,7 +14,6 @@ from polyzymd.builders.conjugation.relaxation._diagnostics import (
     validate_finite_energy,
     validate_finite_positions,
 )
-from polyzymd.builders.conjugation.relaxation.geometry import positions_to_numpy
 from polyzymd.builders.conjugation.relaxation.models import (
     ConjugateRelaxationSettings,
     ProductLinkage,
@@ -391,29 +390,6 @@ def _state_energy_kj_mol(state: Any, openmm_unit: Any) -> float:
     if hasattr(energy, "value_in_unit"):
         return float(energy.value_in_unit(openmm_unit.kilojoule_per_mole))
     return float(energy)
-
-
-def _add_positional_restraints(
-    system: Any,
-    positions: Any,
-    atom_indices: tuple[int, ...],
-    restraint_k: float,
-    openmm: Any,
-    openmm_unit: Any,
-) -> None:
-    """Add harmonic positional restraints for selected atoms."""
-    reference_nm = positions_to_numpy(positions, openmm_unit)
-    restraint = openmm.CustomExternalForce("k*periodicdistance(x,y,z,x0,y0,z0)^2")
-    restraint.addGlobalParameter(
-        "k", restraint_k * openmm_unit.kilojoule_per_mole / openmm_unit.nanometer**2
-    )
-    restraint.addPerParticleParameter("x0")
-    restraint.addPerParticleParameter("y0")
-    restraint.addPerParticleParameter("z0")
-    for atom_index in atom_indices:
-        x_coord, y_coord, z_coord = reference_nm[atom_index]
-        restraint.addParticle(atom_index, [float(x_coord), float(y_coord), float(z_coord)])
-    system.addForce(restraint)
 
 
 def _select_platform(openmm: Any, requested_platform: str | None) -> Any:

--- a/src/polyzymd/builders/conjugation/relaxation/_openmm_system.py
+++ b/src/polyzymd/builders/conjugation/relaxation/_openmm_system.py
@@ -11,17 +11,16 @@ from typing import Any
 import numpy as np
 
 from polyzymd.builders.conjugation.relaxation._diagnostics import (
-    _positions_to_numpy,
     validate_finite_energy,
     validate_finite_positions,
 )
+from polyzymd.builders.conjugation.relaxation.geometry import positions_to_numpy
 from polyzymd.builders.conjugation.relaxation.models import (
     ConjugateRelaxationSettings,
     ProductLinkage,
 )
 
 LOGGER = logging.getLogger(__name__)
-_POSITION_CONVERSION_ERRORS = (AttributeError, TypeError, ValueError)
 
 
 def _freeze_protein_chain_masses(
@@ -355,7 +354,7 @@ def _add_positional_restraints(
     openmm_unit: Any,
 ) -> None:
     """Add harmonic positional restraints for selected atoms."""
-    reference_nm = _positions_to_numpy(positions, openmm_unit)
+    reference_nm = positions_to_numpy(positions, openmm_unit)
     restraint = openmm.CustomExternalForce("k*periodicdistance(x,y,z,x0,y0,z0)^2")
     restraint.addGlobalParameter(
         "k", restraint_k * openmm_unit.kilojoule_per_mole / openmm_unit.nanometer**2

--- a/src/polyzymd/builders/conjugation/relaxation/_openmm_system.py
+++ b/src/polyzymd/builders/conjugation/relaxation/_openmm_system.py
@@ -82,6 +82,54 @@ def _set_zero_initial_velocities(context: Any, topology: Any, openmm_unit: Any) 
     context.setVelocities(velocities)
 
 
+def _create_relaxation_verlet_integrator(openmm: Any, openmm_unit: Any) -> Any:
+    """Create the Verlet integrator used for transient relaxation setup.
+
+    Parameters
+    ----------
+    openmm : Any
+        Imported OpenMM module or compatible test double.
+    openmm_unit : Any
+        Imported OpenMM unit module or compatible test double.
+
+    Returns
+    -------
+    Any
+        OpenMM Verlet integrator with the established relaxation timestep.
+    """
+    return openmm.VerletIntegrator(0.001 * openmm_unit.picoseconds)
+
+
+def _create_simulation(
+    topology: Any,
+    system: Any,
+    integrator: Any,
+    openmm_app: Any,
+    platform: Any,
+) -> Any:
+    """Create an OpenMM simulation with the selected platform.
+
+    Parameters
+    ----------
+    topology : Any
+        OpenMM-compatible topology.
+    system : Any
+        OpenMM-compatible system.
+    integrator : Any
+        OpenMM-compatible integrator.
+    openmm_app : Any
+        Imported ``openmm.app`` module or compatible test double.
+    platform : Any
+        Selected OpenMM platform.
+
+    Returns
+    -------
+    Any
+        OpenMM simulation object.
+    """
+    return openmm_app.Simulation(topology, system, integrator, platform)
+
+
 def _run_fixed_product_md(
     topology: Any,
     system: Any,
@@ -103,7 +151,7 @@ def _run_fixed_product_md(
                 settings.friction_per_picosecond / openmm_unit.picosecond,
                 timestep_fs * openmm_unit.femtosecond,
             )
-            simulation = openmm_app.Simulation(topology, system, integrator, platform)
+            simulation = _create_simulation(topology, system, integrator, openmm_app, platform)
             simulation.context.setPositions(positions)
             _set_zero_initial_velocities(simulation.context, topology, openmm_unit)
             energy_before = _state_energy_kj_mol(
@@ -393,7 +441,7 @@ def _validate_platform_context(openmm: Any, platform: Any) -> None:
 
     system = openmm.System()
     system.addParticle(39.9)
-    integrator = openmm.VerletIntegrator(0.001 * openmm_unit.picoseconds)
+    integrator = _create_relaxation_verlet_integrator(openmm, openmm_unit)
     context = openmm.Context(system, integrator, platform)
     context.setPositions([[0.0, 0.0, 0.0]] * openmm_unit.nanometer)
     context.getState(getEnergy=True)

--- a/src/polyzymd/builders/conjugation/relaxation/_openmm_workflows.py
+++ b/src/polyzymd/builders/conjugation/relaxation/_openmm_workflows.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any
 
 from polyzymd.builders.conjugation.relaxation._diagnostics import (
-    _positions_to_numpy,
     validate_finite_energy,
     validate_finite_positions,
 )
@@ -34,6 +33,7 @@ from polyzymd.builders.conjugation.relaxation._openmm_system import (
     _state_energy_kj_mol,
     _write_openmm_pdb,
 )
+from polyzymd.builders.conjugation.relaxation.geometry import positions_to_numpy
 from polyzymd.builders.conjugation.relaxation.models import (
     ConjugateRelaxationDiagnostics,
     ConjugateRelaxationResult,
@@ -158,7 +158,7 @@ def run_conjugate_relaxation_workflow(
         openmm_unit,
         product_pdb_path,
     )
-    initial_coords_nm = _positions_to_numpy(initial_positions, openmm_unit)
+    initial_coords_nm = positions_to_numpy(initial_positions, openmm_unit)
     linkage_pairs = resolve_product_linkage_pairs(
         topology,
         product_pdb_path=product_pdb_path,
@@ -238,7 +238,7 @@ def run_conjugate_relaxation_workflow(
             group_labels_min,
             openmm_unit,
         )
-        minimized_coords_nm = _positions_to_numpy(minimized_positions, openmm_unit)
+        minimized_coords_nm = positions_to_numpy(minimized_positions, openmm_unit)
         stage_a_protein_rmsd, stage_a_protein_max = _protein_displacements_angstrom(
             initial_coords_nm,
             minimized_coords_nm,
@@ -278,7 +278,7 @@ def run_conjugate_relaxation_workflow(
             _restore_particle_masses(system_md, _original_masses)
 
         _write_openmm_pdb(openmm_app, topology, final_positions, relaxed_pdb)
-        final_coords_nm = _positions_to_numpy(final_positions, openmm_unit)
+        final_coords_nm = positions_to_numpy(final_positions, openmm_unit)
         stage_b_protein_rmsd, stage_b_protein_max = _protein_displacements_angstrom(
             minimized_coords_nm,
             final_coords_nm,

--- a/src/polyzymd/builders/conjugation/relaxation/_openmm_workflows.py
+++ b/src/polyzymd/builders/conjugation/relaxation/_openmm_workflows.py
@@ -20,6 +20,8 @@ from polyzymd.builders.conjugation.relaxation._linkages import (
 from polyzymd.builders.conjugation.relaxation._openmm_system import (
     _add_linkage_anchor_restraints,
     _assign_force_groups,
+    _create_relaxation_verlet_integrator,
+    _create_simulation,
     _force_group_energies,
     _force_group_labels,
     _freeze_protein_chain_masses,
@@ -208,8 +210,8 @@ def run_conjugate_relaxation_workflow(
             openmm_unit,
         )
         group_labels_min = _force_group_labels(system_min, existing_labels=group_labels_min)
-        integrator_min = openmm.VerletIntegrator(0.001 * openmm_unit.picoseconds)
-        simulation = openmm_app.Simulation(topology, system_min, integrator_min, platform)
+        integrator_min = _create_relaxation_verlet_integrator(openmm, openmm_unit)
+        simulation = _create_simulation(topology, system_min, integrator_min, openmm_app, platform)
         simulation.context.setPositions(initial_positions)
         energy_before_min = _state_energy_kj_mol(
             simulation.context.getState(getEnergy=True),

--- a/src/polyzymd/builders/conjugation/relaxation/_openmm_workflows.py
+++ b/src/polyzymd/builders/conjugation/relaxation/_openmm_workflows.py
@@ -51,6 +51,162 @@ def _openmm_stage_errors(openmm: Any) -> tuple[type[BaseException], ...]:
     return (RuntimeError, ValueError, ArithmeticError, openmm_error)
 
 
+def _finite_or_none(value: float) -> float | None:
+    """Return a finite diagnostic value or ``None`` for JSON-safe output.
+
+    Parameters
+    ----------
+    value : float
+        Numeric diagnostic value that may be non-finite.
+
+    Returns
+    -------
+    float or None
+        ``float(value)`` when finite, otherwise ``None``.
+    """
+    return float(value) if math.isfinite(value) else None
+
+
+def _build_relaxation_diagnostics(
+    *,
+    success: bool,
+    platform_name: str,
+    relaxation_settings: ConjugateRelaxationSettings,
+    fixed_indices: tuple[int, ...],
+    anchor_count: int,
+    removed_barostats: int,
+    energy_before_min: float,
+    energy_after_min: float,
+    energy_before_md: float,
+    energy_after_md: float,
+    force_energies_before_min: dict[str, float],
+    force_energies_after_min: dict[str, float],
+    stage_a_protein_rmsd: float,
+    stage_a_protein_max: float,
+    stage_a_distances: tuple[float, ...],
+    stage_b_protein_rmsd: float,
+    stage_b_protein_max: float,
+    initial_to_final_protein_rmsd: float,
+    initial_to_final_protein_max: float,
+    distances: tuple[float, ...],
+    errors: tuple[float, ...],
+    relaxed_pdb: Path,
+    linkage_pairs: tuple[Any, ...],
+    warnings: list[str],
+    error_type: str | None = None,
+    error_message: str | None = None,
+    error_traceback: str | None = None,
+) -> ConjugateRelaxationDiagnostics:
+    """Build the relaxation diagnostics payload without changing schema.
+
+    Parameters
+    ----------
+    success : bool
+        Whether both relaxation stages completed successfully.
+    platform_name : str
+        Name of the OpenMM platform used for the workflow.
+    relaxation_settings : ConjugateRelaxationSettings
+        Settings used to run relaxation.
+    fixed_indices : tuple of int
+        Fixed protein atom indices from Stage B.
+    anchor_count : int
+        Number of temporary linkage anchor restraints.
+    removed_barostats : int
+        Number of removed barostat forces.
+    energy_before_min, energy_after_min, energy_before_md, energy_after_md : float
+        Stage energy diagnostics in kJ/mol.
+    force_energies_before_min, force_energies_after_min : dict of str to float
+        Stage A force-group energy diagnostics.
+    stage_a_protein_rmsd, stage_a_protein_max : float
+        Stage A protein displacement diagnostics.
+    stage_a_distances : tuple of float
+        Stage A linkage distances.
+    stage_b_protein_rmsd, stage_b_protein_max : float
+        Stage B protein displacement diagnostics relative to Stage A.
+    initial_to_final_protein_rmsd, initial_to_final_protein_max : float
+        Stage B protein displacement diagnostics relative to initial coordinates.
+    distances : tuple of float
+        Final linkage distances.
+    errors : tuple of float
+        Final linkage distance errors.
+    relaxed_pdb : pathlib.Path
+        Final relaxed PDB path.
+    linkage_pairs : tuple of Any
+        Resolved product linkage pairs.
+    warnings : list of str
+        Warning messages accumulated during relaxation.
+    error_type, error_message, error_traceback : str or None, optional
+        Failure diagnostics, by default ``None``.
+
+    Returns
+    -------
+    ConjugateRelaxationDiagnostics
+        Diagnostics model matching the existing JSON schema.
+    """
+    if success:
+        stage_a_energy_before = float(energy_before_min)
+        stage_a_energy_after = float(energy_after_min)
+        stage_b_energy_before = float(energy_before_md)
+        stage_b_energy_after = float(energy_after_md)
+        stage_a_rmsd = stage_a_protein_rmsd
+        stage_a_max = stage_a_protein_max
+        stage_b_rmsd = stage_b_protein_rmsd
+        stage_b_max = stage_b_protein_max
+        initial_to_final_rmsd = initial_to_final_protein_rmsd
+        initial_to_final_max = initial_to_final_protein_max
+        final_relaxed_pdb_path = relaxed_pdb
+    else:
+        stage_a_energy_before = _finite_or_none(energy_before_min)
+        stage_a_energy_after = _finite_or_none(energy_after_min)
+        stage_b_energy_before = _finite_or_none(energy_before_md)
+        stage_b_energy_after = _finite_or_none(energy_after_md)
+        stage_a_rmsd = _finite_or_none(stage_a_protein_rmsd)
+        stage_a_max = _finite_or_none(stage_a_protein_max)
+        stage_b_rmsd = _finite_or_none(stage_b_protein_rmsd)
+        stage_b_max = _finite_or_none(stage_b_protein_max)
+        initial_to_final_rmsd = _finite_or_none(initial_to_final_protein_rmsd)
+        initial_to_final_max = _finite_or_none(initial_to_final_protein_max)
+        final_relaxed_pdb_path = relaxed_pdb if relaxed_pdb.exists() else None
+
+    return ConjugateRelaxationDiagnostics(
+        success=success,
+        stage_a_success=success or math.isfinite(energy_after_min),
+        stage_b_success=success,
+        platform_name=platform_name,
+        settings=relaxation_settings.model_dump(mode="json"),
+        md_steps=relaxation_settings.md_steps,
+        fixed_atom_count=len(fixed_indices),
+        temporary_anchor_count=anchor_count,
+        removed_barostat_count=removed_barostats,
+        barostat_used=False,
+        stage_a_energy_before_min_kj_mol=stage_a_energy_before,
+        stage_a_energy_after_min_kj_mol=stage_a_energy_after,
+        stage_a_force_group_energies_before_min_kj_mol=force_energies_before_min,
+        stage_a_force_group_energies_after_min_kj_mol=force_energies_after_min,
+        stage_a_protein_rmsd_from_initial_angstrom=stage_a_rmsd,
+        stage_a_protein_max_displacement_from_initial_angstrom=stage_a_max,
+        stage_a_linkage_distances_angstrom=stage_a_distances,
+        stage_b_energy_before_md_kj_mol=stage_b_energy_before,
+        stage_b_energy_after_md_kj_mol=stage_b_energy_after,
+        stage_b_protein_rmsd_from_stage_a_angstrom=stage_b_rmsd,
+        stage_b_protein_max_displacement_from_stage_a_angstrom=stage_b_max,
+        stage_b_protein_rmsd_from_initial_angstrom=initial_to_final_rmsd,
+        stage_b_protein_max_displacement_from_initial_angstrom=initial_to_final_max,
+        stage_b_linkage_distances_angstrom=distances,
+        stage_b_linkage_distance_errors_angstrom=errors,
+        final_relaxed_pdb_path=final_relaxed_pdb_path,
+        protein_rmsd_angstrom=stage_b_rmsd,
+        protein_max_displacement_angstrom=stage_b_max,
+        linkage_distances_angstrom=distances,
+        linkage_distance_errors_angstrom=errors,
+        linkage_pairs=tuple(linkage_pairs),
+        warnings=tuple(warnings),
+        error_type=error_type,
+        error_message=error_message,
+        traceback=error_traceback,
+    )
+
+
 def _stage_b_tolerance_violations(
     *,
     stage_b_protein_rmsd: float,
@@ -310,118 +466,75 @@ def run_conjugate_relaxation_workflow(
             raise RuntimeError(f"Conjugate relaxation Stage B evidence failed: {violation_text}")
     except _openmm_stage_errors(openmm) as exc:
         failure_path = artifact_dir / relaxation_settings.failure_json_name
+        exc_traceback = traceback.format_exc()
         failure_payload = {
             "success": False,
             "error_type": type(exc).__name__,
             "error_message": str(exc),
-            "traceback": traceback.format_exc(),
+            "traceback": exc_traceback,
             "energy_before_min_kj_mol": energy_before_min,
             "energy_after_min_kj_mol": energy_after_min,
             "energy_before_md_kj_mol": energy_before_md,
             "energy_after_md_kj_mol": energy_after_md,
         }
         failure_path.write_text(json.dumps(failure_payload, indent=2) + "\n", encoding="utf-8")
-        diagnostics = ConjugateRelaxationDiagnostics(
+        diagnostics = _build_relaxation_diagnostics(
             success=False,
-            stage_a_success=math.isfinite(energy_after_min),
-            stage_b_success=False,
             platform_name=platform_name,
-            settings=relaxation_settings.model_dump(mode="json"),
-            md_steps=relaxation_settings.md_steps,
-            fixed_atom_count=len(fixed_indices),
-            temporary_anchor_count=anchor_count,
-            removed_barostat_count=removed_barostats,
-            barostat_used=False,
-            stage_a_energy_before_min_kj_mol=(
-                float(energy_before_min) if math.isfinite(energy_before_min) else None
-            ),
-            stage_a_energy_after_min_kj_mol=(
-                float(energy_after_min) if math.isfinite(energy_after_min) else None
-            ),
-            stage_a_force_group_energies_before_min_kj_mol=force_energies_before_min,
-            stage_a_force_group_energies_after_min_kj_mol=force_energies_after_min,
-            stage_a_protein_rmsd_from_initial_angstrom=(
-                stage_a_protein_rmsd if math.isfinite(stage_a_protein_rmsd) else None
-            ),
-            stage_a_protein_max_displacement_from_initial_angstrom=(
-                stage_a_protein_max if math.isfinite(stage_a_protein_max) else None
-            ),
-            stage_a_linkage_distances_angstrom=stage_a_distances,
-            stage_b_energy_before_md_kj_mol=(
-                float(energy_before_md) if math.isfinite(energy_before_md) else None
-            ),
-            stage_b_energy_after_md_kj_mol=(
-                float(energy_after_md) if math.isfinite(energy_after_md) else None
-            ),
-            stage_b_protein_rmsd_from_stage_a_angstrom=(
-                stage_b_protein_rmsd if math.isfinite(stage_b_protein_rmsd) else None
-            ),
-            stage_b_protein_max_displacement_from_stage_a_angstrom=(
-                stage_b_protein_max if math.isfinite(stage_b_protein_max) else None
-            ),
-            stage_b_protein_rmsd_from_initial_angstrom=(
-                initial_to_final_protein_rmsd
-                if math.isfinite(initial_to_final_protein_rmsd)
-                else None
-            ),
-            stage_b_protein_max_displacement_from_initial_angstrom=(
-                initial_to_final_protein_max
-                if math.isfinite(initial_to_final_protein_max)
-                else None
-            ),
-            stage_b_linkage_distances_angstrom=distances,
-            stage_b_linkage_distance_errors_angstrom=errors,
-            final_relaxed_pdb_path=relaxed_pdb if relaxed_pdb.exists() else None,
-            protein_rmsd_angstrom=(
-                stage_b_protein_rmsd if math.isfinite(stage_b_protein_rmsd) else None
-            ),
-            protein_max_displacement_angstrom=(
-                stage_b_protein_max if math.isfinite(stage_b_protein_max) else None
-            ),
-            linkage_distances_angstrom=distances,
-            linkage_distance_errors_angstrom=errors,
+            relaxation_settings=relaxation_settings,
+            fixed_indices=fixed_indices,
+            anchor_count=anchor_count,
+            removed_barostats=removed_barostats,
+            energy_before_min=energy_before_min,
+            energy_after_min=energy_after_min,
+            energy_before_md=energy_before_md,
+            energy_after_md=energy_after_md,
+            force_energies_before_min=force_energies_before_min,
+            force_energies_after_min=force_energies_after_min,
+            stage_a_protein_rmsd=stage_a_protein_rmsd,
+            stage_a_protein_max=stage_a_protein_max,
+            stage_a_distances=stage_a_distances,
+            stage_b_protein_rmsd=stage_b_protein_rmsd,
+            stage_b_protein_max=stage_b_protein_max,
+            initial_to_final_protein_rmsd=initial_to_final_protein_rmsd,
+            initial_to_final_protein_max=initial_to_final_protein_max,
+            distances=distances,
+            errors=errors,
+            relaxed_pdb=relaxed_pdb,
             linkage_pairs=tuple(linkage_pairs),
-            warnings=tuple(warnings),
+            warnings=warnings,
             error_type=type(exc).__name__,
             error_message=str(exc),
-            traceback=traceback.format_exc(),
+            error_traceback=exc_traceback,
         )
         diagnostics.write_json(diagnostics_path)
         raise
 
-    diagnostics = ConjugateRelaxationDiagnostics(
+    diagnostics = _build_relaxation_diagnostics(
         success=True,
-        stage_a_success=True,
-        stage_b_success=True,
         platform_name=platform_name,
-        settings=relaxation_settings.model_dump(mode="json"),
-        md_steps=relaxation_settings.md_steps,
-        fixed_atom_count=len(fixed_indices),
-        temporary_anchor_count=anchor_count,
-        removed_barostat_count=removed_barostats,
-        barostat_used=False,
-        stage_a_energy_before_min_kj_mol=float(energy_before_min),
-        stage_a_energy_after_min_kj_mol=float(energy_after_min),
-        stage_a_force_group_energies_before_min_kj_mol=force_energies_before_min,
-        stage_a_force_group_energies_after_min_kj_mol=force_energies_after_min,
-        stage_a_protein_rmsd_from_initial_angstrom=stage_a_protein_rmsd,
-        stage_a_protein_max_displacement_from_initial_angstrom=stage_a_protein_max,
-        stage_a_linkage_distances_angstrom=stage_a_distances,
-        stage_b_energy_before_md_kj_mol=float(energy_before_md),
-        stage_b_energy_after_md_kj_mol=float(energy_after_md),
-        stage_b_protein_rmsd_from_stage_a_angstrom=stage_b_protein_rmsd,
-        stage_b_protein_max_displacement_from_stage_a_angstrom=stage_b_protein_max,
-        stage_b_protein_rmsd_from_initial_angstrom=initial_to_final_protein_rmsd,
-        stage_b_protein_max_displacement_from_initial_angstrom=initial_to_final_protein_max,
-        stage_b_linkage_distances_angstrom=distances,
-        stage_b_linkage_distance_errors_angstrom=errors,
-        final_relaxed_pdb_path=relaxed_pdb,
-        protein_rmsd_angstrom=stage_b_protein_rmsd,
-        protein_max_displacement_angstrom=stage_b_protein_max,
-        linkage_distances_angstrom=distances,
-        linkage_distance_errors_angstrom=errors,
+        relaxation_settings=relaxation_settings,
+        fixed_indices=fixed_indices,
+        anchor_count=anchor_count,
+        removed_barostats=removed_barostats,
+        energy_before_min=energy_before_min,
+        energy_after_min=energy_after_min,
+        energy_before_md=energy_before_md,
+        energy_after_md=energy_after_md,
+        force_energies_before_min=force_energies_before_min,
+        force_energies_after_min=force_energies_after_min,
+        stage_a_protein_rmsd=stage_a_protein_rmsd,
+        stage_a_protein_max=stage_a_protein_max,
+        stage_a_distances=stage_a_distances,
+        stage_b_protein_rmsd=stage_b_protein_rmsd,
+        stage_b_protein_max=stage_b_protein_max,
+        initial_to_final_protein_rmsd=initial_to_final_protein_rmsd,
+        initial_to_final_protein_max=initial_to_final_protein_max,
+        distances=distances,
+        errors=errors,
+        relaxed_pdb=relaxed_pdb,
         linkage_pairs=tuple(linkage_pairs),
-        warnings=tuple(warnings),
+        warnings=warnings,
     )
     diagnostics.write_json(diagnostics_path)
     return ConjugateRelaxationResult(

--- a/src/polyzymd/builders/conjugation/relaxation/geometry.py
+++ b/src/polyzymd/builders/conjugation/relaxation/geometry.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+
+LOGGER = logging.getLogger(__name__)
+_POSITION_CONVERSION_ERRORS = (AttributeError, TypeError, ValueError)
 
 
 def positions_to_numpy(positions: Any, unit_module: Any | None = None) -> np.ndarray:
@@ -23,10 +27,24 @@ def positions_to_numpy(positions: Any, unit_module: Any | None = None) -> np.nda
     numpy.ndarray
         Coordinate array in nanometers when units are available.
     """
+    conversion_error: Exception | None = None
     if unit_module is not None and hasattr(positions, "value_in_unit"):
-        return np.asarray(positions.value_in_unit(unit_module.nanometer), dtype=float)
+        try:
+            return np.asarray(positions.value_in_unit(unit_module.nanometer), dtype=float)
+        except _POSITION_CONVERSION_ERRORS as exc:
+            conversion_error = exc
     if hasattr(positions, "m_as"):
-        return np.asarray(positions.m_as("nanometer"), dtype=float)
+        try:
+            return np.asarray(positions.m_as("nanometer"), dtype=float)
+        except _POSITION_CONVERSION_ERRORS as exc:
+            conversion_error = exc
+    if conversion_error is not None:
+        LOGGER.warning(
+            "Falling back to raw np.asarray() for positions of type %s after unit-aware "
+            "coordinate conversion failed: %s",
+            type(positions).__name__,
+            conversion_error,
+        )
     return np.asarray(positions, dtype=float)
 
 

--- a/tests/test_conjugation_relaxation.py
+++ b/tests/test_conjugation_relaxation.py
@@ -16,7 +16,6 @@ from pydantic import ValidationError
 import polyzymd.builders.conjugation.relaxation._openmm_workflows as relaxation_workflows
 import polyzymd.builders.conjugation.relaxation.openmm as relaxation
 from polyzymd.builders.conjugation.relaxation._diagnostics import (
-    _positions_to_numpy,
     validate_finite_energy,
     validate_finite_positions,
 )
@@ -28,6 +27,7 @@ from polyzymd.builders.conjugation.relaxation._openmm_system import (
     _restore_particle_masses,
     _run_fixed_product_md,
 )
+from polyzymd.builders.conjugation.relaxation.geometry import positions_to_numpy
 from polyzymd.builders.conjugation.relaxation.models import (
     ConjugateRelaxationDiagnostics,
     ConjugateRelaxationSettings,
@@ -566,7 +566,7 @@ def test_positions_to_numpy_logs_expected_conversion_fallback(caplog):
     unit_module = type("UnitModule", (), {"nanometer": "nanometer"})()
 
     with caplog.at_level("WARNING"):
-        array = _positions_to_numpy(RawArrayPositions(), unit_module)
+        array = positions_to_numpy(RawArrayPositions(), unit_module)
 
     np.testing.assert_allclose(array, [[0.0, 0.0, 0.0]])
     assert "Falling back to raw np.asarray()" in caplog.text


### PR DESCRIPTION
## Summary
- Deduplicate relaxation coordinate conversion into one canonical geometry.positions_to_numpy() function; no compatibility shim retained.
- Reuse shared OpenMM relaxation setup helpers for integrators and simulations while preserving platform semantics.
- Consolidate relaxation diagnostics payload construction without changing conjugate_relaxation.json schema.
- Remove unused _add_positional_restraints() helper after confirming no references.

## Verification
- pixi run -e build pytest tests/test_conjugation_relaxation.py -v: 21 passed, 1 skipped
- pixi run -e build pytest tests/test_conjugation_validation.py -v: 49 passed
- pixi run -e build pytest tests/test_conjugation_system_workflow.py tests/test_conjugation_integrated_construction.py tests/test_conjugation_final_interchange.py -v: 36 passed
- pixi run -e build pytest tests/ -v -k conjugation: 337 passed, 3 skipped
- pixi run -e build ruff check src/polyzymd/builders/conjugation tests/test_conjugation_relaxation.py tests/test_conjugation_validation.py: pass
- pixi run -e build black src/polyzymd/builders/conjugation tests/test_conjugation_relaxation.py tests/test_conjugation_validation.py --check: 53 unchanged
- Real checkpoint config completed successfully with expected artifacts in /tmp/polyzymd-refactor-checkpoints/phase-7-final/...run1