### PR TITLE
Phase 8: use safe native APIs

### DIFF
--- a/src/polyzymd/builders/conjugation/pablo/charge_bridge.py
+++ b/src/polyzymd/builders/conjugation/pablo/charge_bridge.py
@@ -946,6 +946,7 @@ def _polymer_template_records(
                 "Attached polymer charged SDF atom count does not match generated fragment: "
                 f"{len(template_charges)} charges vs {len(fragment_atoms)} atom(s) for {sidecar}"
             )
+        fragment_atoms_by_sdf_order = fragment_atoms_in_sdf_order(fragment_atoms)
         mappings = getattr(spec, "product_residue_mappings", {}) or {}
         leaving_names = {
             str(name).strip() for name in getattr(generated_fragment, "leaving_atom_names", ())
@@ -956,7 +957,7 @@ def _polymer_template_records(
         leaving_total = 0.0
         residue_totals: dict[tuple[str, int | None], float] = {}
         mapped_product_count = 0
-        for atom, charge in zip(fragment_atoms, template_charges, strict=True):
+        for atom, charge in zip(fragment_atoms_by_sdf_order, template_charges, strict=True):
             atom_name = str(getattr(atom, "atom_name", "") or getattr(atom, "name", "")).strip()
             if atom_name in leaving_names:
                 leaving_count += 1

--- a/src/polyzymd/builders/conjugation/pablo/product.py
+++ b/src/polyzymd/builders/conjugation/pablo/product.py
@@ -17,13 +17,9 @@ from polyzymd.builders.conjugation._linkage import (
 from polyzymd.builders.conjugation.pablo.sdf import (
     charged_sdf_formal_charges,
     explicit_bond_order,
-    fragment_atom_element,
-    fragment_atoms_in_sdf_order,
-    guess_element,
     read_sdf_molecules,
+    sdf_bond_orders_by_atom_index,
     select_sdf_molecule,
-    validate_sdf_atom_elements,
-    validate_sdf_bond_orders,
 )
 from polyzymd.builders.conjugation.structure.parsing import parse_pdb_conect_pairs
 from polyzymd.builders.conjugation.structure.pdb import PdbAtomRecord
@@ -646,21 +642,26 @@ def _polymer_sdf_bonds(
         source_label="Polymer SDF sidecar",
         prefer_most_bonds=True,
     )
-    validate_sdf_bond_orders(mol, sdf_path, source_label="Polymer SDF sidecar")
+    fragment_atoms = tuple(getattr(generated_fragment, "atoms", ()) or ())
+    sdf_bonds = sdf_bond_orders_by_atom_index(
+        mol,
+        fragment_atoms=fragment_atoms,
+        sdf_path=sdf_path,
+        source_label="Polymer SDF sidecar",
+    )
     unique_atom_names = _unique_fragment_atom_names(generated_fragment)
     bonds: list[tuple[Any, Any, int]] = []
-    for bond in mol.GetBonds():
-        order = explicit_bond_order(bond.GetBondTypeAsDouble(), source=f"SDF {sdf_path}")
+    for begin_index, end_index, order in sdf_bonds:
         atom1 = _fragment_atom_descriptor(
-            atoms_by_index.get(bond.GetBeginAtomIdx()), unique_atom_names=unique_atom_names
+            atoms_by_index.get(begin_index), unique_atom_names=unique_atom_names
         )
         atom2 = _fragment_atom_descriptor(
-            atoms_by_index.get(bond.GetEndAtomIdx()), unique_atom_names=unique_atom_names
+            atoms_by_index.get(end_index), unique_atom_names=unique_atom_names
         )
         if atom1 is None or atom2 is None:
             raise ValueError(
                 "Polymer SDF bond endpoint could not be mapped to a generated-fragment atom: "
-                f"SDF atoms {bond.GetBeginAtomIdx() + 1}-{bond.GetEndAtomIdx() + 1} in "
+                f"SDF atoms {begin_index + 1}-{end_index + 1} in "
                 f"{sdf_path}. Regenerate the polymer PDB/SDF pair from the same source molecule."
             )
         bonds.append((atom1, atom2, order))
@@ -759,7 +760,9 @@ def _product_formal_charges(
         source_residue_aliases=source_residue_aliases,
     )
     charges: dict[tuple[str, str, int, str], dict[str, int]] = defaultdict(dict)
-    for atom_index, atom in enumerate(getattr(generated_fragment, "atoms", ()) or ()):
+    for fallback_index, atom in enumerate(getattr(generated_fragment, "atoms", ()) or ()):
+        raw_atom_index = getattr(atom, "atom_index", None)
+        atom_index = int(raw_atom_index) if raw_atom_index is not None else fallback_index
         charge = charged_formal_charges.get(atom_index, getattr(atom, "formal_charge", None))
         if charge in (None, 0):
             continue
@@ -783,48 +786,6 @@ def _charged_sdf_formal_charges(
         return {}
     fragment_atoms = tuple(getattr(generated_fragment, "atoms", ()) or ())
     return charged_sdf_formal_charges(charged_polymer_sdf, fragment_atoms=fragment_atoms)
-
-
-def _select_sdf_molecule(molecules: list[Any], *, expected_atoms: int, sdf_path: Path) -> Any:
-    """Select the SDF molecule matching the generated-fragment atom count."""
-    return select_sdf_molecule(
-        molecules,
-        expected_atoms=expected_atoms,
-        sdf_path=sdf_path,
-        source_label="Polymer SDF sidecar",
-        prefer_most_bonds=True,
-    )
-
-
-def _validate_sdf_atom_elements(
-    mol: Any,
-    *,
-    fragment_atoms: tuple[Any, ...],
-    sdf_path: Path,
-    source_label: str,
-) -> None:
-    """Validate that an SDF atom sequence matches a generated fragment."""
-    validate_sdf_atom_elements(
-        mol,
-        fragment_atoms=fragment_atoms,
-        sdf_path=sdf_path,
-        source_label=source_label,
-    )
-
-
-def _fragment_atoms_in_sdf_order(fragment_atoms: tuple[Any, ...]) -> tuple[Any, ...]:
-    """Return fragment atoms in the atom-index order used by production SDF sidecars."""
-    return fragment_atoms_in_sdf_order(fragment_atoms)
-
-
-def _fragment_atom_element(atom: Any) -> str:
-    """Return a generated-fragment atom element symbol for sidecar validation."""
-    return fragment_atom_element(atom)
-
-
-def _validate_sdf_bond_orders(mol: Any, sdf_path: Path) -> None:
-    """Require explicit positive bond orders in an SDF source molecule."""
-    validate_sdf_bond_orders(mol, sdf_path, source_label="Polymer SDF sidecar")
 
 
 def _explicit_bond_order(value: Any, *, source: str) -> int:

--- a/src/polyzymd/builders/conjugation/pablo/product.py
+++ b/src/polyzymd/builders/conjugation/pablo/product.py
@@ -625,9 +625,21 @@ def _polymer_sdf_bonds(
         raise ValueError(f"Polymer SDF sidecar does not exist: {sdf_path}")
 
     molecules = read_sdf_molecules(sdf_path, source_label="Polymer SDF")
+    fragment_atoms = tuple(getattr(generated_fragment, "atoms", ()) or ())
+    missing_index_atoms = tuple(
+        getattr(atom, "atom_name", "<unnamed>")
+        for atom in fragment_atoms
+        if getattr(atom, "atom_index", None) is None
+    )
+    if missing_index_atoms:
+        raise ValueError(
+            "Generated polymer fragment atoms require complete atom_index values before SDF bond "
+            "orders can be mapped onto product-state Pablo definitions. Missing atom_index for: "
+            f"{', '.join(str(name) for name in missing_index_atoms)}"
+        )
     atoms_by_index = {
         getattr(atom, "atom_index", None): atom
-        for atom in getattr(generated_fragment, "atoms", ()) or ()
+        for atom in fragment_atoms
         if getattr(atom, "atom_index", None) is not None
     }
     if not atoms_by_index:
@@ -637,12 +649,11 @@ def _polymer_sdf_bonds(
         )
     mol = select_sdf_molecule(
         molecules,
-        expected_atoms=len(atoms_by_index),
+        expected_atoms=len(fragment_atoms),
         sdf_path=sdf_path,
         source_label="Polymer SDF sidecar",
         prefer_most_bonds=True,
     )
-    fragment_atoms = tuple(getattr(generated_fragment, "atoms", ()) or ())
     sdf_bonds = sdf_bond_orders_by_atom_index(
         mol,
         fragment_atoms=fragment_atoms,

--- a/src/polyzymd/builders/conjugation/pablo/product.py
+++ b/src/polyzymd/builders/conjugation/pablo/product.py
@@ -20,6 +20,7 @@ from polyzymd.builders.conjugation.pablo.sdf import (
     read_sdf_molecules,
     sdf_bond_orders_by_atom_index,
     select_sdf_molecule,
+    validate_fragment_atom_indices,
 )
 from polyzymd.builders.conjugation.structure.parsing import parse_pdb_conect_pairs
 from polyzymd.builders.conjugation.structure.pdb import PdbAtomRecord
@@ -626,22 +627,10 @@ def _polymer_sdf_bonds(
 
     molecules = read_sdf_molecules(sdf_path, source_label="Polymer SDF")
     fragment_atoms = tuple(getattr(generated_fragment, "atoms", ()) or ())
-    missing_index_atoms = tuple(
-        getattr(atom, "atom_name", "<unnamed>")
-        for atom in fragment_atoms
-        if getattr(atom, "atom_index", None) is None
+    atoms_by_index = validate_fragment_atom_indices(
+        fragment_atoms,
+        source_label="Generated polymer fragment atoms for SDF bond orders",
     )
-    if missing_index_atoms:
-        raise ValueError(
-            "Generated polymer fragment atoms require complete atom_index values before SDF bond "
-            "orders can be mapped onto product-state Pablo definitions. Missing atom_index for: "
-            f"{', '.join(str(name) for name in missing_index_atoms)}"
-        )
-    atoms_by_index = {
-        getattr(atom, "atom_index", None): atom
-        for atom in fragment_atoms
-        if getattr(atom, "atom_index", None) is not None
-    }
     if not atoms_by_index:
         raise ValueError(
             "Generated polymer fragment atoms do not carry atom_index values, so SDF bond "

--- a/src/polyzymd/builders/conjugation/pablo/sdf.py
+++ b/src/polyzymd/builders/conjugation/pablo/sdf.py
@@ -343,7 +343,13 @@ def validated_charged_sdf_molecule(
 def charged_sdf_partial_charges(
     path: Path | str, *, fragment_atoms: Sequence[Any]
 ) -> tuple[float, ...]:
-    """Read per-atom partial charges from a validated production charged SDF."""
+    """Read per-atom partial charges from a validated production charged SDF.
+
+    Returns
+    -------
+    tuple of float
+        Partial charges in validated SDF atom-index order.
+    """
     if not fragment_atoms:
         raise ValueError("Attached polymer charge transfer requires generated-fragment atoms")
     sdf_path = Path(path)

--- a/src/polyzymd/builders/conjugation/pablo/sdf.py
+++ b/src/polyzymd/builders/conjugation/pablo/sdf.py
@@ -135,6 +135,48 @@ def validate_sdf_bond_orders(mol: Any, sdf_path: Path, *, source_label: str) -> 
         )
 
 
+def sdf_bond_orders_by_atom_index(
+    mol: Any,
+    *,
+    fragment_atoms: Sequence[Any],
+    sdf_path: Path,
+    source_label: str,
+) -> tuple[tuple[int, int, int], ...]:
+    """Return validated SDF bond orders keyed by zero-based atom indices.
+
+    Parameters
+    ----------
+    mol : Any
+        RDKit molecule read from the SDF sidecar.
+    fragment_atoms : sequence of Any
+        Generated-fragment atoms whose order must match the SDF atoms.
+    sdf_path : pathlib.Path
+        Source SDF path for diagnostics.
+    source_label : str
+        Human-readable sidecar label for diagnostics.
+
+    Returns
+    -------
+    tuple of tuple of int
+        ``(begin_index, end_index, order)`` entries using RDKit zero-based atom indices.
+    """
+    validate_sdf_atom_elements(
+        mol,
+        fragment_atoms=fragment_atoms,
+        sdf_path=sdf_path,
+        source_label=source_label,
+    )
+    validate_sdf_bond_orders(mol, sdf_path, source_label=source_label)
+    return tuple(
+        (
+            int(bond.GetBeginAtomIdx()),
+            int(bond.GetEndAtomIdx()),
+            explicit_bond_order(bond.GetBondTypeAsDouble(), source=f"{source_label} {sdf_path}"),
+        )
+        for bond in mol.GetBonds()
+    )
+
+
 def explicit_bond_order(value: Any, *, source: str) -> int:
     """Return a supported integer bond order or raise an actionable error."""
     try:
@@ -153,6 +195,44 @@ def explicit_bond_order(value: Any, *, source: str) -> int:
             "Pablo definitions currently require explicit integer bond orders."
         )
     return int(rounded)
+
+
+def sdf_formal_charges_by_atom_index(
+    mol: Any,
+    *,
+    fragment_atoms: Sequence[Any],
+    sdf_path: Path,
+    source_label: str,
+) -> dict[int, int]:
+    """Return validated non-zero SDF formal charges keyed by zero-based atom index.
+
+    Parameters
+    ----------
+    mol : Any
+        RDKit molecule read from the charged SDF sidecar.
+    fragment_atoms : sequence of Any
+        Generated-fragment atoms whose order must match the SDF atoms.
+    sdf_path : pathlib.Path
+        Source SDF path for diagnostics.
+    source_label : str
+        Human-readable sidecar label for diagnostics.
+
+    Returns
+    -------
+    dict of int to int
+        Non-zero formal charges keyed by RDKit zero-based atom index.
+    """
+    validate_sdf_atom_elements(
+        mol,
+        fragment_atoms=fragment_atoms,
+        sdf_path=sdf_path,
+        source_label=source_label,
+    )
+    return {
+        int(atom.GetIdx()): int(atom.GetFormalCharge())
+        for atom in mol.GetAtoms()
+        if int(atom.GetFormalCharge())
+    }
 
 
 def validated_charged_sdf_molecule(
@@ -213,17 +293,20 @@ def charged_sdf_formal_charges(
     """Return non-zero formal charges from a validated charged SDF sidecar."""
     if not fragment_atoms:
         return {}
-    mol = validated_charged_sdf_molecule(
-        path,
-        fragment_atoms=fragment_atoms,
+    sdf_path = Path(path)
+    molecules = read_sdf_molecules(sdf_path, source_label="Charged polymer SDF")
+    mol = select_sdf_molecule(
+        molecules,
+        expected_atoms=len(fragment_atoms),
+        sdf_path=sdf_path,
         source_label="Charged polymer SDF",
     )
-    charges = {}
-    for atom in mol.GetAtoms():
-        formal_charge = int(atom.GetFormalCharge())
-        if formal_charge:
-            charges[int(atom.GetIdx())] = formal_charge
-    return charges
+    return sdf_formal_charges_by_atom_index(
+        mol,
+        fragment_atoms=fragment_atoms,
+        sdf_path=sdf_path,
+        source_label="Charged polymer SDF",
+    )
 
 
 def guess_element(atom_name: str) -> str:

--- a/src/polyzymd/builders/conjugation/pablo/sdf.py
+++ b/src/polyzymd/builders/conjugation/pablo/sdf.py
@@ -77,9 +77,90 @@ def select_sdf_molecule(
 
 def fragment_atoms_in_sdf_order(fragment_atoms: Sequence[Any]) -> tuple[Any, ...]:
     """Return fragment atoms in the atom-index order used by production SDF sidecars."""
-    if all(getattr(atom, "atom_index", None) is not None for atom in fragment_atoms):
-        return tuple(sorted(fragment_atoms, key=lambda atom: int(atom.atom_index)))
-    return tuple(fragment_atoms)
+    atoms_by_index = validate_fragment_atom_indices(
+        fragment_atoms,
+        source_label="Generated fragment atom_index provenance",
+    )
+    return tuple(atoms_by_index[index] for index in range(len(fragment_atoms)))
+
+
+def validate_fragment_atom_indices(
+    fragment_atoms: Sequence[Any],
+    *,
+    source_label: str,
+) -> dict[int, Any]:
+    """Validate generated-fragment atom indices for identity-preserving SDF mapping.
+
+    Parameters
+    ----------
+    fragment_atoms : sequence of Any
+        Generated-fragment atoms that must carry zero-based atom indices.
+    source_label : str
+        Human-readable mapping path for diagnostics.
+
+    Returns
+    -------
+    dict of int to Any
+        Fragment atoms keyed by validated zero-based atom index.
+    """
+    missing = [
+        str(getattr(atom, "atom_name", None) or getattr(atom, "name", None) or index)
+        for index, atom in enumerate(fragment_atoms)
+        if getattr(atom, "atom_index", None) is None
+    ]
+    if missing:
+        raise ValueError(
+            f"{source_label} requires complete atom_index values before SDF atom-index "
+            "mapping can be used. Missing atom_index for: " + ", ".join(missing)
+        )
+
+    atoms_by_index: dict[int, Any] = {}
+    duplicates: list[int] = []
+    invalid: list[str] = []
+    for atom in fragment_atoms:
+        raw_index = getattr(atom, "atom_index", None)
+        try:
+            atom_index = int(raw_index)
+        except (TypeError, ValueError):
+            invalid.append(str(raw_index))
+            continue
+        if atom_index < 0:
+            invalid.append(str(atom_index))
+            continue
+        if atom_index in atoms_by_index:
+            duplicates.append(atom_index)
+            continue
+        atoms_by_index[atom_index] = atom
+
+    if invalid:
+        preview = ", ".join(invalid[:8])
+        raise ValueError(
+            f"{source_label} requires non-negative integer atom_index values before SDF "
+            f"atom-index mapping can be used. Invalid atom_index values: {preview}"
+        )
+    if duplicates:
+        preview = ", ".join(str(index) for index in sorted(set(duplicates))[:8])
+        raise ValueError(
+            f"{source_label} requires unique atom_index values before SDF atom-index mapping "
+            f"can be used. Duplicate atom_index values: {preview}"
+        )
+
+    expected = set(range(len(fragment_atoms)))
+    observed = set(atoms_by_index)
+    if observed != expected:
+        missing_indices = sorted(expected - observed)
+        out_of_range = sorted(observed - expected)
+        details: list[str] = []
+        if missing_indices:
+            details.append("missing " + ", ".join(str(index) for index in missing_indices[:8]))
+        if out_of_range:
+            details.append("out-of-range " + ", ".join(str(index) for index in out_of_range[:8]))
+        raise ValueError(
+            f"{source_label} requires atom_index values to be contiguous and exactly match "
+            f"0..{len(fragment_atoms) - 1} before SDF atom-index mapping can be used; "
+            + "; ".join(details)
+        )
+    return atoms_by_index
 
 
 def fragment_atom_element(atom: Any) -> str:

--- a/src/polyzymd/builders/conjugation/placement.py
+++ b/src/polyzymd/builders/conjugation/placement.py
@@ -614,6 +614,16 @@ def _minimum_distance(points_a: np.ndarray, points_b: np.ndarray) -> float:
     """Return the minimum pairwise distance between two coordinate arrays."""
     if len(points_a) == 0 or len(points_b) == 0:
         return float("inf")
+    try:
+        from MDAnalysis.lib.distances import distance_array
+
+        return float(np.min(distance_array(points_a, points_b)))
+    except (ImportError, RuntimeError):
+        return _minimum_distance_numpy(points_a, points_b)
+
+
+def _minimum_distance_numpy(points_a: np.ndarray, points_b: np.ndarray) -> float:
+    """Return the minimum pairwise distance using NumPy broadcasting."""
     deltas = points_a[:, np.newaxis, :] - points_b[np.newaxis, :, :]
     distances = np.linalg.norm(deltas, axis=2)
     return float(np.min(distances))

--- a/src/polyzymd/builders/conjugation/placement.py
+++ b/src/polyzymd/builders/conjugation/placement.py
@@ -629,18 +629,33 @@ def _minimum_distance(points_a: np.ndarray, points_b: np.ndarray) -> float:
 def _is_mdanalysis_distance_backend_unavailable(error: RuntimeError) -> bool:
     """Return whether an MDAnalysis distance error is an expected backend failure."""
     message = str(error).lower()
-    expected_markers = (
-        "backend unavailable",
-        "backend is unavailable",
+    backend_unavailable_markers = (
+        "mdanalysis distance backend unavailable",
+        "mdanalysis distance backend is unavailable",
         "distance backend unavailable",
+        "distance backend is unavailable",
         "serial backend unavailable",
+        "serial backend is unavailable",
         "openmp backend unavailable",
+        "openmp backend is unavailable",
         "distopia backend unavailable",
-        "failed to import",
-        "could not import",
-        "no module named",
+        "distopia backend is unavailable",
     )
-    return any(marker in message for marker in expected_markers)
+    if any(marker in message for marker in backend_unavailable_markers):
+        return True
+
+    import_failure_markers = ("failed to import", "could not import", "no module named")
+    backend_context_markers = (
+        "mdanalysis.lib.distances",
+        "mdanalysis distance",
+        "distance backend",
+        "distopia",
+        "openmp backend",
+        "serial backend",
+    )
+    return any(marker in message for marker in import_failure_markers) and any(
+        marker in message for marker in backend_context_markers
+    )
 
 
 def _minimum_distance_numpy(points_a: np.ndarray, points_b: np.ndarray) -> float:

--- a/src/polyzymd/builders/conjugation/placement.py
+++ b/src/polyzymd/builders/conjugation/placement.py
@@ -618,8 +618,29 @@ def _minimum_distance(points_a: np.ndarray, points_b: np.ndarray) -> float:
         from MDAnalysis.lib.distances import distance_array
 
         return float(np.min(distance_array(points_a, points_b)))
-    except (ImportError, RuntimeError):
+    except ImportError:
         return _minimum_distance_numpy(points_a, points_b)
+    except RuntimeError as error:
+        if not _is_mdanalysis_distance_backend_unavailable(error):
+            raise
+        return _minimum_distance_numpy(points_a, points_b)
+
+
+def _is_mdanalysis_distance_backend_unavailable(error: RuntimeError) -> bool:
+    """Return whether an MDAnalysis distance error is an expected backend failure."""
+    message = str(error).lower()
+    expected_markers = (
+        "backend unavailable",
+        "backend is unavailable",
+        "distance backend unavailable",
+        "serial backend unavailable",
+        "openmp backend unavailable",
+        "distopia backend unavailable",
+        "failed to import",
+        "could not import",
+        "no module named",
+    )
+    return any(marker in message for marker in expected_markers)
 
 
 def _minimum_distance_numpy(points_a: np.ndarray, points_b: np.ndarray) -> float:

--- a/src/polyzymd/builders/conjugation/reactions/_roles.py
+++ b/src/polyzymd/builders/conjugation/reactions/_roles.py
@@ -238,8 +238,14 @@ def validate_mapped_smarts(
         generic POC path permits missing product maps so leaving groups can be
         represented explicitly, by default ``False``.
     """
-    reactant_maps = _mapped_atom_numbers(reactant_smarts)
-    product_maps = _mapped_atom_numbers(product_smarts)
+    try:
+        reactant_maps, product_maps = _rdkit_reaction_mapped_atom_numbers(
+            reactant_smarts,
+            product_smarts,
+        )
+    except (ImportError, ValueError):
+        reactant_maps = _mapped_atom_numbers(reactant_smarts)
+        product_maps = _mapped_atom_numbers(product_smarts)
     if not reactant_maps:
         raise ValueError("Reactant SMARTS must contain atom-map numbers")
     if not product_maps:
@@ -411,6 +417,41 @@ def _mapped_atom_numbers(smarts_entries: Sequence[str]) -> tuple[int, ...]:
     maps: set[int] = set()
     for smarts in smarts_entries:
         maps.update(int(match) for match in re.findall(r":(\d+)(?=[^\]]*\])", smarts))
+    return tuple(sorted(maps))
+
+
+def _rdkit_reaction_mapped_atom_numbers(
+    reactant_smarts: Sequence[str],
+    product_smarts: Sequence[str],
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Return mapped atom numbers from an RDKit reaction SMARTS parse.
+
+    RDKit is used only as a parser for full mapped reaction SMARTS. The parsed
+    reaction is not executed and no product generation or substructure matching is
+    performed.
+    """
+    from rdkit.Chem import rdChemReactions
+
+    reaction_smarts = f"{'.'.join(reactant_smarts)}>>{'.'.join(product_smarts)}"
+    try:
+        reaction = rdChemReactions.ReactionFromSmarts(reaction_smarts)
+    except RuntimeError as error:
+        raise ValueError(f"RDKit could not parse reaction SMARTS: {reaction_smarts}") from error
+    if reaction is None:
+        raise ValueError(f"RDKit could not parse reaction SMARTS: {reaction_smarts}")
+    return _rdkit_template_map_numbers(reaction.GetReactants()), _rdkit_template_map_numbers(
+        reaction.GetProducts()
+    )
+
+
+def _rdkit_template_map_numbers(templates: Sequence[Any]) -> tuple[int, ...]:
+    """Return sorted unique atom-map numbers from RDKit reaction templates."""
+    maps: set[int] = set()
+    for template in templates:
+        for atom in template.GetAtoms():
+            map_number = atom.GetAtomMapNum()
+            if map_number:
+                maps.add(int(map_number))
     return tuple(sorted(maps))
 
 

--- a/src/polyzymd/builders/conjugation/reactions/_roles.py
+++ b/src/polyzymd/builders/conjugation/reactions/_roles.py
@@ -492,12 +492,13 @@ def _is_rdkit_parse_runtime_error(error: RuntimeError) -> bool:
     """Return whether an RDKit runtime error is an expected SMARTS parse failure."""
     message = str(error).lower()
     parse_markers = (
-        "parse",
-        "parser",
-        "smarts",
         "chemicalreactionparserexception",
-        "reaction parse",
-        "syntax error",
+        "smarts parse error",
+        "smiles parse error",
+        "failed parsing smarts",
+        "failed parsing smiles",
+        "syntax error in smarts",
+        "syntax error in smiles",
     )
     return any(marker in message for marker in parse_markers)
 

--- a/src/polyzymd/builders/conjugation/reactions/_roles.py
+++ b/src/polyzymd/builders/conjugation/reactions/_roles.py
@@ -436,6 +436,8 @@ def _rdkit_reaction_mapped_atom_numbers(
     try:
         reaction = rdChemReactions.ReactionFromSmarts(reaction_smarts)
     except RuntimeError as error:
+        if not _is_rdkit_parse_runtime_error(error):
+            raise
         raise ValueError(f"RDKit could not parse reaction SMARTS: {reaction_smarts}") from error
     if reaction is None:
         raise ValueError(f"RDKit could not parse reaction SMARTS: {reaction_smarts}")
@@ -472,6 +474,8 @@ def _rdkit_mapped_bond_orders(smarts_entries: Sequence[str]) -> dict[tuple[int, 
         try:
             mol = Chem.MolFromSmarts(smarts)
         except RuntimeError as error:
+            if not _is_rdkit_parse_runtime_error(error):
+                raise
             raise ValueError(f"RDKit could not parse SMARTS: {smarts}") from error
         if mol is None:
             raise ValueError(f"RDKit could not parse SMARTS: {smarts}")
@@ -482,6 +486,20 @@ def _rdkit_mapped_bond_orders(smarts_entries: Sequence[str]) -> dict[tuple[int, 
                 key = tuple(sorted((int(begin), int(end))))
                 bonds[key] = _rdkit_bond_order(bond)
     return bonds
+
+
+def _is_rdkit_parse_runtime_error(error: RuntimeError) -> bool:
+    """Return whether an RDKit runtime error is an expected SMARTS parse failure."""
+    message = str(error).lower()
+    parse_markers = (
+        "parse",
+        "parser",
+        "smarts",
+        "chemicalreactionparserexception",
+        "reaction parse",
+        "syntax error",
+    )
+    return any(marker in message for marker in parse_markers)
 
 
 def _rdkit_bond_order(bond: Any) -> float:

--- a/tests/test_conjugation_charge_bridge.py
+++ b/tests/test_conjugation_charge_bridge.py
@@ -372,6 +372,48 @@ def test_polymer_records_refine_duplicate_atom_names_by_residue_mapping(monkeypa
     assert records[0].charge_e == pytest.approx(0.125)
 
 
+def test_polymer_records_assign_charged_sdf_charges_by_atom_index(monkeypatch, tmp_path):
+    """Polymer template charges should follow atom_index order, not tuple order."""
+    charged_sdf = tmp_path / "polymer_charged.sdf"
+    charged_sdf.write_text("", encoding="utf-8")
+    fragment = SimpleNamespace(
+        atoms=(
+            SimpleNamespace(
+                atom_index=1,
+                atom_name="O001",
+                element="O",
+                residue_name="NHX",
+                residue_number=1,
+                insertion_code="",
+            ),
+            SimpleNamespace(
+                atom_index=0,
+                atom_name="C001",
+                element="C",
+                residue_name="NHX",
+                residue_number=1,
+                insertion_code="",
+            ),
+        ),
+        leaving_atom_names=(),
+    )
+    spec = SimpleNamespace(
+        source_sidecars={"charged_sdf": charged_sdf},
+        generated_fragment=fragment,
+        product_residue_mappings={},
+    )
+    monkeypatch.setattr(
+        charge_bridge,
+        "_charged_sdf_atom_charges",
+        lambda *_args, **_kwargs: (0.25, -0.5),
+    )
+
+    records = charge_bridge._polymer_template_records((spec,))
+
+    charges_by_atom_name = {record.atom_name: record.charge_e for record in records}
+    assert charges_by_atom_name == pytest.approx({"C001": 0.25, "O001": -0.5})
+
+
 def test_bridge_validates_charged_sdf_atom_order(tmp_path):
     """Charged SDF sources must match generated-fragment atom order."""
     charged_sdf = tmp_path / "polymer_charged.sdf"

--- a/tests/test_conjugation_final_interchange.py
+++ b/tests/test_conjugation_final_interchange.py
@@ -146,6 +146,7 @@ def test_final_helper_has_no_formal_charge_template_export(monkeypatch):
 
     assert result == "ok"
 
+
 def test_final_helper_fails_before_parameterizer_when_bridge_fails():
     """A charge bridge failure should prevent OpenFF parameterization."""
     captured = {}

--- a/tests/test_conjugation_packmol_placement.py
+++ b/tests/test_conjugation_packmol_placement.py
@@ -233,6 +233,32 @@ def test_minimum_distance_propagates_unexpected_mdanalysis_runtime_errors(monkey
         _minimum_distance(points_a, points_b)
 
 
+@pytest.mark.parametrize(
+    "message",
+    (
+        "failed to import coordinate shape regression",
+        "could not import malformed coordinate buffer",
+        "no module named coordinate buffer",
+    ),
+)
+def test_minimum_distance_propagates_generic_import_wording_runtime_errors(
+    monkeypatch,
+    message: str,
+):
+    """Generic import-wording RuntimeErrors should not trigger backend fallback."""
+    points_a = np.asarray([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
+    points_b = np.asarray([[2.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+
+    def fake_distance_array(_points_a: np.ndarray, _points_b: np.ndarray) -> np.ndarray:
+        """Simulate a non-backend RuntimeError with import-like wording."""
+        raise RuntimeError(message)
+
+    _install_fake_mdanalysis_distance_array(monkeypatch, fake_distance_array)
+
+    with pytest.raises(RuntimeError, match=message):
+        _minimum_distance(points_a, points_b)
+
+
 def _install_fake_mdanalysis_distance_array(monkeypatch, distance_array) -> None:
     """Install a fake MDAnalysis distance module for placement helper tests."""
     mdanalysis_module = ModuleType("MDAnalysis")

--- a/tests/test_conjugation_packmol_placement.py
+++ b/tests/test_conjugation_packmol_placement.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import ModuleType
 
 import numpy as np
+import pytest
 
 from polyzymd.builders.conjugation._linkage import (
     ExplicitLinkageContract,
@@ -215,6 +216,21 @@ def test_minimum_distance_falls_back_when_mdanalysis_distance_array_errors(monke
     _install_fake_mdanalysis_distance_array(monkeypatch, fake_distance_array)
 
     assert _minimum_distance(points_a, points_b) == 2.0
+
+
+def test_minimum_distance_propagates_unexpected_mdanalysis_runtime_errors(monkeypatch):
+    """Unexpected MDAnalysis runtime errors should not silently use NumPy fallback."""
+    points_a = np.asarray([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
+    points_b = np.asarray([[2.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+
+    def fake_distance_array(_points_a: np.ndarray, _points_b: np.ndarray) -> np.ndarray:
+        """Simulate an unexpected MDAnalysis runtime failure."""
+        raise RuntimeError("unexpected coordinate shape regression")
+
+    _install_fake_mdanalysis_distance_array(monkeypatch, fake_distance_array)
+
+    with pytest.raises(RuntimeError, match="unexpected coordinate shape regression"):
+        _minimum_distance(points_a, points_b)
 
 
 def _install_fake_mdanalysis_distance_array(monkeypatch, distance_array) -> None:

--- a/tests/test_conjugation_packmol_placement.py
+++ b/tests/test_conjugation_packmol_placement.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+from types import ModuleType
+
+import numpy as np
 
 from polyzymd.builders.conjugation._linkage import (
     ExplicitLinkageContract,
@@ -13,6 +17,7 @@ from polyzymd.builders.conjugation._linkage import (
     resolve_explicit_linkage_contract,
 )
 from polyzymd.builders.conjugation.placement import (
+    _minimum_distance,
     place_modifier_with_packmol,
     place_modifier_with_resolved_plan,
     place_modifiers_with_resolved_plans,
@@ -177,6 +182,53 @@ def test_joint_resolved_plan_placement_uses_one_packmol_run_for_two_fragments(
     assert input_text.count("structure ") == 3
     assert input_text.count("inside sphere") == 2
     assert all(abs(result.placed_bond_length_angstrom - 1.45) < 1.0e-6 for result in results)
+
+
+def test_minimum_distance_uses_mdanalysis_distance_array(monkeypatch):
+    """Minimum distance should use MDAnalysis distance utilities when available."""
+    points_a = np.asarray([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
+    points_b = np.asarray([[2.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+    calls = {"distance_array": 0}
+
+    def fake_distance_array(observed_a: np.ndarray, observed_b: np.ndarray) -> np.ndarray:
+        """Return NumPy-equivalent distances for the fake MDAnalysis module."""
+        calls["distance_array"] += 1
+        np.testing.assert_array_equal(observed_a, points_a)
+        np.testing.assert_array_equal(observed_b, points_b)
+        return np.linalg.norm(observed_a[:, np.newaxis, :] - observed_b[np.newaxis, :, :], axis=2)
+
+    _install_fake_mdanalysis_distance_array(monkeypatch, fake_distance_array)
+
+    assert _minimum_distance(points_a, points_b) == 2.0
+    assert calls["distance_array"] == 1
+
+
+def test_minimum_distance_falls_back_when_mdanalysis_distance_array_errors(monkeypatch):
+    """Minimum distance should preserve NumPy behavior when MDAnalysis cannot run."""
+    points_a = np.asarray([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
+    points_b = np.asarray([[2.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+
+    def fake_distance_array(_points_a: np.ndarray, _points_b: np.ndarray) -> np.ndarray:
+        """Simulate an expected MDAnalysis runtime failure."""
+        raise RuntimeError("MDAnalysis distance backend unavailable")
+
+    _install_fake_mdanalysis_distance_array(monkeypatch, fake_distance_array)
+
+    assert _minimum_distance(points_a, points_b) == 2.0
+
+
+def _install_fake_mdanalysis_distance_array(monkeypatch, distance_array) -> None:
+    """Install a fake MDAnalysis distance module for placement helper tests."""
+    mdanalysis_module = ModuleType("MDAnalysis")
+    lib_module = ModuleType("MDAnalysis.lib")
+    distances_module = ModuleType("MDAnalysis.lib.distances")
+    distances_module.distance_array = distance_array
+    lib_module.distances = distances_module
+    mdanalysis_module.lib = lib_module
+
+    monkeypatch.setitem(sys.modules, "MDAnalysis", mdanalysis_module)
+    monkeypatch.setitem(sys.modules, "MDAnalysis.lib", lib_module)
+    monkeypatch.setitem(sys.modules, "MDAnalysis.lib.distances", distances_module)
 
 
 def _explicit_contract(*, target_bond_length: float) -> ExplicitLinkageContract:

--- a/tests/test_conjugation_product_pablo.py
+++ b/tests/test_conjugation_product_pablo.py
@@ -564,6 +564,30 @@ def test_product_state_pablo_library_rejects_sdf_element_order_mismatch(tmp_path
         )
 
 
+def test_product_state_pablo_library_rejects_partial_fragment_atom_indices(tmp_path: Path):
+    """SDF mapping should require every generated-fragment atom to carry atom_index."""
+    fixture = _SBMA_EGPMA_NHS_CHEMISTRY
+    source = tmp_path / "source.pdb"
+    product = tmp_path / "product.pdb"
+    polymer_sdf = tmp_path / "polymer.sdf"
+    source.write_text(_source_lys_pdb(), encoding="utf-8")
+    product.write_text(_fixture_product_pdb(fixture), encoding="utf-8")
+    polymer_sdf.write_text(_fixture_sdf(fixture), encoding="utf-8")
+    fragment = _generated_fragment_from_fixture(fixture)
+    atoms = list(fragment.atoms)
+    atoms[3] = atoms[3].model_copy(update={"atom_index": None})
+    fragment = fragment.model_copy(update={"atoms": tuple(atoms)})
+
+    with pytest.raises(ValueError, match="complete atom_index values"):
+        build_product_state_pablo_library(
+            product,
+            source,
+            polymer_sdf,
+            fragment,
+            _fixture_resolved_plan_like(),
+        )
+
+
 def test_generated_fragment_from_polymerist_pdb_preserves_sdf_bond_orders(tmp_path: Path):
     """GeneratedPolymerFragment should carry explicit SDF orders from the sidecar."""
     pdb_path = tmp_path / "modifier.pdb"

--- a/tests/test_conjugation_product_pablo.py
+++ b/tests/test_conjugation_product_pablo.py
@@ -588,6 +588,89 @@ def test_product_state_pablo_library_rejects_partial_fragment_atom_indices(tmp_p
         )
 
 
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({0: 1}, "Duplicate atom_index"),
+        ({0: -1}, "non-negative integer atom_index"),
+        ({0: len(_SBMA_EGPMA_NHS_CHEMISTRY.atoms)}, "out-of-range"),
+        ({0: len(_SBMA_EGPMA_NHS_CHEMISTRY.atoms), -1: 0}, "contiguous and exactly match"),
+    ],
+    ids=("duplicate", "negative", "out_of_range", "non_contiguous"),
+)
+def test_product_state_pablo_library_rejects_invalid_sdf_bond_atom_indices(
+    updates: dict[int, int],
+    message: str,
+    tmp_path: Path,
+):
+    """Bond-order SDF mapping should reject invalid generated-fragment atom indices."""
+    fixture = _SBMA_EGPMA_NHS_CHEMISTRY
+    source = tmp_path / "source.pdb"
+    product = tmp_path / "product.pdb"
+    polymer_sdf = tmp_path / "polymer.sdf"
+    source.write_text(_source_lys_pdb(), encoding="utf-8")
+    product.write_text(_fixture_product_pdb(fixture), encoding="utf-8")
+    polymer_sdf.write_text(_fixture_sdf(fixture), encoding="utf-8")
+    fragment = _fragment_with_atom_index_updates(
+        _generated_fragment_from_fixture(fixture),
+        updates,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        build_product_state_pablo_library(
+            product,
+            source,
+            polymer_sdf,
+            fragment,
+            _fixture_resolved_plan_like(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({0: 1}, "Duplicate atom_index"),
+        ({0: -1}, "non-negative integer atom_index"),
+        ({0: len(_SBMA_EGPMA_NHS_CHEMISTRY.atoms)}, "out-of-range"),
+        ({0: len(_SBMA_EGPMA_NHS_CHEMISTRY.atoms), -1: 0}, "contiguous and exactly match"),
+    ],
+    ids=("duplicate", "negative", "out_of_range", "non_contiguous"),
+)
+def test_product_state_pablo_library_rejects_invalid_charged_sdf_atom_indices(
+    updates: dict[int, int],
+    message: str,
+    tmp_path: Path,
+):
+    """Charged/formal-charge SDF mapping should reject invalid atom indices."""
+    fixture = _SBMA_EGPMA_NHS_CHEMISTRY
+    neutral_atoms = tuple(
+        (atom_name, residue_name, residue_number, element, "")
+        for atom_name, residue_name, residue_number, element, _charge in fixture.atoms
+    )
+    source = tmp_path / "source.pdb"
+    product = tmp_path / "product.pdb"
+    raw_sdf = tmp_path / "polymer_raw.sdf"
+    charged_sdf = tmp_path / "polymer_charged.sdf"
+    source.write_text(_source_lys_pdb(), encoding="utf-8")
+    product.write_text(_fixture_product_pdb(fixture, include_charges=False), encoding="utf-8")
+    raw_sdf.write_text(_sdf_from_atoms_and_bonds(neutral_atoms, fixture.bonds), encoding="utf-8")
+    charged_sdf.write_text(_fixture_sdf(fixture), encoding="utf-8")
+    fragment = _fragment_with_atom_index_updates(
+        _generated_fragment_from_fixture(fixture, include_bond_orders=False),
+        updates,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        build_product_state_pablo_library(
+            product,
+            source,
+            raw_sdf,
+            fragment,
+            _fixture_resolved_plan_like(),
+            charged_polymer_sdf=charged_sdf,
+        )
+
+
 def test_generated_fragment_from_polymerist_pdb_preserves_sdf_bond_orders(tmp_path: Path):
     """GeneratedPolymerFragment should carry explicit SDF orders from the sidecar."""
     pdb_path = tmp_path / "modifier.pdb"
@@ -681,6 +764,17 @@ def _generated_fragment_from_fixture(
         reactive_atom_name="CAA",
         name=fixture.name,
     )
+
+
+def _fragment_with_atom_index_updates(
+    fragment: GeneratedPolymerFragment,
+    updates: dict[int, int],
+) -> GeneratedPolymerFragment:
+    """Return a fragment copy with selected atom_index values changed."""
+    atoms = list(fragment.atoms)
+    for position, atom_index in updates.items():
+        atoms[position] = atoms[position].model_copy(update={"atom_index": atom_index})
+    return fragment.model_copy(update={"atoms": tuple(atoms)})
 
 
 def _fixture_product_pdb(

--- a/tests/test_conjugation_product_pablo.py
+++ b/tests/test_conjugation_product_pablo.py
@@ -441,6 +441,40 @@ def test_product_state_pablo_library_uses_charged_sdf_formal_charges(tmp_path: P
     assert _definition_atom_charge(definitions[2], "OS3") == -1
 
 
+def test_product_state_pablo_library_maps_charged_sdf_by_atom_index(tmp_path: Path):
+    """Charged SDF formal charges should preserve atom-index mapping."""
+    fixture = _SBMA_EGPMA_NHS_CHEMISTRY
+    neutral_atoms = tuple(
+        (atom_name, residue_name, residue_number, element, "")
+        for atom_name, residue_name, residue_number, element, _charge in fixture.atoms
+    )
+    source = tmp_path / "source.pdb"
+    product = tmp_path / "product.pdb"
+    raw_sdf = tmp_path / "polymer_raw.sdf"
+    charged_sdf = tmp_path / "polymer_charged.sdf"
+    source.write_text(_source_lys_pdb(), encoding="utf-8")
+    product.write_text(_fixture_product_pdb(fixture, include_charges=False), encoding="utf-8")
+    raw_sdf.write_text(_sdf_from_atoms_and_bonds(neutral_atoms, fixture.bonds), encoding="utf-8")
+    charged_sdf.write_text(_fixture_sdf(fixture), encoding="utf-8")
+    fragment = _generated_fragment_from_fixture(fixture, include_bond_orders=False)
+    fragment = fragment.model_copy(update={"atoms": tuple(reversed(fragment.atoms))})
+
+    library = build_product_state_pablo_library(
+        product,
+        source,
+        raw_sdf,
+        fragment,
+        _fixture_resolved_plan_like(),
+        charged_polymer_sdf=charged_sdf,
+    )
+
+    definitions = {
+        summary.residue_number: definition for summary, definition in _chain_c_definitions(library)
+    }
+    assert _definition_atom_charge(definitions[2], "NQA") == 1
+    assert _definition_atom_charge(definitions[2], "OS3") == -1
+
+
 def test_product_state_pablo_library_for_specs_scopes_repeated_polymer_residues(
     tmp_path: Path,
 ):
@@ -498,6 +532,29 @@ def test_product_state_pablo_library_rejects_under_specified_sdf(tmp_path: Path)
     polymer_sdf.write_text(_fixture_sdf(fixture, overrides={("CAA", "OAA"): 0}), encoding="utf-8")
 
     with pytest.raises(ValueError, match="under-specified zero/unknown bond orders"):
+        build_product_state_pablo_library(
+            product,
+            source,
+            polymer_sdf,
+            _generated_fragment_from_fixture(fixture),
+            _fixture_resolved_plan_like(),
+        )
+
+
+def test_product_state_pablo_library_rejects_sdf_element_order_mismatch(tmp_path: Path):
+    """SDF atom order should be validated before bond-order transfer."""
+    fixture = _SBMA_EGPMA_NHS_CHEMISTRY
+    source = tmp_path / "source.pdb"
+    product = tmp_path / "product.pdb"
+    polymer_sdf = tmp_path / "polymer.sdf"
+    mismatched_atoms = ((fixture.atoms[0][0], *fixture.atoms[0][1:3], "O", ""), *fixture.atoms[1:])
+    source.write_text(_source_lys_pdb(), encoding="utf-8")
+    product.write_text(_fixture_product_pdb(fixture), encoding="utf-8")
+    polymer_sdf.write_text(
+        _sdf_from_atoms_and_bonds(mismatched_atoms, fixture.bonds), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="element/order does not match"):
         build_product_state_pablo_library(
             product,
             source,

--- a/tests/test_conjugation_reaction_roles.py
+++ b/tests/test_conjugation_reaction_roles.py
@@ -156,6 +156,31 @@ def test_rdkit_reaction_from_smarts_unexpected_runtime_errors_propagate(monkeypa
         validate_mapped_smarts(("[N:1][H:2]",), ("[N:1]",))
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        "unexpected smarts cache corruption",
+        "unexpected parser allocation failure",
+    ],
+)
+def test_rdkit_parser_runtime_classifier_rejects_generic_parse_words(message):
+    """Generic SMARTS or parser words should not mask unexpected RDKit failures."""
+    assert reaction_roles._is_rdkit_parse_runtime_error(RuntimeError(message)) is False
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "ChemicalReactionParserException: problems constructing product",
+        "SMARTS Parse Error: syntax error while parsing",
+        "Failed parsing SMARTS '[C' for input",
+    ],
+)
+def test_rdkit_parser_runtime_classifier_accepts_specific_parser_signatures(message):
+    """Known RDKit parser signatures should remain expected parse failures."""
+    assert reaction_roles._is_rdkit_parse_runtime_error(RuntimeError(message)) is True
+
+
 def test_resolve_reaction_roles_preserves_geometry_anchor_and_concrete_identities():
     """Role resolution should keep role labels and supplied PDB identities generic."""
     reaction = _nhs_like_reaction()

--- a/tests/test_conjugation_reaction_roles.py
+++ b/tests/test_conjugation_reaction_roles.py
@@ -60,6 +60,89 @@ def test_nhs_like_mapped_smarts_derives_added_removed_bonds_and_leaving_maps():
     assert changes.order_changes == ()
 
 
+def test_rdkit_reaction_parse_detects_missing_product_atom_maps():
+    """Native reaction parsing should retain missing-map diagnostics."""
+    pytest.importorskip("rdkit.Chem.rdChemReactions")
+
+    validation = validate_mapped_smarts(("[N:1]([H:2])",), ("[N:1]",))
+
+    assert validation.reactant_maps == (1, 2)
+    assert validation.product_maps == (1,)
+    assert validation.missing_product_maps == (2,)
+
+
+def test_bond_change_detection_matches_fallback_for_added_removed_and_order_changed(
+    monkeypatch,
+):
+    """RDKit-backed bond diagnostics should match the existing fallback behavior."""
+    reactants = ("[C:1]=[O:2].[N:3][H:4]",)
+    products = ("[O:2]-[C:1][N:3]",)
+    normal = derive_bond_changes(reactants, products)
+
+    def raise_value_error(smarts_entries):
+        raise ValueError("force fallback")
+
+    monkeypatch.setattr(reaction_roles, "_rdkit_mapped_bond_orders", raise_value_error)
+    fallback = derive_bond_changes(reactants, products)
+
+    assert normal.model_dump() == fallback.model_dump()
+    assert [change.atom_maps for change in normal.added_bonds] == [(1, 3)]
+    assert [change.atom_maps for change in normal.removed_bonds] == [(3, 4)]
+    assert [
+        (change.atom_maps, change.reactant_order, change.product_order)
+        for change in normal.order_changes
+    ] == [((1, 2), 2.0, 1.0)]
+
+
+def test_rdkit_reaction_parse_preserves_participant_indices_and_map_evidence_order():
+    """RDKit parsing should not mutate participant order or sorted map evidence."""
+    pytest.importorskip("rdkit.Chem.rdChemReactions")
+    reaction = AtomMappedReaction(
+        name="participant_order",
+        reactant_smarts=("[C:10]", "[N:1].[O:5]"),
+        product_smarts=("[N:1][C:10]=[O:5]",),
+        participants=(
+            ReactionParticipant(name="moiety", role="moiety", reactant_index=1),
+            ReactionParticipant(name="site", role="site", reactant_index=0),
+        ),
+    )
+
+    validation = validate_mapped_smarts(reaction.reactant_smarts, reaction.product_smarts)
+
+    assert [participant.reactant_index for participant in reaction.participants] == [1, 0]
+    assert validation.reactant_maps == (1, 5, 10)
+    assert validation.product_maps == (1, 5, 10)
+
+
+def test_mapped_smarts_validation_fallback_still_handles_expected_rdkit_parse_errors(
+    monkeypatch,
+):
+    """Expected RDKit reaction parse errors should fall back to text diagnostics."""
+
+    def raise_value_error(reactant_smarts, product_smarts):
+        raise ValueError("invalid reaction query")
+
+    monkeypatch.setattr(reaction_roles, "_rdkit_reaction_mapped_atom_numbers", raise_value_error)
+
+    validation = validate_mapped_smarts(("[N:1][H:2]",), ("[N:1]",))
+
+    assert validation.reactant_maps == (1, 2)
+    assert validation.product_maps == (1,)
+    assert validation.missing_product_maps == (2,)
+
+
+def test_mapped_smarts_validation_does_not_swallow_unexpected_runtime_errors(monkeypatch):
+    """Unexpected reaction parsing runtime errors should propagate."""
+
+    def raise_runtime_error(reactant_smarts, product_smarts):
+        raise RuntimeError("unexpected reaction parser failure")
+
+    monkeypatch.setattr(reaction_roles, "_rdkit_reaction_mapped_atom_numbers", raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="unexpected reaction parser failure"):
+        validate_mapped_smarts(("[N:1][H:2]",), ("[N:1]",))
+
+
 def test_resolve_reaction_roles_preserves_geometry_anchor_and_concrete_identities():
     """Role resolution should keep role labels and supplied PDB identities generic."""
     reaction = _nhs_like_reaction()

--- a/tests/test_conjugation_reaction_roles.py
+++ b/tests/test_conjugation_reaction_roles.py
@@ -143,6 +143,19 @@ def test_mapped_smarts_validation_does_not_swallow_unexpected_runtime_errors(mon
         validate_mapped_smarts(("[N:1][H:2]",), ("[N:1]",))
 
 
+def test_rdkit_reaction_from_smarts_unexpected_runtime_errors_propagate(monkeypatch):
+    """Unexpected RDKit reaction constructor runtime errors should not fall back."""
+    rdchem_reactions = pytest.importorskip("rdkit.Chem.rdChemReactions")
+
+    def raise_runtime_error(_reaction_smarts):
+        raise RuntimeError("unexpected RDKit allocator failure")
+
+    monkeypatch.setattr(rdchem_reactions, "ReactionFromSmarts", raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="unexpected RDKit allocator failure"):
+        validate_mapped_smarts(("[N:1][H:2]",), ("[N:1]",))
+
+
 def test_resolve_reaction_roles_preserves_geometry_anchor_and_concrete_identities():
     """Role resolution should keep role labels and supplied PDB identities generic."""
     reaction = _nhs_like_reaction()
@@ -244,6 +257,19 @@ def test_mapped_bond_order_fallback_does_not_swallow_runtime_errors(monkeypatch)
     monkeypatch.setattr(reaction_roles, "_rdkit_mapped_bond_orders", raise_runtime_error)
 
     with pytest.raises(RuntimeError, match="unexpected helper failure"):
+        reaction_roles._mapped_bond_orders(("[N:1][C:2]",))
+
+
+def test_rdkit_mol_from_smarts_unexpected_runtime_errors_propagate(monkeypatch):
+    """Unexpected RDKit molecule parser runtime errors should not fall back."""
+    chem = pytest.importorskip("rdkit.Chem")
+
+    def raise_runtime_error(_smarts):
+        raise RuntimeError("unexpected RDKit molecule allocator failure")
+
+    monkeypatch.setattr(chem, "MolFromSmarts", raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="unexpected RDKit molecule allocator failure"):
         reaction_roles._mapped_bond_orders(("[N:1][C:2]",))
 
 


### PR DESCRIPTION
## Summary
- Use RDKit reaction parsing only for mapped SMARTS diagnostics; no product generation or matching.
- Centralize RDKit SDF graph helpers for validated bond-order/formal-charge mapping.
- Use MDAnalysis distance_array for array-only placement minimum-distance checks with restricted backend fallback.
- Validate SDF atom_index provenance before identity-preserving mapping: present, unique, non-negative, contiguous, and exactly 0..N-1.
- Assign charged SDF partial charges in validated SDF atom-index order.
- Add regression tests for native API fallback boundaries and atom-order/provenance preservation.

## Verification
- pixi run -e build pytest tests/test_conjugation_product_pablo.py -v: 23 passed
- pixi run -e build pytest tests/test_conjugation_charge_bridge.py -v: 11 passed
- pixi run -e build pytest tests/test_conjugation_final_interchange.py -v: 10 passed
- pixi run -e build pytest tests/test_conjugation_system_workflow.py -v: 23 passed
- pixi run -e build pytest tests/test_conjugation_reaction_roles.py tests/test_conjugation_packmol_placement.py tests/test_conjugation_nhs_lys.py tests/test_conjugation_n_glycosylation.py -v: 48 passed
- pixi run -e build pytest tests/ -v -k "conjugation": 367 passed, 3 skipped
- pixi run -e build ruff check src/polyzymd/builders/conjugation tests/test_conjugation*.py: pass
- pixi run -e build black src/polyzymd/builders/conjugation tests/test_conjugation*.py --check: 81 unchanged
- Real checkpoint config completed successfully with expected artifacts in /tmp/polyzymd-refactor-checkpoints/phase-8-final-review4-retry/...run1

## Review
- Final adversarial reviewer verdict: APPROVED
