### PR TITLE
Fix trajectory reporting and temperature ramps

### DIFF
--- a/docs/source/get_started/quickstart.md
+++ b/docs/source/get_started/quickstart.md
@@ -112,13 +112,12 @@ thermodynamics:
 simulation_phases:
   equilibration_stages:
     - name: "heating"
-      duration: 0.2
       samples: 20
       ensemble: "NVT"
       temperature_start: 60.0
       temperature_end: 300.0
       temperature_increment: 1.0
-      temperature_interval: 1200.0
+      temperature_interval_steps: 600  # duration is derived
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0

--- a/docs/source/get_started/quickstart.md
+++ b/docs/source/get_started/quickstart.md
@@ -117,7 +117,7 @@ simulation_phases:
       temperature_start: 60.0
       temperature_end: 300.0
       temperature_increment: 1.0
-      temperature_interval_steps: 600  # duration is derived
+      temperature_interval_steps: 600  # increase temperature by `temperature_increment` every this many steps
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0

--- a/docs/source/how_to/dynamic_polymers.md
+++ b/docs/source/how_to/dynamic_polymers.md
@@ -256,7 +256,7 @@ simulation_phases:
       temperature_start: 60.0
       temperature_end: 300.0
       temperature_increment: 1.0
-      temperature_interval_steps: 600  # duration is derived
+      temperature_interval_steps: 600  # increase temperature by `temperature_increment` every this many steps
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0

--- a/docs/source/how_to/dynamic_polymers.md
+++ b/docs/source/how_to/dynamic_polymers.md
@@ -251,13 +251,12 @@ thermodynamics:
 simulation_phases:
   equilibration_stages:
     - name: "heating"
-      duration: 0.2
       samples: 20
       ensemble: "NVT"
       temperature_start: 60.0
       temperature_end: 300.0
       temperature_increment: 1.0
-      temperature_interval: 1200.0
+      temperature_interval_steps: 600  # duration is derived
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0

--- a/docs/source/how_to/equilibration.md
+++ b/docs/source/how_to/equilibration.md
@@ -30,7 +30,7 @@ simulation_phases:
       temperature_start: 60.0
       temperature_end: 293.0
       temperature_increment: 1.0
-      temperature_interval_steps: 600  # duration is derived
+      temperature_interval_steps: 600  # increase temperature by `temperature_increment` every this many steps
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0
@@ -69,8 +69,7 @@ simulation_phases:
 
 Use a heating stage when you want a gentler start for a crowded or fragile
 system. Set `temperature_start`, `temperature_end`, and
-`temperature_increment` in K, plus `temperature_interval_steps` in MD steps. Do
-not set `duration`; PolyzyMD calculates the number of updates needed to reach
+`temperature_increment` in K, plus `temperature_interval_steps` in MD steps. PolyzyMD calculates the number of updates needed to reach
 the endpoint and derives the duration. If the final update would overshoot,
 PolyzyMD shortens only that final temperature increase. Validation and
 simulation logs report the derived duration before the stage runs.

--- a/docs/source/how_to/equilibration.md
+++ b/docs/source/how_to/equilibration.md
@@ -25,13 +25,12 @@ Even if your protocol is minimal, represent it as one or more named stages.
 simulation_phases:
   equilibration_stages:
     - name: "heating"
-      duration: 0.288
       samples: 50
       ensemble: "NVT"
       temperature_start: 60.0
       temperature_end: 293.0
       temperature_increment: 1.0
-      temperature_interval: 1200.0
+      temperature_interval_steps: 600  # duration is derived
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0
@@ -69,8 +68,18 @@ simulation_phases:
 ### Heating stage
 
 Use a heating stage when you want a gentler start for a crowded or fragile
-system. Set `temperature_start`, `temperature_end`, and optionally the ramp
-increment and interval.
+system. Set `temperature_start`, `temperature_end`, and
+`temperature_increment` in K, plus `temperature_interval_steps` in MD steps. Do
+not set `duration`; PolyzyMD calculates the number of updates needed to reach
+the endpoint and derives the duration. If the final update would overshoot,
+PolyzyMD shortens only that final temperature increase. Validation and
+simulation logs report the derived duration before the stage runs.
+
+The ramp ends when the target reaches `temperature_end`; it does not include a
+hold at that temperature. Add a following constant-temperature stage when the
+system should equilibrate at the endpoint. OpenMM updates the thermostat target
+at each requested step interval, while GROMACS interpolates between the same
+temperature update points over the same derived duration.
 
 ### Restrained relaxation stage
 
@@ -98,10 +107,11 @@ Omit `position_restraints` when you want the stage to run fully unrestrained.
 simulation_phases:
   equilibration_stages:
     - name: "heating"
-      duration: 0.288
       ensemble: "NVT"
       temperature_start: 60.0
       temperature_end: 300.0
+      temperature_increment: 1.0
+      temperature_interval_steps: 600
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0
@@ -118,10 +128,11 @@ simulation_phases:
 simulation_phases:
   equilibration_stages:
     - name: "heating"
-      duration: 0.288
       ensemble: "NVT"
       temperature_start: 60.0
       temperature_end: 300.0
+      temperature_increment: 1.0
+      temperature_interval_steps: 600
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0
@@ -172,7 +183,7 @@ position restraints.
 
 ### temperature overshoots the target
 
-Use a smaller `temperature_increment` or a longer `temperature_interval`.
+Use a smaller `temperature_increment` or a larger `temperature_interval_steps`.
 
 ### protein moves too much while polymers relax
 

--- a/docs/source/how_to/equilibration.md
+++ b/docs/source/how_to/equilibration.md
@@ -76,9 +76,10 @@ simulation logs report the derived duration before the stage runs.
 
 The ramp ends when the target reaches `temperature_end`; it does not include a
 hold at that temperature. Add a following constant-temperature stage when the
-system should equilibrate at the endpoint. OpenMM updates the thermostat target
-at each requested step interval, while GROMACS interpolates between the same
-temperature update points over the same derived duration.
+system should equilibrate at the endpoint. Both engines hold each target for
+the requested step interval and change it at the same integration-step
+boundary. GROMACS encodes each boundary change over one MD timestep because its
+annealing schedule is piecewise linear.
 
 ### Restrained relaxation stage
 

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -530,13 +530,12 @@ thermodynamics:
 simulation_phases:
   equilibration_stages:
     - name: "heating"
-      duration: 0.2                      # nanoseconds
       samples: 20                        # frames to save
       ensemble: "NVT"
       temperature_start: 60.0            # starting temperature (K)
       temperature_end: 300.0             # final temperature (K)
-      temperature_increment: 1.0         # step size (K)
-      temperature_interval: 1200.0       # time between steps (fs)
+      temperature_increment: 1.0         # increase per update (K)
+      temperature_interval_steps: 600    # MD steps between updates
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0
@@ -560,6 +559,11 @@ simulation_phases:
 
 PolyzyMD requires staged equilibration. Use one or more entries in
 `equilibration_stages` even for minimal workflows.
+
+For a temperature ramp, omit `duration`. Set `temperature_increment` in K and
+`temperature_interval_steps` in MD steps. PolyzyMD computes how many updates are
+needed to reach the endpoint and derives the duration. Constant-temperature
+stages continue to require an explicit `duration`.
 
 ### Ensembles
 

--- a/scripts/convert_legacy.py
+++ b/scripts/convert_legacy.py
@@ -956,10 +956,6 @@ def _build_phases_config(metadata: SimMetadata) -> dict:
             "ensemble": prod.ensemble,
             "duration": prod.duration_ns,
             "samples": prod.samples,
-            "report_interval": max(
-                1,
-                int(prod.duration_ns * 1e6 / prod.time_step_fs) // prod.samples,
-            ),
             "checkpoint_interval": 60.0,
             "time_step": prod.time_step_fs,
             "thermostat": prod.thermostat,

--- a/src/polyzymd/cli/main.py
+++ b/src/polyzymd/cli/main.py
@@ -494,8 +494,17 @@ def build(
             if eq_stages:
                 colored_echo(f"  Equilibration: {len(eq_stages)} stage(s)", phase="build")
                 for i, stage in enumerate(eq_stages, 1):
+                    if stage.is_temperature_ramping:
+                        ramp_info = (
+                            f", {stage.temperature_start:g}->{stage.temperature_end:g} K, "
+                            f"+{stage.temperature_increment:g} K every "
+                            f"{stage.temperature_interval_steps} steps (derived)"
+                        )
+                    else:
+                        ramp_info = ""
                     colored_echo(
-                        f"    Stage {i}: {stage.duration} ns, {stage.ensemble}",
+                        f"    Stage {i}: {stage.resolved_duration:.6f} ns, "
+                        f"{stage.ensemble}{ramp_info}",
                         phase="build",
                     )
             colored_echo(
@@ -1120,8 +1129,12 @@ def _run_openmm_impl(
     replicate : int
         Replicate number.
     """
+    from polyzymd.simulation.progress import calculate_report_interval
+
     production = sim_config.simulation_phases.production
     working_dir = sim_config.get_working_directory(replicate)
+    total_steps = int(production.duration * 1e6 / production.time_step)
+    report_interval = calculate_report_interval(total_steps, production.samples)
 
     colored_echo(f"Building and running OpenMM in {working_dir}", phase="simulation")
     _run_initial_segment(
@@ -1132,6 +1145,8 @@ def _run_openmm_impl(
         duration_ns=production.duration,
         num_samples=production.samples,
         timestep_fs=production.time_step,
+        report_interval=report_interval,
+        checkpoint_interval_s=production.checkpoint_interval,
     )
     colored_echo("OpenMM simulation completed successfully.", phase="simulation")
     colored_echo(f"Output directory: {working_dir}", phase="simulation")
@@ -1859,7 +1874,7 @@ def run_segment(
     seg_idx = seg_info["segment_index"]
     steps_to_run = seg_info["steps_to_run"]
     samples_to_write = seg_info["samples_to_write"]
-    report_interval = prod.report_interval
+    report_interval = seg_info["report_interval"]
     duration_ns = (steps_to_run * timestep_fs) / 1e6
 
     colored_echo(
@@ -2469,11 +2484,23 @@ def validate(config: str) -> None:
         colored_echo("Simulation phases:")
         eq_stages = sim_config.simulation_phases.equilibration_stages
         colored_echo(
-            f"  Equilibration: {sim_config.simulation_phases.total_equilibration_duration} ns "
+            f"  Equilibration: "
+            f"{sim_config.simulation_phases.total_equilibration_duration:.6f} ns "
             f"across {len(eq_stages)} stage(s)"
         )
         for stage in eq_stages:
-            colored_echo(f"    - {stage.name}: {stage.duration} ns ({stage.ensemble.value})")
+            if stage.is_temperature_ramping:
+                colored_echo(
+                    f"    - {stage.name}: {stage.temperature_start:g} -> "
+                    f"{stage.temperature_end:g} K, +{stage.temperature_increment:g} K "
+                    f"every {stage.temperature_interval_steps} steps; "
+                    f"derived duration {stage.resolved_duration:.6f} ns "
+                    f"({stage.ensemble.value})"
+                )
+            else:
+                colored_echo(
+                    f"    - {stage.name}: {stage.resolved_duration:g} ns ({stage.ensemble.value})"
+                )
         prod = sim_config.simulation_phases.production
         colored_echo(f"  Production: {prod.duration} ns ({prod.ensemble.value})")
 

--- a/src/polyzymd/config/schema.py
+++ b/src/polyzymd/config/schema.py
@@ -11,6 +11,7 @@ import logging
 import math
 import re
 import shlex
+import warnings
 from enum import Enum
 from pathlib import Path
 from string import Formatter
@@ -25,8 +26,6 @@ from pydantic import (
     model_serializer,
     model_validator,
 )
-
-import warnings
 
 LOGGER = logging.getLogger(__name__)
 
@@ -882,12 +881,6 @@ class EquilibrationStageConfig(BaseModel):
     @classmethod
     def migrate_temperature_ramp_config(cls, data: Any) -> Any:
         """Migrate legacy ramp fields before validating the derived duration."""
-        warnings.warn(
-        "migrate_temperature_ramp_config is deprecated and will be removed; users must update their config files.",
-        category=DeprecationWarning,
-        stacklevel=2
-        )
-        
         if not isinstance(data, dict):
             return data
 
@@ -914,12 +907,21 @@ class EquilibrationStageConfig(BaseModel):
                 "Cannot specify both legacy 'temperature_interval' and 'temperature_interval_steps'"
             )
 
-        if duration is not None and interval_fs is None:
+        if duration is not None and interval_steps is not None:
             raise ValueError(
                 "Do not specify 'duration' for a temperature ramp; it is derived from "
                 "'temperature_start', 'temperature_end', 'temperature_increment', "
                 "and 'temperature_interval_steps'"
             )
+
+        used_legacy_interval_default = (
+            duration is not None and interval_fs is None and interval_steps is None
+        )
+        if used_legacy_interval_default:
+            # The former schema required duration and defaulted the interval to
+            # 1200 fs. Preserve that behavior long enough to migrate existing
+            # configuration files to the step-based schedule.
+            interval_fs = 1200.0
 
         timestep_fs = float(values.get("time_step") or 2.0)
         if interval_fs is not None:
@@ -945,8 +947,20 @@ class EquilibrationStageConfig(BaseModel):
                     )
                 values["temperature_increment"] = increment_value
                 values["temperature_interval_steps"] = max(1, rounded_interval_steps)
+                legacy_source = (
+                    "the legacy 1200 fs default"
+                    if used_legacy_interval_default
+                    else f"temperature_interval={interval_value:g} fs"
+                )
+                warnings.warn(
+                    f"Deprecated temperature-ramp configuration using {legacy_source} "
+                    "was converted to 'temperature_interval_steps'; update the "
+                    "configuration file and remove the ramp 'duration' field",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
                 LOGGER.warning(
-                    f"Deprecated 'temperature_interval={interval_value:g} fs' was "
+                    f"Deprecated temperature-ramp configuration using {legacy_source} was "
                     f"converted to temperature_interval_steps="
                     f"{values['temperature_interval_steps']}; any supplied ramp "
                     "duration is ignored"

--- a/src/polyzymd/config/schema.py
+++ b/src/polyzymd/config/schema.py
@@ -26,6 +26,8 @@ from pydantic import (
     model_validator,
 )
 
+import warnings
+
 LOGGER = logging.getLogger(__name__)
 
 _TOKEN_UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9_-]+")
@@ -880,6 +882,12 @@ class EquilibrationStageConfig(BaseModel):
     @classmethod
     def migrate_temperature_ramp_config(cls, data: Any) -> Any:
         """Migrate legacy ramp fields before validating the derived duration."""
+        warnings.warn(
+        "migrate_temperature_ramp_config is deprecated and will be removed; users must update their config files.",
+        category=DeprecationWarning,
+        stacklevel=2
+        )
+        
         if not isinstance(data, dict):
             return data
 

--- a/src/polyzymd/config/schema.py
+++ b/src/polyzymd/config/schema.py
@@ -8,6 +8,7 @@ providing validation, type safety, and YAML/JSON serialization support.
 from __future__ import annotations
 
 import logging
+import math
 import re
 import shlex
 from enum import Enum
@@ -15,7 +16,15 @@ from pathlib import Path
 from string import Formatter
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializerFunctionWrapHandler,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -525,8 +534,7 @@ class CoSolventSpec(BaseModel):
 
         if not has_mole_fraction and not has_conc:
             raise ValueError(
-                f"Co-solvent '{self.name}': Must specify either 'mole_fraction' "
-                f"or 'concentration'"
+                f"Co-solvent '{self.name}': Must specify either 'mole_fraction' or 'concentration'"
             )
         if has_mole_fraction and has_conc:
             raise ValueError(
@@ -695,7 +703,6 @@ class SimulationPhaseConfig(BaseModel):
         ensemble: Thermodynamic ensemble (NVT, NPT)
         duration: Simulation duration in nanoseconds
         samples: Number of trajectory frames to save
-        report_interval: Explicit reporter interval in MD steps
         time_step: Integration time step in femtoseconds
         thermostat: Thermostat type
         thermostat_timescale: Thermostat coupling timescale in ps
@@ -708,7 +715,6 @@ class SimulationPhaseConfig(BaseModel):
     ensemble: Ensemble = Field(..., description="Thermodynamic ensemble")
     duration: float = Field(..., gt=0.0, description="Duration (ns)")
     samples: int = Field(..., ge=1, description="Trajectory frames to save")
-    report_interval: int = Field(..., ge=1, description="Reporter interval in MD steps")
     time_step: float = Field(2.0, gt=0.0, description="Time step (fs)")
     thermostat: ThermostatType = Field(
         ThermostatType.LANGEVIN_MIDDLE, description="Thermostat type"
@@ -727,6 +733,18 @@ class SimulationPhaseConfig(BaseModel):
             "unexpected termination recovery remains enabled."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def discard_report_interval(cls, data: Any) -> Any:
+        """Ignore the obsolete reporter interval in existing configurations."""
+        if isinstance(data, dict) and "report_interval" in data:
+            LOGGER.warning(
+                "Ignoring deprecated production 'report_interval'; trajectory "
+                "cadence is derived from 'samples'"
+            )
+            return {key: value for key, value in data.items() if key != "report_interval"}
+        return data
 
     @model_validator(mode="after")
     def validate_ensemble_barostat(self) -> "SimulationPhaseConfig":
@@ -785,22 +803,23 @@ class EquilibrationStageConfig(BaseModel):
     Supports two temperature modes:
 
     1. Constant temperature: Set 'temperature' field.
-    2. Temperature ramping (simulated annealing): Set 'temperature_start'
-       and 'temperature_end' fields.
+    2. Temperature ramping (simulated annealing): Set 'temperature_start',
+       'temperature_end', 'temperature_increment', and
+       'temperature_interval_steps'. The duration is derived.
 
     Position restraints can be applied to hold specific atom groups in place
     during the stage.
 
     Attributes:
         name: Stage identifier (used in output paths)
-        duration: Stage duration in nanoseconds
+        duration: Stage duration in nanoseconds (constant-temperature stages only)
         samples: Number of trajectory frames to save
         ensemble: Thermodynamic ensemble (NVT or NPT)
         temperature: Constant temperature in K (mutually exclusive with ramping)
         temperature_start: Starting temperature for ramping in K
         temperature_end: Ending temperature for ramping in K
-        temperature_increment: Temperature increment per update in K
-        temperature_interval: Time between temperature updates in fs
+        temperature_increment: Temperature increase per update in K
+        temperature_interval_steps: MD steps between temperature updates
         position_restraints: List of position restraints for this stage
         time_step: Optional time step override in fs
         thermostat: Optional thermostat type override
@@ -810,7 +829,11 @@ class EquilibrationStageConfig(BaseModel):
     """
 
     name: str = Field(..., description="Stage identifier (used in output paths)")
-    duration: float = Field(..., gt=0.0, description="Duration (ns)")
+    duration: float | None = Field(
+        None,
+        gt=0.0,
+        description="Duration (ns). Required for constant-temperature stages; derived for ramps.",
+    )
     samples: int = Field(100, ge=1, description="Trajectory frames to save")
     ensemble: Ensemble = Field(Ensemble.NVT, description="Thermodynamic ensemble")
 
@@ -828,11 +851,15 @@ class EquilibrationStageConfig(BaseModel):
     temperature_end: float | None = Field(
         None, gt=0.0, description="Ending temperature for ramping (K)"
     )
-    temperature_increment: float = Field(
-        1.0, gt=0.0, description="Temperature increment per update (K)"
+    temperature_increment: float | None = Field(
+        None,
+        gt=0.0,
+        description="Temperature increase per update (K)",
     )
-    temperature_interval: float = Field(
-        1200.0, gt=0.0, description="Time between temperature updates (fs)"
+    temperature_interval_steps: int | None = Field(
+        None,
+        ge=1,
+        description="MD steps between temperature updates",
     )
 
     # Position restraints
@@ -849,30 +876,117 @@ class EquilibrationStageConfig(BaseModel):
     barostat: BarostatType | None = Field(None, description="Barostat type (for NPT)")
     barostat_frequency: int | None = Field(None, ge=1, description="Barostat update frequency")
 
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_temperature_ramp_config(cls, data: Any) -> Any:
+        """Migrate legacy ramp fields before validating the derived duration."""
+        if not isinstance(data, dict):
+            return data
+
+        values = dict(data)
+        start = values.get("temperature_start")
+        end = values.get("temperature_end")
+        if start is None and end is None:
+            return values
+
+        rate = values.pop("temperature_ramp_rate", None)
+        duration = values.get("duration")
+        increment = values.get("temperature_increment")
+        interval_steps = values.get("temperature_interval_steps")
+        interval_fs = values.pop("temperature_interval", None)
+
+        if rate is not None:
+            raise ValueError(
+                "'temperature_ramp_rate' is not supported; specify "
+                "'temperature_increment' and 'temperature_interval_steps'"
+            )
+
+        if interval_fs is not None and interval_steps is not None:
+            raise ValueError(
+                "Cannot specify both legacy 'temperature_interval' and 'temperature_interval_steps'"
+            )
+
+        if duration is not None and interval_fs is None:
+            raise ValueError(
+                "Do not specify 'duration' for a temperature ramp; it is derived from "
+                "'temperature_start', 'temperature_end', 'temperature_increment', "
+                "and 'temperature_interval_steps'"
+            )
+
+        timestep_fs = float(values.get("time_step") or 2.0)
+        if interval_fs is not None:
+            try:
+                increment_value = float(increment if increment is not None else 1.0)
+                interval_value = float(interval_fs)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "Legacy 'temperature_increment' and 'temperature_interval' must be numeric"
+                ) from exc
+            if increment_value > 0 and interval_value > 0:
+                exact_interval_steps = interval_value / timestep_fs
+                rounded_interval_steps = round(exact_interval_steps)
+                if not math.isclose(
+                    exact_interval_steps,
+                    rounded_interval_steps,
+                    rel_tol=1e-12,
+                    abs_tol=1e-9,
+                ):
+                    raise ValueError(
+                        "Legacy 'temperature_interval' must be an exact multiple "
+                        "of the stage timestep"
+                    )
+                values["temperature_increment"] = increment_value
+                values["temperature_interval_steps"] = max(1, rounded_interval_steps)
+                LOGGER.warning(
+                    f"Deprecated 'temperature_interval={interval_value:g} fs' was "
+                    f"converted to temperature_interval_steps="
+                    f"{values['temperature_interval_steps']}; any supplied ramp "
+                    "duration is ignored"
+                )
+        return values
+
     @model_validator(mode="after")
     def validate_temperature_mode(self) -> "EquilibrationStageConfig":
         """Ensure valid temperature specification."""
-        has_constant = self.temperature is not None
-        has_start = self.temperature_start is not None
-        has_end = self.temperature_end is not None
+        if self.temperature is not None:
+            if self.temperature_start is not None or self.temperature_end is not None:
+                raise ValueError(
+                    "Cannot specify both 'temperature' and temperature ramping "
+                    "('temperature_start'/'temperature_end')"
+                )
+            if (
+                self.temperature_increment is not None
+                or self.temperature_interval_steps is not None
+            ):
+                raise ValueError(
+                    "'temperature_increment' and 'temperature_interval_steps' are only "
+                    "valid for temperature ramps"
+                )
+            if self.duration is None:
+                raise ValueError("Constant-temperature stages require 'duration'")
+            return self
 
-        if has_constant and (has_start or has_end):
-            raise ValueError(
-                "Cannot specify both 'temperature' and temperature ramping "
-                "('temperature_start'/'temperature_end')"
-            )
-
-        if not has_constant and not (has_start and has_end):
+        if self.temperature_start is None or self.temperature_end is None:
             raise ValueError(
                 "Must specify either 'temperature' for constant temperature, "
-                "or both 'temperature_start' and 'temperature_end' for ramping"
+                "or 'temperature_start', 'temperature_end', 'temperature_increment', "
+                "and 'temperature_interval_steps' for ramping"
             )
 
-        if has_start and has_end and self.temperature_start > self.temperature_end:
+        if self.temperature_increment is None or self.temperature_interval_steps is None:
             raise ValueError(
-                f"temperature_start ({self.temperature_start}) must be <= "
+                "Temperature ramps require 'temperature_increment' and 'temperature_interval_steps'"
+            )
+
+        if self.temperature_start >= self.temperature_end:
+            raise ValueError(
+                f"temperature_start ({self.temperature_start}) must be < "
                 f"temperature_end ({self.temperature_end})"
             )
+
+        timestep_fs = self.time_step or 2.0
+        total_steps = self.temperature_ramp_updates * self.temperature_interval_steps
+        self.duration = total_steps * timestep_fs / 1e6
 
         return self
 
@@ -883,6 +997,14 @@ class EquilibrationStageConfig(BaseModel):
             self.barostat = BarostatType.MONTE_CARLO
         return self
 
+    @model_serializer(mode="wrap")
+    def serialize_stage(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        """Omit internally derived ramp duration from saved configurations."""
+        data = handler(self)
+        if self.is_temperature_ramping:
+            data.pop("duration", None)
+        return data
+
     @property
     def is_temperature_ramping(self) -> bool:
         """Check if this stage uses temperature ramping."""
@@ -891,14 +1013,56 @@ class EquilibrationStageConfig(BaseModel):
     def get_start_temperature(self) -> float:
         """Get the starting temperature of this stage."""
         if self.is_temperature_ramping:
+            assert self.temperature_start is not None
             return self.temperature_start
+        assert self.temperature is not None
         return self.temperature
 
     def get_final_temperature(self) -> float:
         """Get the final temperature of this stage."""
         if self.is_temperature_ramping:
+            assert self.temperature_end is not None
             return self.temperature_end
+        assert self.temperature is not None
         return self.temperature
+
+    @property
+    def resolved_duration(self) -> float:
+        """Return the validated stage duration in nanoseconds."""
+        if self.duration is None:
+            raise RuntimeError(f"Equilibration stage '{self.name}' has no resolved duration")
+        return self.duration
+
+    @property
+    def temperature_ramp_updates(self) -> int:
+        """Return the number of discrete updates needed to reach the endpoint."""
+        if not self.is_temperature_ramping:
+            return 0
+        assert self.temperature_start is not None
+        assert self.temperature_end is not None
+        assert self.temperature_increment is not None
+        exact_updates = (self.temperature_end - self.temperature_start) / self.temperature_increment
+        nearest_updates = round(exact_updates)
+        if math.isclose(exact_updates, nearest_updates, rel_tol=1e-12, abs_tol=1e-9):
+            return max(1, nearest_updates)
+        return max(1, math.ceil(exact_updates))
+
+    def temperature_at_step(self, step: int, total_steps: int) -> float:
+        """Return the scheduled ramp temperature at an integration step."""
+        if not self.is_temperature_ramping:
+            return self.get_start_temperature()
+        if total_steps <= 0:
+            raise ValueError("total_steps must be positive")
+        assert self.temperature_start is not None
+        assert self.temperature_end is not None
+        assert self.temperature_increment is not None
+        assert self.temperature_interval_steps is not None
+        bounded_step = min(max(step, 0), total_steps)
+        completed_updates = bounded_step // self.temperature_interval_steps
+        return min(
+            self.temperature_end,
+            self.temperature_start + completed_updates * self.temperature_increment,
+        )
 
 
 class SimulationPhasesConfig(BaseModel):
@@ -938,7 +1102,7 @@ class SimulationPhasesConfig(BaseModel):
 
         Returns the sum of all stage durations.
         """
-        return sum(stage.duration for stage in self.equilibration_stages)
+        return sum(stage.resolved_duration for stage in self.equilibration_stages or [])
 
     @property
     def total_equilibration_samples(self) -> int:
@@ -946,7 +1110,7 @@ class SimulationPhasesConfig(BaseModel):
 
         Returns the sum of all stage samples.
         """
-        return sum(stage.samples for stage in self.equilibration_stages)
+        return sum(stage.samples for stage in self.equilibration_stages or [])
 
 
 # =============================================================================

--- a/src/polyzymd/engines/openmm/engine.py
+++ b/src/polyzymd/engines/openmm/engine.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from polyzymd.engines.base import EngineSubmitRequest, SimulationEngine, TrajectoryLayout
-from polyzymd.simulation.progress import SimulationProgress
+from polyzymd.simulation.progress import (
+    SegmentStatus,
+    SimulationProgress,
+    calculate_report_interval,
+    load_progress,
+)
 
 
 class OpenMMEngine(SimulationEngine):
@@ -57,6 +62,8 @@ class OpenMMEngine(SimulationEngine):
         from polyzymd.cli.main import _run_initial_segment
 
         prod = self._config.simulation_phases.production
+        total_steps = int(prod.duration * 1e6 / prod.time_step)
+        report_interval = calculate_report_interval(total_steps, prod.samples)
         _run_initial_segment(
             sim_config=self._config,
             working_dir=working_dir,
@@ -65,7 +72,7 @@ class OpenMMEngine(SimulationEngine):
             duration_ns=prod.duration,
             num_samples=prod.samples,
             timestep_fs=prod.time_step,
-            report_interval=prod.report_interval,
+            report_interval=report_interval,
             checkpoint_interval_s=prod.checkpoint_interval,
         )
 
@@ -242,11 +249,25 @@ class OpenMMEngine(SimulationEngine):
         if segment_dirs:
             max_index = max(segment_dirs)
             trajectory_paths = []
+            progress = load_progress(working_dir)
+            zero_frame_segments = (
+                {
+                    segment.index
+                    for segment in progress.segments
+                    if segment.status == SegmentStatus.COMPLETED and segment.samples_written == 0
+                }
+                if progress is not None
+                else set()
+            )
             for index in range(max_index + 1):
                 segment_dir = working_dir / f"production_{index}"
                 file_path = segment_dir / f"production_{index}_trajectory.dcd"
                 if not segment_dir.is_dir():
                     raise ValueError(f"Missing OpenMM production segment directory: {segment_dir}")
+                if index in zero_frame_segments and (
+                    not file_path.is_file() or file_path.stat().st_size == 0
+                ):
+                    continue
                 if not file_path.is_file():
                     raise ValueError(f"Missing OpenMM trajectory segment: {file_path}")
                 if file_path.stat().st_size == 0:

--- a/src/polyzymd/exporters/gromacs.py
+++ b/src/polyzymd/exporters/gromacs.py
@@ -507,7 +507,7 @@ class MDPGenerator:
 
                 params = self._create_equilibration_params(
                     name=stage.name,
-                    duration_ns=stage.duration,
+                    duration_ns=stage.resolved_duration,
                     samples=stage.samples,
                     time_step_fs=stage.time_step or 2.0,
                     temperature=temperature,
@@ -619,14 +619,23 @@ class MDPGenerator:
         """
         time_step_fs = stage.time_step or 2.0
         dt_ps = time_step_fs / 1000.0
-        nsteps = int(stage.duration * 1e6 / time_step_fs)
+        nsteps = int(round(stage.resolved_duration * 1e6 / time_step_fs))
         samples = stage.samples
         output_interval = max(1, nsteps // samples) if samples > 0 else 5000
 
         # Temperature ramping parameters
-        t_start = stage.temperature_start
-        t_end = stage.temperature_end
-        duration_ps = stage.duration * 1000  # ns to ps
+        t_start = stage.get_start_temperature()
+        t_end = stage.get_final_temperature()
+        increment = stage.temperature_increment
+        interval_steps = stage.temperature_interval_steps
+        assert increment is not None
+        assert interval_steps is not None
+        logger.info(
+            f"GROMACS temperature ramp '{stage.name}': {t_start:g} K -> {t_end:g} K "
+            f"by {increment:g} K every {interval_steps} steps; derived duration "
+            f"{stage.resolved_duration:.6f} ns ({stage.temperature_ramp_updates} updates, "
+            f"{nsteps} total steps at {time_step_fs:g} fs)"
+        )
 
         # Map thermostat
         thermostat = stage.thermostat.value if stage.thermostat else "LangevinMiddle"
@@ -642,11 +651,12 @@ class MDPGenerator:
 
         ref_p = self._pressure * 1.01325
 
-        # GROMACS annealing: simple linear ramp
-        # annealing-time: times in ps
-        # annealing-temp: temperatures at those times
-        annealing_time = [0.0, duration_ps]
-        annealing_temp = [t_start, t_end]
+        # GROMACS interpolates between update points separated by the requested steps.
+        interval_ps = interval_steps * dt_ps
+        annealing_time = [i * interval_ps for i in range(stage.temperature_ramp_updates + 1)]
+        annealing_temp = [
+            min(t_end, t_start + i * increment) for i in range(stage.temperature_ramp_updates + 1)
+        ]
 
         return MDPParameters(
             title=f"Temperature Ramping: {stage.name} ({t_start}K -> {t_end}K)",
@@ -661,7 +671,7 @@ class MDPGenerator:
             nstxout_compressed=output_interval,
             continuation=not is_first_stage,
             tcoupl=tcoupl,
-            tau_t=stage.thermostat_timescale or 0.5,
+            tau_t=stage.thermostat_timescale or 1.0,
             ref_t=t_end,  # Reference temp is final temp
             pcoupl=pcoupl,
             pcoupltype=pcoupltype,
@@ -669,7 +679,7 @@ class MDPGenerator:
             gen_vel=is_first_stage,
             gen_temp=t_start,  # Generate velocities at start temp
             annealing="single",
-            annealing_npoints=2,
+            annealing_npoints=len(annealing_time),
             annealing_time=annealing_time,
             annealing_temp=annealing_temp,
             define=posres_defines,

--- a/src/polyzymd/exporters/gromacs.py
+++ b/src/polyzymd/exporters/gromacs.py
@@ -651,12 +651,23 @@ class MDPGenerator:
 
         ref_p = self._pressure * 1.01325
 
-        # GROMACS interpolates between update points separated by the requested steps.
+        # GROMACS annealing is piecewise linear. Pair each hold point with the
+        # following boundary so the reference temperature stays constant and
+        # changes over exactly one MD timestep, matching OpenMM at every
+        # integration step.
         interval_ps = interval_steps * dt_ps
-        annealing_time = [i * interval_ps for i in range(stage.temperature_ramp_updates + 1)]
-        annealing_temp = [
-            min(t_end, t_start + i * increment) for i in range(stage.temperature_ramp_updates + 1)
-        ]
+        annealing_time = [0.0]
+        annealing_temp = [t_start]
+        for update in range(1, stage.temperature_ramp_updates + 1):
+            boundary_ps = update * interval_ps
+            hold_end_ps = boundary_ps - dt_ps
+            previous_temp = min(t_end, t_start + (update - 1) * increment)
+            next_temp = min(t_end, t_start + update * increment)
+            if hold_end_ps > annealing_time[-1]:
+                annealing_time.append(hold_end_ps)
+                annealing_temp.append(previous_temp)
+            annealing_time.append(boundary_ps)
+            annealing_temp.append(next_temp)
 
         return MDPParameters(
             title=f"Temperature Ramping: {stage.name} ({t_start}K -> {t_end}K)",

--- a/src/polyzymd/simulation/progress.py
+++ b/src/polyzymd/simulation/progress.py
@@ -831,6 +831,15 @@ def _convert_to_fs(value: float, unit: str) -> float:
 # ---------------------------------------------------------------------------
 
 
+def calculate_report_interval(total_steps: int, total_samples: int) -> int:
+    """Calculate a trajectory reporter interval from the requested frame count."""
+    if total_steps <= 0:
+        raise ValueError("total_steps must be positive")
+    if total_samples <= 0:
+        raise ValueError("total_samples must be positive")
+    return max(1, total_steps // total_samples)
+
+
 def get_next_segment_info(
     progress: SimulationProgress,
     total_steps: int,
@@ -866,8 +875,8 @@ def get_next_segment_info(
         return None
 
     # Fixed interval from the global config — same for every segment
-    report_interval = max(1, total_steps // total_samples)
-    samples = remaining // report_interval
+    report_interval = calculate_report_interval(total_steps, total_samples)
+    samples = total_steps // report_interval - completed // report_interval
 
     return {
         "segment_index": progress.next_segment_index,

--- a/src/polyzymd/simulation/runner.py
+++ b/src/polyzymd/simulation/runner.py
@@ -135,6 +135,8 @@ class SimulationRunner:
         self._current_positions = positions
         self._current_velocities = None  # Carried between equilibration stages
         self._current_box_vectors = None  # Updated during NPT stages
+        self._current_step_count = 0
+        self._current_time = None
         self._history: Dict[str, Any] = {}
 
         # Ensure working directory exists
@@ -317,11 +319,16 @@ class SimulationRunner:
                 or "none"
             )
             if stage.is_temperature_ramping:
-                temp_info = f"{stage.temperature_start}K -> {stage.temperature_end}K"
+                temp_info = (
+                    f"{stage.temperature_start}K -> {stage.temperature_end}K, "
+                    f"+{stage.temperature_increment:g} K every "
+                    f"{stage.temperature_interval_steps} steps "
+                    f"(derived duration {stage.resolved_duration:.6f} ns)"
+                )
             else:
                 temp_info = f"{stage.temperature}K"
             LOGGER.info(
-                f"  Stage {i}: {stage.name} - {stage.duration} ns, "
+                f"  Stage {i}: {stage.name} - {stage.resolved_duration:.6f} ns, "
                 f"{stage.ensemble.value}, {temp_info}, restraints: [{restraint_info}]"
             )
 
@@ -377,7 +384,9 @@ class SimulationRunner:
         )
 
         stage_name = f"equilibration_{stage_index}_{stage.name}"
-        LOGGER.info(f"Starting equilibration stage: {stage.name} ({stage.duration} ns)")
+        LOGGER.info(
+            f"Starting equilibration stage: {stage.name} ({stage.resolved_duration:.6f} ns)"
+        )
 
         # Create output directory for this stage
         phase_dir = self._working_dir / stage_name
@@ -389,10 +398,11 @@ class SimulationRunner:
         friction = 1.0 / thermostat_timescale  # friction (1/ps) = 1 / timescale (ps)
 
         # Calculate steps and reporting interval
-        total_steps = int(stage.duration * 1e6 / timestep_fs)
+        total_steps = int(round(stage.resolved_duration * 1e6 / timestep_fs))
         report_interval = max(1, total_steps // stage.samples)
 
         # Handle ensemble - add/remove barostat
+        barostat_freq = None
         if stage.ensemble == Ensemble.NPT:
             self._remove_barostat()
             pressure = 1.0  # Default pressure for NPT stages
@@ -449,11 +459,21 @@ class SimulationRunner:
 
         self._simulation.context.setPositions(self._current_positions)
 
+        if resume_from_step > 0:
+            if self._current_step_count != resume_from_step:
+                raise RuntimeError(
+                    f"Equilibration resume marker is at step {resume_from_step}, but "
+                    f"the saved state is at step {self._current_step_count}"
+                )
+            self._simulation.currentStep = self._current_step_count
+            if self._current_time is not None:
+                self._simulation.context.setTime(self._current_time)
+
         # Velocity initialization: only generate fresh Maxwell-Boltzmann
         # velocities for the first stage. Subsequent stages inherit velocities
         # from the previous stage for physical continuity — matching the
         # GROMACS convention (gen_vel=yes only for stage 0).
-        if stage_index == 0 or self._current_velocities is None:
+        if (stage_index == 0 and resume_from_step == 0) or self._current_velocities is None:
             self._simulation.context.setVelocitiesToTemperature(start_temp * omm_unit.kelvin)
             LOGGER.info(f"Stage {stage_index}: initialized velocities at {start_temp} K")
         else:
@@ -470,7 +490,15 @@ class SimulationRunner:
         state_path = phase_dir / f"{stage_name}_state_data.csv"
         pdb_path = phase_dir / f"{stage_name}_topology.pdb"
 
-        self._simulation.reporters.append(DCDReporter(str(traj_path), report_interval))
+        append_trajectory = (
+            resume_from_step > 0 and traj_path.exists() and traj_path.stat().st_size > 0
+        )
+        append_state_data = (
+            resume_from_step > 0 and state_path.exists() and state_path.stat().st_size > 0
+        )
+        self._simulation.reporters.append(
+            DCDReporter(str(traj_path), report_interval, append=append_trajectory)
+        )
         self._simulation.reporters.append(
             StateDataReporter(
                 str(state_path),
@@ -484,6 +512,7 @@ class SimulationRunner:
                 volume=True,
                 density=True,
                 speed=True,
+                append=append_state_data,
             )
         )
 
@@ -509,20 +538,43 @@ class SimulationRunner:
 
         install_handlers()
 
+        if self._simulation is None:
+            raise RuntimeError("Equilibration simulation was not initialized")
+
         # Helper: save EQ_INTERRUPTED marker for mid-stage resume
         def _save_eq_interrupted(steps_done: int, current_temp: float) -> None:
-            marker_path = phase_dir / "EQ_INTERRUPTED"
-            marker_path.write_text(
-                f"stage_index={stage_index}\n"
-                f"stage_name={stage.name}\n"
-                f"steps_completed={steps_done}\n"
-                f"total_steps={total_steps}\n"
-                f"current_temperature={current_temp}\n"
-                f"is_temperature_ramping={stage.is_temperature_ramping}\n"
+            self._simulation.saveCheckpoint(str(eq_chk_path))
+            interrupted_state = self._simulation.context.getState(
+                getPositions=True,
+                getVelocities=True,
+                getParameters=True,
             )
+            state_path = phase_dir / f"{stage_name}_state.xml"
+            state_path.write_text(XmlSerializer.serialize(interrupted_state))
+            marker_path = phase_dir / "EQ_INTERRUPTED"
+            marker_lines = [
+                f"stage_index={stage_index}",
+                f"stage_name={stage.name}",
+                f"steps_completed={steps_done}",
+                f"total_steps={total_steps}",
+                f"current_temperature={current_temp}",
+                f"is_temperature_ramping={stage.is_temperature_ramping}",
+            ]
+            if stage.is_temperature_ramping:
+                marker_lines.extend(
+                    [
+                        f"temperature_start={stage.temperature_start}",
+                        f"temperature_end={stage.temperature_end}",
+                        f"temperature_increment={stage.temperature_increment}",
+                        f"temperature_interval_steps={stage.temperature_interval_steps}",
+                    ]
+                )
+            marker_path.write_text("\n".join(marker_lines) + "\n")
             LOGGER.info(
-                f"Saved EQ_INTERRUPTED marker: stage {stage_index}, "
-                f"step {steps_done}/{total_steps}, temp {current_temp} K"
+                f"Saved synchronized equilibration state, checkpoint, and "
+                f"EQ_INTERRUPTED marker: stage {stage_index}, "
+                f"step {steps_done}/{total_steps}, scheduled temperature "
+                f"{current_temp} K"
             )
 
         # Track steps completed (starting from resume point)
@@ -530,40 +582,30 @@ class SimulationRunner:
 
         # Run simulation with temperature ramping if needed
         if stage.is_temperature_ramping:
+            ramp_start = stage.get_start_temperature()
+            ramp_end = stage.get_final_temperature()
+            ramp_increment = stage.temperature_increment
+            temperature_update_steps = stage.temperature_interval_steps
+            assert ramp_increment is not None
+            assert temperature_update_steps is not None
             LOGGER.info(
-                f"Temperature ramping: {stage.temperature_start} K -> {stage.temperature_end} K "
-                f"(increment={stage.temperature_increment} K every {stage.temperature_interval} fs)"
+                f"Temperature ramping: {ramp_start} K -> {ramp_end} K "
+                f"by {ramp_increment:g} K every {temperature_update_steps} steps; "
+                f"derived duration {stage.resolved_duration:.6f} ns "
+                f"({stage.temperature_ramp_updates} updates, {total_steps} total steps "
+                f"at {timestep_fs:g} fs)"
             )
-            steps_per_update = int(stage.temperature_interval / timestep_fs)
-
-            # Calculate total temperature updates needed
-            temp_range = stage.temperature_end - stage.temperature_start
-            num_updates = int(temp_range / stage.temperature_increment)
-            steps_for_ramping = num_updates * steps_per_update
-            remaining_steps_at_final = total_steps - steps_for_ramping
-
-            # Determine starting temperature — always begin from
-            # temperature_start and let the fast-forward loop advance
-            # current_temp by skipping already-completed chunks.  On
-            # resume, resume_temperature is used only for logging.
-            current_temp = stage.temperature_start
+            current_temp = stage.temperature_at_step(resume_from_step, total_steps)
             if resume_from_step > 0 and resume_temperature is not None:
                 LOGGER.info(
                     f"Resuming temperature ramp from step {resume_from_step}, "
-                    f"saved temp {resume_temperature} K (fast-forwarding from {current_temp} K)"
+                    f"saved temp {resume_temperature} K, calculated schedule temp "
+                    f"{current_temp:.6f} K"
                 )
 
-            # Temperature ramping phase — each update is a chunk we can
-            # interrupt between.  Skip chunks already completed on resume.
-            ramp_step_count = 0
-            while current_temp < stage.temperature_end:
-                chunk_end = ramp_step_count + steps_per_update
-                if chunk_end <= resume_from_step:
-                    # Already completed this chunk in a previous run
-                    ramp_step_count = chunk_end
-                    current_temp += stage.temperature_increment
-                    continue
-
+            # Hold each target for the requested step interval, then increment it.
+            while steps_done < total_steps:
+                current_temp = stage.temperature_at_step(steps_done, total_steps)
                 integrator.setTemperature(current_temp * omm_unit.kelvin)
                 if stage.ensemble == Ensemble.NPT:
                     self._simulation.context.setParameter(
@@ -571,12 +613,11 @@ class SimulationRunner:
                         current_temp * omm_unit.kelvin,
                     )
 
-                # If resuming mid-chunk, only run the remainder
-                steps_already = max(0, resume_from_step - ramp_step_count)
-                steps_this_chunk = steps_per_update - steps_already
+                steps_to_update = temperature_update_steps - (steps_done % temperature_update_steps)
+                steps_this_chunk = min(steps_to_update, total_steps - steps_done)
                 self._simulation.step(steps_this_chunk)
                 steps_done += steps_this_chunk
-                ramp_step_count = chunk_end
+                current_temp = stage.temperature_at_step(steps_done, total_steps)
 
                 if is_interrupted():
                     LOGGER.warning(
@@ -588,44 +629,17 @@ class SimulationRunner:
                         signal_number=get_interrupt_signal(), steps_completed=steps_done
                     )
 
-                current_temp += stage.temperature_increment
-
-            # Final temperature - run remaining steps in chunks
-            integrator.setTemperature(stage.temperature_end * omm_unit.kelvin)
+            # Pin both coupling algorithms to the exact requested endpoint.
+            integrator.setTemperature(ramp_end * omm_unit.kelvin)
             if stage.ensemble == Ensemble.NPT:
                 self._simulation.context.setParameter(
                     openmm.MonteCarloBarostat.Temperature(),
-                    stage.temperature_end * omm_unit.kelvin,
+                    ramp_end * omm_unit.kelvin,
                 )
-            current_temp = stage.temperature_end
-            steps_at_final_done = steps_done - steps_for_ramping
-            steps_at_final_remaining = max(0, remaining_steps_at_final - steps_at_final_done)
-
-            if steps_at_final_remaining > 0:
-                LOGGER.info(
-                    f"Running {steps_at_final_remaining} steps at final "
-                    f"temperature {stage.temperature_end} K"
-                )
-                chunk_size = min(report_interval, steps_at_final_remaining)
-                while steps_at_final_remaining > 0:
-                    this_chunk = min(chunk_size, steps_at_final_remaining)
-                    self._simulation.step(this_chunk)
-                    steps_done += this_chunk
-                    steps_at_final_remaining -= this_chunk
-
-                    if is_interrupted():
-                        LOGGER.warning(
-                            f"Interrupt during equilibration stage {stage_index} "
-                            f"at step {steps_done}/{total_steps} (final temp)"
-                        )
-                        _save_eq_interrupted(steps_done, current_temp)
-                        raise GracefulExit(
-                            signal_number=get_interrupt_signal(),
-                            steps_completed=steps_done,
-                        )
+            current_temp = ramp_end
         else:
             # Constant temperature - run in chunks with signal checking
-            current_temp = stage.temperature
+            current_temp = stage.get_start_temperature()
             steps_remaining = total_steps - resume_from_step
             if resume_from_step > 0:
                 LOGGER.info(
@@ -633,7 +647,7 @@ class SimulationRunner:
                     f"{steps_remaining} steps remaining"
                 )
             else:
-                LOGGER.info(f"Running {total_steps} steps at {stage.temperature} K")
+                LOGGER.info(f"Running {total_steps} steps at {current_temp} K")
 
             chunk_size = min(report_interval, steps_remaining)
             while steps_remaining > 0:
@@ -659,6 +673,9 @@ class SimulationRunner:
         self._current_positions = state.getPositions()
         self._current_velocities = state.getVelocities()
         self._current_box_vectors = state.getPeriodicBoxVectors()
+
+        state_xml_path = phase_dir / f"{stage_name}_state.xml"
+        state_xml_path.write_text(XmlSerializer.serialize(state))
 
         # Log final energy for diagnostics
         final_energy = state.getPotentialEnergy().value_in_unit(omm_unit.kilojoule_per_mole)
@@ -687,11 +704,13 @@ class SimulationRunner:
             "stage_index": stage_index,
             "stage_name": stage.name,
             "ensemble": stage.ensemble.value,
-            "duration_ns": stage.duration,
+            "duration_ns": stage.resolved_duration,
             "total_steps": total_steps,
             "temperature_start_K": stage.get_start_temperature(),
             "temperature_end_K": final_temp,
             "is_temperature_ramping": stage.is_temperature_ramping,
+            "temperature_increment_K": stage.temperature_increment,
+            "temperature_interval_steps": stage.temperature_interval_steps,
             "position_restraints": [
                 {"group": r.group, "force_constant": r.force_constant}
                 for r in stage.position_restraints
@@ -791,16 +810,25 @@ class SimulationRunner:
                     info["current_temperature"] = float(value)
                 elif key == "is_temperature_ramping":
                     info["is_temperature_ramping"] = value.lower() == "true"
+                elif key in {
+                    "temperature_start",
+                    "temperature_end",
+                    "temperature_increment",
+                }:
+                    info[key] = float(value)
+                elif key == "temperature_interval_steps":
+                    info[key] = int(value)
         except (ValueError, OSError) as exc:
             LOGGER.warning(f"Could not parse EQ_INTERRUPTED marker {marker_path}: {exc}")
             return None
 
-        # Verify checkpoint exists (needed for resume)
+        # Verify a synchronized portable state or binary checkpoint exists.
         chk = stage_dir / f"{stage_name}_checkpoint.chk"
-        if not chk.exists():
+        state_xml = stage_dir / f"{stage_name}_state.xml"
+        if not state_xml.exists() and not chk.exists():
             LOGGER.warning(
-                f"EQ_INTERRUPTED marker found for stage {next_idx} but no checkpoint — "
-                f"will restart stage from beginning"
+                f"EQ_INTERRUPTED marker found for stage {next_idx} but no state or "
+                "checkpoint — will restart stage from beginning"
             )
             return None
 
@@ -831,10 +859,27 @@ class SimulationRunner:
             Name of the completed stage (used in directory/file naming).
         """
         dir_name = f"equilibration_{stage_index}_{stage_name}"
-        chk_path = self._working_dir / dir_name / f"{dir_name}_checkpoint.chk"
+        stage_dir = self._working_dir / dir_name
+        state_path = stage_dir / f"{dir_name}_state.xml"
+        chk_path = stage_dir / f"{dir_name}_checkpoint.chk"
+
+        if state_path.exists():
+            state = XmlSerializer.deserialize(state_path.read_text())
+            self._current_positions = state.getPositions()
+            self._current_velocities = state.getVelocities()
+            self._current_box_vectors = state.getPeriodicBoxVectors()
+            self._current_step_count = int(state.getStepCount())
+            self._current_time = state.getTime()
+            LOGGER.info(
+                f"Loaded portable state from equilibration stage {stage_index} "
+                f"({stage_name}) at step {self._current_step_count}"
+            )
+            return
 
         if not chk_path.exists():
-            raise FileNotFoundError(f"Equilibration checkpoint not found: {chk_path}")
+            raise FileNotFoundError(
+                f"Equilibration state and checkpoint not found: {state_path}, {chk_path}"
+            )
 
         # Temporary simulation context to deserialise the binary checkpoint.
         # We use a dummy VerletIntegrator because we only need to extract
@@ -849,12 +894,75 @@ class SimulationRunner:
         self._current_positions = state.getPositions()
         self._current_velocities = state.getVelocities()
         self._current_box_vectors = state.getPeriodicBoxVectors()
+        self._current_step_count = int(state.getStepCount())
+        self._current_time = state.getTime()
         # Discard the temporary simulation — it has a dummy integrator
         del temp_sim
 
         LOGGER.info(
-            f"Loaded state from equilibration stage {stage_index} ({stage_name}) checkpoint"
+            f"Loaded legacy checkpoint from equilibration stage {stage_index} "
+            f"({stage_name}) at step {self._current_step_count}"
         )
+
+    @staticmethod
+    def _validate_eq_resume_metadata(
+        stage: "EquilibrationStageConfig",
+        resume_step: int,
+        saved_total_steps: int | None,
+        saved_temperature: float | None,
+        saved_temperature_start: float | None,
+        saved_temperature_end: float | None,
+        saved_temperature_increment: float | None,
+        saved_temperature_interval_steps: int | None,
+    ) -> None:
+        """Reject resume markers created with a different stage schedule."""
+        timestep_fs = stage.time_step or 2.0
+        expected_total_steps = int(round(stage.resolved_duration * 1e6 / timestep_fs))
+        if saved_total_steps is not None and saved_total_steps != expected_total_steps:
+            raise RuntimeError(
+                f"Cannot resume equilibration stage '{stage.name}': marker has "
+                f"{saved_total_steps} total steps, but the current configuration "
+                f"requires {expected_total_steps}"
+            )
+
+        if stage.is_temperature_ramping:
+            if saved_temperature is None:
+                raise RuntimeError(
+                    f"Cannot resume temperature ramp '{stage.name}': marker does not "
+                    "contain the scheduled temperature"
+                )
+            saved_schedule = (
+                saved_temperature_start,
+                saved_temperature_end,
+                saved_temperature_increment,
+                saved_temperature_interval_steps,
+            )
+            if any(value is None for value in saved_schedule):
+                raise RuntimeError(
+                    f"Cannot resume temperature ramp '{stage.name}': marker does not "
+                    "contain the complete increment schedule"
+                )
+            current_schedule = (
+                stage.temperature_start,
+                stage.temperature_end,
+                stage.temperature_increment,
+                stage.temperature_interval_steps,
+            )
+            if saved_schedule != current_schedule:
+                raise RuntimeError(
+                    f"Cannot resume temperature ramp '{stage.name}': marker schedule "
+                    f"{saved_schedule} does not match current schedule {current_schedule}"
+                )
+            expected_temperature = stage.temperature_at_step(
+                resume_step,
+                expected_total_steps,
+            )
+            if abs(saved_temperature - expected_temperature) > 1e-6:
+                raise RuntimeError(
+                    f"Cannot resume temperature ramp '{stage.name}': marker temperature "
+                    f"is {saved_temperature} K, but the current schedule requires "
+                    f"{expected_temperature} K at step {resume_step}"
+                )
 
     def run_staged_equilibration(
         self,
@@ -921,10 +1029,10 @@ class SimulationRunner:
                         "stage_index": i,
                         "stage_name": stage.name,
                         "skipped": True,
-                        "duration_ns": stage.duration,
+                        "duration_ns": stage.resolved_duration,
                     }
                 )
-                results["total_duration_ns"] += stage.duration
+                results["total_duration_ns"] += stage.resolved_duration
                 continue
 
             stage_dir_name = f"equilibration_{i}_{stage.name}"
@@ -935,6 +1043,18 @@ class SimulationRunner:
                 # Resume mid-stage from checkpoint
                 resume_step = interrupted_info.get("steps_completed", 0)
                 resume_temp = interrupted_info.get("current_temperature")
+                self._validate_eq_resume_metadata(
+                    stage=stage,
+                    resume_step=resume_step,
+                    saved_total_steps=interrupted_info.get("total_steps"),
+                    saved_temperature=resume_temp,
+                    saved_temperature_start=interrupted_info.get("temperature_start"),
+                    saved_temperature_end=interrupted_info.get("temperature_end"),
+                    saved_temperature_increment=interrupted_info.get("temperature_increment"),
+                    saved_temperature_interval_steps=interrupted_info.get(
+                        "temperature_interval_steps"
+                    ),
+                )
                 LOGGER.info(
                     f"Resuming interrupted equilibration stage {i} ({stage.name}) "
                     f"from step {resume_step}"
@@ -950,7 +1070,7 @@ class SimulationRunner:
                     resume_temperature=resume_temp,
                 )
                 results["stages"].append(stage_result)
-                results["total_duration_ns"] += stage.duration
+                results["total_duration_ns"] += stage.resolved_duration
                 continue
 
             # Clean up partial stage directory (exists but no checkpoint and
@@ -969,7 +1089,7 @@ class SimulationRunner:
                 stage_index=i,
             )
             results["stages"].append(stage_result)
-            results["total_duration_ns"] += stage.duration
+            results["total_duration_ns"] += stage.resolved_duration
 
         # Get final energy
         if results["stages"]:

--- a/src/polyzymd/templates/examples/dynamic_polymer_test.yaml
+++ b/src/polyzymd/templates/examples/dynamic_polymer_test.yaml
@@ -123,7 +123,6 @@ simulation_phases:
     ensemble: "NPT"
     duration: 0.1  # 100 ps - short for testing
     samples: 10
-    report_interval: 5000
     checkpoint_interval: 60.0
     time_step: 2.0
     thermostat: "LangevinMiddle"

--- a/src/polyzymd/templates/examples/enzyme_cosolvent.yaml
+++ b/src/polyzymd/templates/examples/enzyme_cosolvent.yaml
@@ -86,13 +86,12 @@ thermodynamics:
 simulation_phases:
   equilibration_stages:
     - name: "heating"
-      duration: 0.2
       samples: 20
       ensemble: "NVT"
       temperature_start: 60.0
       temperature_end: 298.0
       temperature_increment: 1.0
-      temperature_interval: 1200.0
+      temperature_interval_steps: 600  # duration is derived
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0
@@ -116,7 +115,6 @@ simulation_phases:
     ensemble: "NPT"
     duration: 50.0  # 50 ns production
     samples: 1250
-    report_interval: 20000
     checkpoint_interval: 60.0
     time_step: 2.0
     thermostat: "LangevinMiddle"

--- a/src/polyzymd/templates/examples/enzyme_cosolvent.yaml
+++ b/src/polyzymd/templates/examples/enzyme_cosolvent.yaml
@@ -91,7 +91,7 @@ simulation_phases:
       temperature_start: 60.0
       temperature_end: 298.0
       temperature_increment: 1.0
-      temperature_interval_steps: 600  # duration is derived
+      temperature_interval_steps: 600  # increase temperature by `temperature_increment` every this many steps
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0

--- a/src/polyzymd/templates/examples/enzyme_only.yaml
+++ b/src/polyzymd/templates/examples/enzyme_only.yaml
@@ -99,7 +99,7 @@ simulation_phases:
       temperature_start: 60.0
       temperature_end: 293.0
       temperature_increment: 1.0
-      temperature_interval_steps: 600  # duration is derived
+      temperature_interval_steps: 600  # increase temperature by `temperature_increment` every this many steps
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0

--- a/src/polyzymd/templates/examples/enzyme_only.yaml
+++ b/src/polyzymd/templates/examples/enzyme_only.yaml
@@ -94,13 +94,12 @@ thermodynamics:
 simulation_phases:
   equilibration_stages:
     - name: "heating"
-      duration: 0.1  # nanoseconds
       samples: 10
       ensemble: "NVT"
       temperature_start: 60.0
       temperature_end: 293.0
       temperature_increment: 1.0
-      temperature_interval: 1200.0
+      temperature_interval_steps: 600  # duration is derived
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0
@@ -116,7 +115,6 @@ simulation_phases:
     ensemble: "NPT"
     duration: 100.0  # nanoseconds total
     samples: 2500  # frames to save (total across all segments)
-    report_interval: 20000  # MD steps between trajectory/report writes
     checkpoint_interval: 60.0  # seconds between restart checkpoints
     time_step: 2.0  # femtoseconds
     thermostat: "LangevinMiddle"

--- a/src/polyzymd/templates/examples/enzyme_polymer.yaml
+++ b/src/polyzymd/templates/examples/enzyme_polymer.yaml
@@ -119,7 +119,7 @@ simulation_phases:
       temperature_start: 60.0
       temperature_end: 293.0
       temperature_increment: 1.0
-      temperature_interval_steps: 600  # duration is derived
+      temperature_interval_steps: 600  # increase temperature by `temperature_increment` every this many steps
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0

--- a/src/polyzymd/templates/examples/enzyme_polymer.yaml
+++ b/src/polyzymd/templates/examples/enzyme_polymer.yaml
@@ -114,13 +114,12 @@ thermodynamics:
 simulation_phases:
   equilibration_stages:
     - name: "heating"
-      duration: 0.1
       samples: 10
       ensemble: "NVT"
       temperature_start: 60.0
       temperature_end: 293.0
       temperature_increment: 1.0
-      temperature_interval: 1200.0
+      temperature_interval_steps: 600  # duration is derived
       position_restraints:
         - group: "protein_heavy"
           force_constant: 4184.0
@@ -144,7 +143,6 @@ simulation_phases:
     ensemble: "NPT"
     duration: 100.0  # 100 ns total
     samples: 2500
-    report_interval: 20000
     checkpoint_interval: 60.0
     time_step: 2.0
     thermostat: "LangevinMiddle"

--- a/src/polyzymd/templates/templates/config_template.yaml
+++ b/src/polyzymd/templates/templates/config_template.yaml
@@ -295,26 +295,26 @@ description: "Description of your simulation system"
 #
 # Temperature settings:
 #   - Use "temperature" for constant temperature
-#   - Use "temperature_start" + "temperature_end" for ramping
-#   - temperature_increment: Temperature step size (K, default: 1.0)
-#   - temperature_interval: Time between increments (fs, default: 1200)
+#   - For ramping, set temperature_start, temperature_end,
+#     temperature_increment (K), and temperature_interval_steps;
+#     PolyzyMD derives the duration
 #
 # simulation_phases:
 #   equilibration_stages:
 #     # Stage 1: Heat from 60K to 300K with everything restrained
 #     - name: "heating"
-#       duration: 0.288                   # nanoseconds
 #       samples: 50                       # trajectory frames
 #       ensemble: "NVT"
 #       temperature_start: 60.0           # Start temperature (K)
 #       temperature_end: 300.0            # End temperature (K)
-#       temperature_increment: 1.0        # Step size (K)
-#       temperature_interval: 1200.0      # Time between steps (fs)
+#       temperature_increment: 1.0         # Increase per update (K)
+#       temperature_interval_steps: 600    # MD steps between updates
 #       position_restraints:
 #         - group: "protein_heavy"
 #           force_constant: 4184.0        # kJ/mol/nm^2 (= 1 kcal/mol/A^2)
 #         - group: "polymer_heavy"
 #           force_constant: 4184.0
+#     # Add a constant-temperature stage after heating to equilibrate at the endpoint.
 #     
 #     # Stage 2: Relax polymers while keeping protein restrained
 #     - name: "polymer_relaxation"
@@ -338,7 +338,6 @@ description: "Description of your simulation system"
 #     ensemble: "NPT"
 #     duration: 100.0
 #     samples: 2500
-#     report_interval: 20000
 #     checkpoint_interval: 60.0
 #     time_step: 2.0
 #     thermostat: "LangevinMiddle"

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -16,7 +16,7 @@ import yaml
 from click.testing import CliRunner
 from jinja2 import UndefinedError
 
-from polyzymd.cli.main import _resolve_replicates_option, cli
+from polyzymd.cli.main import _resolve_replicates_option, _run_openmm_impl, cli
 from polyzymd.utils.templates import render_package_template
 
 BRANDING_LINE = "PolyzyMD: Created by Joseph R. Laforet Jr."
@@ -50,8 +50,18 @@ def _make_dry_run_config() -> SimpleNamespace:
         thermodynamics=SimpleNamespace(temperature=300.0, pressure=1.0),
         simulation_phases=SimpleNamespace(
             equilibration_stages=[
-                SimpleNamespace(name="heating", duration=0.2, ensemble="NVT"),
-                SimpleNamespace(name="free_equilibration", duration=0.8, ensemble="NPT"),
+                SimpleNamespace(
+                    name="heating",
+                    resolved_duration=0.2,
+                    ensemble="NVT",
+                    is_temperature_ramping=False,
+                ),
+                SimpleNamespace(
+                    name="free_equilibration",
+                    resolved_duration=0.8,
+                    ensemble="NPT",
+                    is_temperature_ramping=False,
+                ),
             ],
             production=SimpleNamespace(duration=10.0, samples=250),
         ),
@@ -87,7 +97,6 @@ def _minimal_cli_config_data(pdb_path: str | Path) -> dict[str, object]:
                 "ensemble": "NPT",
                 "duration": 1.0,
                 "samples": 10,
-                "report_interval": 50000,
                 "checkpoint_interval": 60.0,
             },
         },
@@ -242,6 +251,29 @@ class TestValidateCommandReferenceWarnings:
         assert "Configuration is valid!" in result.output
         assert "Referenced file warnings" in result.output
         assert "Missing enzyme PDB" in result.output
+
+    def test_validate_reports_derived_temperature_ramp_duration(self, tmp_path: Path) -> None:
+        """Validation clearly reports rate-based heating duration."""
+        data = _minimal_cli_config_data("missing.pdb")
+        data["simulation_phases"]["equilibration_stages"] = [
+            {
+                "name": "heating",
+                "ensemble": "NVT",
+                "temperature_start": 60.0,
+                "temperature_end": 300.0,
+                "temperature_increment": 1.0,
+                "temperature_interval_steps": 600,
+                "time_step": 2.0,
+            }
+        ]
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+        result = CliRunner().invoke(cli, ["validate", "-c", str(config_path)])
+
+        assert result.exit_code == 0
+        assert "60 -> 300 K, +1 K every 600 steps" in result.output
+        assert "derived duration 0.288000 ns" in result.output
 
 
 class TestBuildCommandReplicateFlags:
@@ -590,6 +622,40 @@ class TestBuildDryRunEndToEnd:
 
         assert result.exit_code != 0
         assert "No such option: --replicate" in result.output
+
+
+class TestOpenMMRunImplementation:
+    """Regression tests for local OpenMM production configuration."""
+
+    @patch("polyzymd.cli.main._run_initial_segment")
+    def test_derives_report_interval_from_samples(
+        self, run_initial_segment, tmp_path: Path
+    ) -> None:
+        """Local OpenMM runs use samples as the trajectory frame control."""
+        production = SimpleNamespace(
+            duration=1000.0,
+            samples=2500,
+            time_step=2.0,
+            checkpoint_interval=60.0,
+        )
+        config = SimpleNamespace(
+            simulation_phases=SimpleNamespace(production=production),
+            get_working_directory=lambda replicate: tmp_path / f"run_{replicate}",
+        )
+
+        _run_openmm_impl(config, replicate=1)
+
+        run_initial_segment.assert_called_once_with(
+            sim_config=config,
+            working_dir=tmp_path / "run_1",
+            replicate=1,
+            skip_build=False,
+            duration_ns=1000.0,
+            num_samples=2500,
+            timestep_fs=2.0,
+            report_interval=200000,
+            checkpoint_interval_s=60.0,
+        )
 
 
 class TestCliExceptionHandlingNarrowing:

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -580,30 +580,51 @@ class TestEquilibrationTemperatureRamp:
     def test_migrates_legacy_increment_and_interval(self, caplog):
         from polyzymd.config.schema import EquilibrationStageConfig
 
-        stage = EquilibrationStageConfig(
-            name="heating",
-            duration=0.1,
-            temperature_start=60.0,
-            temperature_end=300.0,
-            temperature_increment=1.0,
-            temperature_interval=1200.0,
-        )
+        with pytest.warns(DeprecationWarning, match="temperature_interval_steps"):
+            stage = EquilibrationStageConfig(
+                name="heating",
+                duration=0.1,
+                temperature_start=60.0,
+                temperature_end=300.0,
+                temperature_increment=1.0,
+                temperature_interval=1200.0,
+            )
 
         assert stage.temperature_increment == pytest.approx(1.0)
         assert stage.temperature_interval_steps == 600
         assert stage.resolved_duration == pytest.approx(0.288)
         assert "converted to temperature_interval_steps=600" in caplog.text
 
-    def test_rejects_duration_only_ramp(self):
+    def test_migrates_duration_only_ramp_with_legacy_defaults(self, caplog):
         from polyzymd.config.schema import EquilibrationStageConfig
 
-        with pytest.raises(ValidationError, match="Do not specify 'duration'"):
-            EquilibrationStageConfig(
+        with pytest.warns(DeprecationWarning, match="legacy 1200 fs default"):
+            stage = EquilibrationStageConfig(
                 name="heating",
                 duration=0.3,
                 temperature_start=60.0,
                 temperature_end=300.0,
             )
+
+        assert stage.temperature_increment == pytest.approx(1.0)
+        assert stage.temperature_interval_steps == 600
+        assert stage.resolved_duration == pytest.approx(0.288)
+        assert "legacy 1200 fs default" in caplog.text
+
+    def test_constant_stage_does_not_emit_ramp_deprecation_warning(self):
+        import warnings
+
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            stage = EquilibrationStageConfig(
+                name="equilibration",
+                duration=0.1,
+                temperature=300.0,
+            )
+
+        assert stage.resolved_duration == pytest.approx(0.1)
 
     def test_rejects_decimal_rate(self):
         from polyzymd.config.schema import EquilibrationStageConfig

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -29,7 +29,6 @@ def minimal_config_data():
                 "ensemble": "NPT",
                 "duration": 1.0,
                 "samples": 10,
-                "report_interval": 50000,
                 "checkpoint_interval": 60.0,
             },
         },
@@ -430,6 +429,21 @@ class TestRunDirectoryNaming:
 class TestSimulationPhasesConfig:
     """Test staged equilibration requirements."""
 
+    def test_ignores_deprecated_report_interval(self, caplog):
+        """Legacy intervals are ignored so samples controls trajectory cadence."""
+        from polyzymd.config.schema import SimulationPhaseConfig
+
+        phase = SimulationPhaseConfig(
+            ensemble="NPT",
+            duration=1.0,
+            samples=10,
+            report_interval=50000,
+            checkpoint_interval=60.0,
+        )
+
+        assert "report_interval" not in phase.model_dump()
+        assert "Ignoring deprecated" in caplog.text
+
     def test_requires_equilibration_stages(self):
         from pydantic import ValidationError
 
@@ -439,7 +453,6 @@ class TestSimulationPhasesConfig:
             ensemble="NPT",
             duration=1.0,
             samples=10,
-            report_interval=50000,
             checkpoint_interval=60.0,
             time_step=2.0,
         )
@@ -456,7 +469,6 @@ class TestSimulationPhasesConfig:
             ensemble="NPT",
             duration=1.0,
             samples=10,
-            report_interval=50000,
             checkpoint_interval=60.0,
             time_step=2.0,
         )
@@ -485,10 +497,136 @@ class TestSimulationPhasesConfig:
                     "ensemble": "NPT",
                     "duration": 1.0,
                     "samples": 10,
-                    "report_interval": 50000,
                     "checkpoint_interval": 60.0,
                 },
                 segments=[],
+            )
+
+
+class TestEquilibrationTemperatureRamp:
+    """Validate increment-based temperature ramps and derived durations."""
+
+    @staticmethod
+    def _stage(**overrides):
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        values = {
+            "name": "heating",
+            "temperature_start": 60.0,
+            "temperature_end": 300.0,
+            "temperature_increment": 1.0,
+            "temperature_interval_steps": 600,
+            "time_step": 2.0,
+        }
+        values.update(overrides)
+        return EquilibrationStageConfig(**values)
+
+    def test_derives_duration_without_user_duration(self):
+        stage = self._stage()
+
+        assert stage.resolved_duration == pytest.approx(0.288)
+        assert stage.temperature_ramp_updates == 240
+
+    def test_shortens_final_increment_to_hit_endpoint(self):
+        stage = self._stage(
+            temperature_start=100.0,
+            temperature_end=112.0,
+            temperature_increment=5.0,
+            temperature_interval_steps=100,
+        )
+
+        assert stage.temperature_ramp_updates == 3
+        assert stage.resolved_duration == pytest.approx(0.0006)
+        assert stage.temperature_at_step(200, 300) == pytest.approx(110.0)
+        assert stage.temperature_at_step(300, 300) == pytest.approx(112.0)
+
+    def test_fractional_increment_does_not_add_spurious_update(self):
+        stage = self._stage(
+            temperature_start=60.0,
+            temperature_end=60.7,
+            temperature_increment=0.1,
+            temperature_interval_steps=100,
+        )
+
+        assert stage.temperature_ramp_updates == 7
+        assert stage.resolved_duration == pytest.approx(0.0014)
+
+    def test_serialized_ramp_omits_derived_duration_and_round_trips(self):
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        stage = self._stage()
+        serialized = stage.model_dump()
+
+        assert "duration" not in serialized
+        restored = EquilibrationStageConfig.model_validate(serialized)
+        assert restored.resolved_duration == stage.resolved_duration
+        assert restored.temperature_ramp_updates == stage.temperature_ramp_updates
+
+    def test_rejects_duration_with_increment_based_ramp(self):
+        with pytest.raises(ValidationError, match="Do not specify 'duration'"):
+            self._stage(duration=0.2)
+
+    def test_requires_duration_for_constant_temperature(self):
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        with pytest.raises(ValidationError, match="require 'duration'"):
+            EquilibrationStageConfig(name="equilibration", temperature=300.0)
+
+    @pytest.mark.parametrize("end", [60.0, 50.0])
+    def test_requires_increasing_temperature(self, end):
+        with pytest.raises(ValidationError, match="must be <"):
+            self._stage(temperature_end=end)
+
+    def test_migrates_legacy_increment_and_interval(self, caplog):
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        stage = EquilibrationStageConfig(
+            name="heating",
+            duration=0.1,
+            temperature_start=60.0,
+            temperature_end=300.0,
+            temperature_increment=1.0,
+            temperature_interval=1200.0,
+        )
+
+        assert stage.temperature_increment == pytest.approx(1.0)
+        assert stage.temperature_interval_steps == 600
+        assert stage.resolved_duration == pytest.approx(0.288)
+        assert "converted to temperature_interval_steps=600" in caplog.text
+
+    def test_rejects_duration_only_ramp(self):
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        with pytest.raises(ValidationError, match="Do not specify 'duration'"):
+            EquilibrationStageConfig(
+                name="heating",
+                duration=0.3,
+                temperature_start=60.0,
+                temperature_end=300.0,
+            )
+
+    def test_rejects_decimal_rate(self):
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        with pytest.raises(ValidationError, match="not supported"):
+            EquilibrationStageConfig(
+                name="heating",
+                temperature_start=60.0,
+                temperature_end=300.0,
+                temperature_ramp_rate=0.8333333333333334,
+            )
+
+    def test_rejects_old_and_new_intervals_together(self):
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        with pytest.raises(ValidationError, match="Cannot specify both"):
+            EquilibrationStageConfig(
+                name="heating",
+                temperature_start=60.0,
+                temperature_end=300.0,
+                temperature_increment=1.0,
+                temperature_interval=1200.0,
+                temperature_interval_steps=600,
             )
 
 

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -29,7 +29,6 @@ def _minimal_config_data(tmp_path: Path) -> dict[str, object]:
                 "ensemble": "NPT",
                 "duration": 1.0,
                 "samples": 10,
-                "report_interval": 50000,
                 "checkpoint_interval": 60.0,
             },
         },

--- a/tests/engines/test_openmm_layout.py
+++ b/tests/engines/test_openmm_layout.py
@@ -8,6 +8,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from polyzymd.engines.openmm.engine import OpenMMEngine
+from polyzymd.simulation.progress import (
+    SegmentRecord,
+    SegmentStatus,
+    SimulationProgress,
+    save_progress,
+)
 
 
 def _make_engine() -> OpenMMEngine:
@@ -126,6 +132,39 @@ class TestOpenMMTrajectorySearch:
         engine = _make_engine()
         with pytest.raises(ValueError, match="Empty OpenMM trajectory segment"):
             engine.resolve_trajectory_layout(tmp_path, replicate=1)
+
+    def test_skips_completed_zero_frame_final_segment(self, tmp_path: Path) -> None:
+        """A final remainder after the last report boundary has no DCD file."""
+        prod0 = tmp_path / "production_0"
+        prod0.mkdir()
+        (prod0 / "production_0_trajectory.dcd").write_bytes(b"DCD")
+        (tmp_path / "production_1").mkdir()
+        progress = SimulationProgress(
+            total_steps_requested=105,
+            total_samples_requested=10,
+            status="completed",
+            segments=[
+                SegmentRecord(
+                    index=0,
+                    steps_completed=102,
+                    steps_requested=102,
+                    samples_written=10,
+                    status=SegmentStatus.COMPLETED,
+                ),
+                SegmentRecord(
+                    index=1,
+                    steps_completed=3,
+                    steps_requested=3,
+                    samples_written=0,
+                    status=SegmentStatus.COMPLETED,
+                ),
+            ],
+        )
+        save_progress(tmp_path, progress)
+
+        layout = _make_engine().resolve_trajectory_layout(tmp_path, replicate=1)
+
+        assert layout.trajectory_paths == [prod0 / "production_0_trajectory.dcd"]
 
     def test_rejects_gapped_daisy_chain_segments(self, tmp_path: Path) -> None:
         """Canonical daisy-chain segment indices must be contiguous."""

--- a/tests/engines/test_openmm_reporting.py
+++ b/tests/engines/test_openmm_reporting.py
@@ -1,0 +1,34 @@
+"""Tests for OpenMM production reporting cadence."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from polyzymd.engines.openmm.engine import OpenMMEngine
+
+
+def test_run_local_derives_report_interval_from_samples() -> None:
+    """Requested trajectory samples determine the reporter interval."""
+    config = MagicMock()
+    production = config.simulation_phases.production
+    production.duration = 1000.0
+    production.samples = 2500
+    production.time_step = 2.0
+    production.checkpoint_interval = 60.0
+
+    with patch("polyzymd.cli.main._run_initial_segment") as run_initial_segment:
+        OpenMMEngine(config=config).run_local(
+            replicate=1,
+            working_dir=Path("run"),
+        )
+
+    run_initial_segment.assert_called_once_with(
+        sim_config=config,
+        working_dir=Path("run"),
+        replicate=1,
+        skip_build=False,
+        duration_ns=1000.0,
+        num_samples=2500,
+        timestep_fs=2.0,
+        report_interval=200000,
+        checkpoint_interval_s=60.0,
+    )

--- a/tests/exporters/test_gromacs.py
+++ b/tests/exporters/test_gromacs.py
@@ -180,6 +180,43 @@ def _posres_indices(itp_path: Path, define: str) -> list[int]:
     return indices
 
 
+class TestTemperatureRampMDP:
+    """Verify GROMACS annealing uses the schema-derived ramp duration."""
+
+    def test_annealing_duration_and_steps_are_derived_from_rate(self, caplog):
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        caplog.set_level("INFO")
+        stage = EquilibrationStageConfig(
+            name="heating",
+            temperature_start=60.0,
+            temperature_end=300.0,
+            temperature_increment=1.0,
+            temperature_interval_steps=600,
+            time_step=2.0,
+            samples=20,
+        )
+        generator = MDPGenerator.__new__(MDPGenerator)
+        generator._pressure = 1.0
+
+        params = generator._create_annealing_params(
+            stage=stage,
+            stage_num=1,
+            is_first_stage=True,
+        )
+
+        assert params.nsteps == 144000
+        assert params.annealing_time[0] == 0.0
+        assert params.annealing_time[1] == pytest.approx(1.2)
+        assert params.annealing_npoints == 241
+        assert params.annealing_time[-1] == pytest.approx(288.0)
+        assert params.annealing_temp[0] == 60.0
+        assert params.annealing_temp[-1] == 300.0
+        assert params.tau_t == pytest.approx(1.0)
+        assert "1 K every 600 steps" in caplog.text
+        assert "derived duration 0.288000 ns" in caplog.text
+
+
 def _assert_posres_indices_within_atom_count(itp_path: Path, define: str) -> None:
     """Assert generated position restraint indices are local to their ITP."""
     indices = _posres_indices(itp_path, define)

--- a/tests/exporters/test_gromacs.py
+++ b/tests/exporters/test_gromacs.py
@@ -12,6 +12,7 @@ Covers:
   _parse_itp_atom_and_residue_counts, _fix_gro_residue_numbering)
 """
 
+from bisect import bisect_right
 from importlib import resources
 from pathlib import Path
 from types import SimpleNamespace
@@ -183,6 +184,19 @@ def _posres_indices(itp_path: Path, define: str) -> list[int]:
 class TestTemperatureRampMDP:
     """Verify GROMACS annealing uses the schema-derived ramp duration."""
 
+    @staticmethod
+    def _interpolated_temperature(params, time_ps: float) -> float:
+        """Evaluate GROMACS' piecewise-linear reference temperature."""
+        index = bisect_right(params.annealing_time, time_ps) - 1
+        if index >= len(params.annealing_time) - 1:
+            return params.annealing_temp[-1]
+        left_time = params.annealing_time[index]
+        right_time = params.annealing_time[index + 1]
+        fraction = (time_ps - left_time) / (right_time - left_time)
+        return params.annealing_temp[index] + fraction * (
+            params.annealing_temp[index + 1] - params.annealing_temp[index]
+        )
+
     def test_annealing_duration_and_steps_are_derived_from_rate(self, caplog):
         from polyzymd.config.schema import EquilibrationStageConfig
 
@@ -207,14 +221,43 @@ class TestTemperatureRampMDP:
 
         assert params.nsteps == 144000
         assert params.annealing_time[0] == 0.0
-        assert params.annealing_time[1] == pytest.approx(1.2)
-        assert params.annealing_npoints == 241
+        assert params.annealing_time[1] == pytest.approx(1.198)
+        assert params.annealing_time[2] == pytest.approx(1.2)
+        assert params.annealing_npoints == 481
         assert params.annealing_time[-1] == pytest.approx(288.0)
         assert params.annealing_temp[0] == 60.0
         assert params.annealing_temp[-1] == 300.0
         assert params.tau_t == pytest.approx(1.0)
         assert "1 K every 600 steps" in caplog.text
         assert "derived duration 0.288000 ns" in caplog.text
+
+    def test_matches_openmm_temperature_at_every_integration_step(self):
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        stage = EquilibrationStageConfig(
+            name="heating",
+            temperature_start=100.0,
+            temperature_end=112.0,
+            temperature_increment=5.0,
+            temperature_interval_steps=3,
+            time_step=2.0,
+            samples=3,
+        )
+        generator = MDPGenerator.__new__(MDPGenerator)
+        generator._pressure = 1.0
+        params = generator._create_annealing_params(
+            stage=stage,
+            stage_num=1,
+            is_first_stage=True,
+        )
+
+        for step in range(params.nsteps + 1):
+            gromacs_temperature = self._interpolated_temperature(
+                params,
+                time_ps=step * params.dt,
+            )
+            openmm_temperature = stage.temperature_at_step(step, params.nsteps)
+            assert gromacs_temperature == pytest.approx(openmm_temperature)
 
 
 def _assert_posres_indices_within_atom_count(itp_path: Path, define: str) -> None:

--- a/tests/scripts/test_convert_legacy.py
+++ b/tests/scripts/test_convert_legacy.py
@@ -300,6 +300,7 @@ def test_generate_config_yaml_includes_engine_and_loads(
 
     data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     assert data["engine"] == "openmm"
+    assert "report_interval" not in data["simulation_phases"]["production"]
     config = SimulationConfig.from_yaml(config_path)
     assert config.engine == "openmm"
 

--- a/tests/simulation/test_progress.py
+++ b/tests/simulation/test_progress.py
@@ -518,6 +518,16 @@ class TestGetNextSegmentInfo:
         assert info["samples_to_write"] == 125  # Half the samples
         assert info["report_interval"] == 40000  # Same interval as full run
 
+    def test_non_boundary_resume_counts_absolute_report_steps(self):
+        seg = _make_segment(0, steps=25)
+        p = _make_progress(segments=[seg], total_steps=100, total_samples=10)
+
+        info = get_next_segment_info(p, total_steps=100, total_samples=10)
+
+        assert info is not None
+        assert info["report_interval"] == 10
+        assert info["samples_to_write"] == 8  # Frames at steps 30 through 100
+
     def test_complete_returns_none(self):
         segs = [_make_segment(0, steps=5000000), _make_segment(1, steps=5000000)]
         p = _make_progress(segments=segs, total_steps=10000000)
@@ -559,6 +569,18 @@ class TestGetNextSegmentInfo:
         assert info2 is not None
         assert info2["report_interval"] == expected_interval
         assert info2["samples_to_write"] == 25  # 250_000 // 10_000
+
+
+class TestCalculateReportInterval:
+    """Derive reporter cadence from requested trajectory frames."""
+
+    def test_rejects_nonpositive_inputs(self):
+        from polyzymd.simulation.progress import calculate_report_interval
+
+        with pytest.raises(ValueError, match="total_steps"):
+            calculate_report_interval(0, 10)
+        with pytest.raises(ValueError, match="total_samples"):
+            calculate_report_interval(100, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/simulation/test_runner.py
+++ b/tests/simulation/test_runner.py
@@ -4,6 +4,8 @@ These tests verify runner logic using mocks to avoid requiring a full
 OpenMM simulation setup (GPU, topology, system, etc.).
 """
 
+import gc
+import struct
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -206,44 +208,105 @@ class TestRampResumeFastForward:
 class TestRampResumeIntegrity:
     """Protect synchronized state and output handling for interrupted ramps."""
 
-    def test_stage_zero_resume_preserves_velocities(self):
-        import inspect
+    def test_reference_platform_interrupt_and_resume_appends_outputs(self, tmp_path, monkeypatch):
+        from openmm import System, Vec3, unit
+        from openmm.app import Element, Topology
 
+        from polyzymd.config.schema import EquilibrationStageConfig
+        from polyzymd.simulation import signals
         from polyzymd.simulation.runner import SimulationRunner
 
-        source = inspect.getsource(SimulationRunner.run_equilibration_stage)
+        class DeterministicRunner(SimulationRunner):
+            def _create_integrator(self, *args, **kwargs):
+                integrator = super()._create_integrator(*args, **kwargs)
+                integrator.setRandomNumberSeed(20260721)
+                return integrator
 
-        assert "stage_index == 0 and resume_from_step == 0" in source
+        class EmptyResolver:
+            @staticmethod
+            def resolve(_group):
+                return []
 
-    def test_interruption_checkpoint_precedes_marker(self):
-        import inspect
+        topology = Topology()
+        chain = topology.addChain("A")
+        residue = topology.addResidue("MOL", chain)
+        topology.addAtom("C", Element.getBySymbol("C"), residue)
+        system = System()
+        system.addParticle(12.0 * unit.dalton)
+        system.setDefaultPeriodicBoxVectors(
+            Vec3(2.0, 0.0, 0.0),
+            Vec3(0.0, 2.0, 0.0),
+            Vec3(0.0, 0.0, 2.0),
+        )
+        positions = [Vec3(0.0, 0.0, 0.0)] * unit.nanometer
+        stage = EquilibrationStageConfig(
+            name="heating",
+            temperature_start=100.0,
+            temperature_end=102.0,
+            temperature_increment=1.0,
+            temperature_interval_steps=5,
+            time_step=1.0,
+            samples=5,
+        )
 
-        from polyzymd.simulation.runner import SimulationRunner
+        monkeypatch.setattr(signals, "is_interrupted", lambda: True)
+        monkeypatch.setattr(signals, "get_interrupt_signal", lambda: 15)
+        runner = DeterministicRunner(
+            topology=topology,
+            system=system,
+            positions=positions,
+            working_dir=tmp_path,
+            platform="Reference",
+        )
+        with pytest.raises(signals.GracefulExit):
+            runner.run_equilibration_stage(
+                stage=stage,
+                reference_positions=positions,
+                atom_group_resolver=EmptyResolver(),
+                stage_index=0,
+            )
 
-        source = inspect.getsource(SimulationRunner.run_equilibration_stage)
-        helper = source[source.index("def _save_eq_interrupted") :]
+        stage_dir = tmp_path / "equilibration_0_heating"
+        marker = (stage_dir / "EQ_INTERRUPTED").read_text()
+        assert "steps_completed=5" in marker
+        assert "current_temperature=101.0" in marker
+        assert (stage_dir / "equilibration_0_heating_checkpoint.chk").is_file()
+        assert (stage_dir / "equilibration_0_heating_state.xml").is_file()
 
-        assert helper.index("saveCheckpoint") < helper.index("marker_path.write_text")
+        del runner
+        gc.collect()
+        monkeypatch.setattr(signals, "is_interrupted", lambda: False)
+        resumed = DeterministicRunner(
+            topology=topology,
+            system=system,
+            positions=positions,
+            working_dir=tmp_path,
+            platform="Reference",
+        )
+        resumed._load_eq_stage_state(0, "heating")
+        result = resumed.run_equilibration_stage(
+            stage=stage,
+            reference_positions=positions,
+            atom_group_resolver=EmptyResolver(),
+            stage_index=0,
+            resume_from_step=5,
+            resume_temperature=101.0,
+        )
 
-    def test_resume_appends_existing_reporter_outputs(self):
-        import inspect
-
-        from polyzymd.simulation.runner import SimulationRunner
-
-        source = inspect.getsource(SimulationRunner.run_equilibration_stage)
-
-        assert "append=append_trajectory" in source
-        assert "append=append_state_data" in source
-
-    def test_resume_restores_saved_step_and_time(self):
-        import inspect
-
-        from polyzymd.simulation.runner import SimulationRunner
-
-        source = inspect.getsource(SimulationRunner.run_equilibration_stage)
-
-        assert "self._simulation.currentStep = self._current_step_count" in source
-        assert "self._simulation.context.setTime(self._current_time)" in source
+        assert result["total_steps"] == 10
+        assert not (stage_dir / "EQ_INTERRUPTED").exists()
+        state_lines = (
+            (stage_dir / "equilibration_0_heating_state_data.csv").read_text().splitlines()
+        )
+        reported_steps = [
+            int(line.split(",", 1)[0]) for line in state_lines if not line.startswith("#")
+        ]
+        assert reported_steps == [2, 4, 6, 8, 10]
+        trajectory = stage_dir / "equilibration_0_heating_trajectory.dcd"
+        with trajectory.open("rb") as handle:
+            header = handle.read(12)
+        assert header[4:8] == b"CORD"
+        assert struct.unpack("<i", header[8:12])[0] == 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/simulation/test_runner.py
+++ b/tests/simulation/test_runner.py
@@ -135,229 +135,115 @@ class TestBarostatTemperatureRampUpdate:
 
 
 class TestRampInterruptTemperature:
-    """Verify the EQ_INTERRUPTED marker records the correct temperature (B4).
+    """Verify interrupted ramps recover temperature from completed steps."""
 
-    Before the fix, current_temp was incremented *before* the interrupt
-    check, so the marker would record a temperature one increment higher
-    than what was actually simulated.
-    """
+    @staticmethod
+    def _make_ramp():
+        from polyzymd.config.schema import EquilibrationStageConfig
 
-    def test_increment_after_interrupt_check(self):
-        """current_temp must be incremented AFTER the interrupt check, not before.
-
-        We verify by inspecting the source code structure: in the ramp
-        ``while`` loop, ``is_interrupted()`` must appear before
-        ``current_temp += stage.temperature_increment``.
-        """
-        import inspect
-
-        from polyzymd.simulation.runner import SimulationRunner
-
-        source = inspect.getsource(SimulationRunner.run_equilibration_stage)
-        lines = source.split("\n")
-
-        # Find the ramp while-loop body (contains "while current_temp <")
-        in_ramp_loop = False
-        interrupt_line = None
-        increment_line = None
-
-        for i, line in enumerate(lines):
-            if "while current_temp < stage.temperature_end:" in line:
-                in_ramp_loop = True
-                continue
-            if in_ramp_loop:
-                # Detect end of while loop (de-indented line that isn't blank)
-                stripped = line.strip()
-                if stripped.startswith("# Final temperature"):
-                    break
-                if "is_interrupted()" in stripped and interrupt_line is None:
-                    interrupt_line = i
-                if "current_temp += stage.temperature_increment" in stripped:
-                    if increment_line is None or i > (interrupt_line or 0):
-                        increment_line = i
-
-        assert interrupt_line is not None, "is_interrupted() not found in ramp loop"
-        assert increment_line is not None, "current_temp increment not found in ramp loop"
-        assert increment_line > interrupt_line, (
-            f"current_temp increment (line {increment_line}) must come AFTER "
-            f"is_interrupted() check (line {interrupt_line})"
+        return EquilibrationStageConfig(
+            name="heating",
+            temperature_start=100.0,
+            temperature_end=400.0,
+            temperature_increment=10.0,
+            temperature_interval_steps=5000,
+            samples=10,
         )
 
-    def test_save_eq_interrupted_uses_current_not_next_temp(self):
-        """_save_eq_interrupted must be called with the temperature of the
-        last-run chunk, not the next chunk's temperature.
+    def test_completed_step_temperature_is_recorded(self):
+        stage = self._make_ramp()
+        total_steps = int(stage.resolved_duration * 1e6 / 2.0)
 
-        We verify by checking that _save_eq_interrupted(steps_done, current_temp)
-        appears between is_interrupted() and current_temp += increment.
-        """
-        import inspect
+        assert stage.temperature_at_step(total_steps // 4, total_steps) == pytest.approx(170.0)
 
-        from polyzymd.simulation.runner import SimulationRunner
+    def test_temperature_changes_at_requested_step_boundary(self):
+        stage = self._make_ramp()
+        total_steps = int(stage.resolved_duration * 1e6 / 2.0)
 
-        source = inspect.getsource(SimulationRunner.run_equilibration_stage)
-        lines = source.split("\n")
+        assert stage.temperature_at_step(4999, total_steps) == pytest.approx(100.0)
+        assert stage.temperature_at_step(5000, total_steps) == pytest.approx(110.0)
 
-        in_ramp_loop = False
-        interrupt_idx = None
-        save_marker_idx = None
-        increment_idx = None
+    def test_temperature_schedule_clamps_to_endpoints(self):
+        stage = self._make_ramp()
+        total_steps = int(stage.resolved_duration * 1e6 / 2.0)
 
-        for i, line in enumerate(lines):
-            if "while current_temp < stage.temperature_end:" in line:
-                in_ramp_loop = True
-                continue
-            if in_ramp_loop:
-                stripped = line.strip()
-                if stripped.startswith("# Final temperature"):
-                    break
-                if "is_interrupted()" in stripped and interrupt_idx is None:
-                    interrupt_idx = i
-                if "_save_eq_interrupted(steps_done, current_temp)" in stripped:
-                    save_marker_idx = i
-                if "current_temp += stage.temperature_increment" in stripped:
-                    increment_idx = i
-
-        assert interrupt_idx is not None
-        assert save_marker_idx is not None
-        assert increment_idx is not None
-        assert interrupt_idx < save_marker_idx < increment_idx, (
-            f"Expected order: is_interrupted ({interrupt_idx}) < "
-            f"_save_eq_interrupted ({save_marker_idx}) < "
-            f"temp increment ({increment_idx})"
-        )
+        assert stage.temperature_at_step(-1, total_steps) == pytest.approx(100.0)
+        assert stage.temperature_at_step(total_steps + 1, total_steps) == pytest.approx(400.0)
 
 
 class TestRampResumeFastForward:
-    """Verify temperature ramp resume starts from temperature_start, not resume_temperature (B5).
+    """Verify resumed ramps calculate temperature directly from elapsed steps."""
 
-    Before the fix, the ramp loop initialized current_temp from the
-    resume_temperature (saved in the EQ_INTERRUPTED marker) and then
-    ALSO fast-forwarded by incrementing during skipped chunks, causing a
-    double-count that made the simulation jump ahead in temperature.
-    """
+    def test_resume_uses_elapsed_fraction(self):
+        from polyzymd.config.schema import EquilibrationStageConfig
 
-    def test_resume_starts_from_temperature_start(self):
-        """On resume, current_temp must start from stage.temperature_start,
-        not from resume_temperature.
-        """
+        stage = EquilibrationStageConfig(
+            name="heating",
+            temperature_start=200.0,
+            temperature_end=500.0,
+            temperature_increment=10.0,
+            temperature_interval_steps=10000,
+        )
+        total_steps = int(stage.resolved_duration * 1e6 / 2.0)
+
+        assert stage.temperature_at_step(total_steps // 2, total_steps) == pytest.approx(350.0)
+
+    def test_completed_ramp_uses_final_temperature(self):
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        stage = EquilibrationStageConfig(
+            name="heating",
+            temperature_start=100.0,
+            temperature_end=130.0,
+            temperature_increment=10.0,
+            temperature_interval_steps=5000,
+        )
+        total_steps = int(stage.resolved_duration * 1e6 / 2.0)
+
+        assert stage.temperature_at_step(total_steps, total_steps) == pytest.approx(130.0)
+
+
+class TestRampResumeIntegrity:
+    """Protect synchronized state and output handling for interrupted ramps."""
+
+    def test_stage_zero_resume_preserves_velocities(self):
         import inspect
 
         from polyzymd.simulation.runner import SimulationRunner
 
         source = inspect.getsource(SimulationRunner.run_equilibration_stage)
-        lines = source.split("\n")
 
-        # Find the ramp section (between "is_temperature_ramping" and the while loop)
-        in_ramp_section = False
-        found_unconditional_start = False
+        assert "stage_index == 0 and resume_from_step == 0" in source
 
-        for line in lines:
-            stripped = line.strip()
-            if "if stage.is_temperature_ramping:" in stripped:
-                in_ramp_section = True
-                continue
-            if in_ramp_section:
-                # Check that current_temp is set to temperature_start unconditionally
-                if "current_temp = stage.temperature_start" in stripped:
-                    found_unconditional_start = True
-                # Make sure we don't find current_temp = resume_temperature
-                if "current_temp = resume_temperature" in stripped:
-                    pytest.fail(
-                        "current_temp should NOT be set from resume_temperature; "
-                        "fast-forward loop handles temperature advancement"
-                    )
-                if "while current_temp < stage.temperature_end:" in stripped:
-                    break
+    def test_interruption_checkpoint_precedes_marker(self):
+        import inspect
 
-        assert found_unconditional_start, (
-            "current_temp must be set to stage.temperature_start unconditionally "
-            "before the ramp while-loop"
-        )
+        from polyzymd.simulation.runner import SimulationRunner
 
-    def test_fast_forward_produces_correct_temperature(self):
-        """Simulate the fast-forward loop logic and verify the resumed
-        temperature is correct.
-        """
-        # Ramp parameters
-        temp_start = 100.0
-        temp_end = 400.0
-        temp_increment = 10.0
-        steps_per_update = 1000
+        source = inspect.getsource(SimulationRunner.run_equilibration_stage)
+        helper = source[source.index("def _save_eq_interrupted") :]
 
-        # Simulate: ran chunks at 100, 110, 120 K (3000 steps completed)
-        resume_from_step = 3000
+        assert helper.index("saveCheckpoint") < helper.index("marker_path.write_text")
 
-        # --- Replicate the fixed resume logic ---
-        current_temp = temp_start  # always start from temp_start
-        ramp_step_count = 0
-        first_run_temp = None
+    def test_resume_appends_existing_reporter_outputs(self):
+        import inspect
 
-        while current_temp < temp_end:
-            chunk_end = ramp_step_count + steps_per_update
-            if chunk_end <= resume_from_step:
-                ramp_step_count = chunk_end
-                current_temp += temp_increment
-                continue
+        from polyzymd.simulation.runner import SimulationRunner
 
-            # This is the first non-skipped chunk
-            first_run_temp = current_temp
-            break
+        source = inspect.getsource(SimulationRunner.run_equilibration_stage)
 
-        # After running 100, 110, 120, the next should be 130
-        message = (
-            f"Expected next temperature 130.0 K after running 100, 110, 120 K; got {first_run_temp}"
-        )
-        assert first_run_temp == pytest.approx(130.0), message
+        assert "append=append_trajectory" in source
+        assert "append=append_state_data" in source
 
-    def test_fast_forward_handles_no_resume(self):
-        """Fresh start (no resume) should begin at temperature_start."""
-        temp_start = 200.0
-        temp_end = 500.0
-        temp_increment = 5.0
-        steps_per_update = 500
-        resume_from_step = 0
+    def test_resume_restores_saved_step_and_time(self):
+        import inspect
 
-        current_temp = temp_start
-        ramp_step_count = 0
-        first_run_temp = None
+        from polyzymd.simulation.runner import SimulationRunner
 
-        while current_temp < temp_end:
-            chunk_end = ramp_step_count + steps_per_update
-            if chunk_end <= resume_from_step:
-                ramp_step_count = chunk_end
-                current_temp += temp_increment
-                continue
-            first_run_temp = current_temp
-            break
+        source = inspect.getsource(SimulationRunner.run_equilibration_stage)
 
-        assert first_run_temp == pytest.approx(200.0)
-
-    def test_fast_forward_all_chunks_done(self):
-        """If all ramp chunks are done, the loop should exit and go to final temp."""
-        temp_start = 100.0
-        temp_end = 130.0
-        temp_increment = 10.0
-        steps_per_update = 1000
-        # 3 chunks: 100, 110, 120 → 3000 steps
-        resume_from_step = 3000
-
-        current_temp = temp_start
-        ramp_step_count = 0
-        first_run_temp = None
-
-        while current_temp < temp_end:
-            chunk_end = ramp_step_count + steps_per_update
-            if chunk_end <= resume_from_step:
-                ramp_step_count = chunk_end
-                current_temp += temp_increment
-                continue
-            first_run_temp = current_temp
-            break
-
-        # All ramp chunks completed, should go to final temp section
-        assert first_run_temp is None, "Expected no non-skipped chunk (all ramp chunks done)"
-        message = f"current_temp should equal temp_end ({temp_end}) after fast-forward"
-        assert current_temp == pytest.approx(130.0), message
+        assert "self._simulation.currentStep = self._current_step_count" in source
+        assert "self._simulation.context.setTime(self._current_time)" in source
 
 
 # ---------------------------------------------------------------------------
@@ -387,6 +273,127 @@ class TestLoadCheckpointRestoresVelocities:
         src = inspect.getsource(SimulationRunner.load_checkpoint)
         assert "_current_velocities" in src, "load_checkpoint must update self._current_velocities"
         assert "getVelocities()" in src, "load_checkpoint must call state.getVelocities()"
+
+
+class TestEquilibrationPortableState:
+    """Portable equilibration state avoids binary System compatibility issues."""
+
+    def test_load_prefers_portable_state(self, tmp_path):
+        from unittest.mock import patch
+
+        from polyzymd.simulation.runner import SimulationRunner
+
+        stage_dir = tmp_path / "equilibration_0_heating"
+        stage_dir.mkdir()
+        (stage_dir / "equilibration_0_heating_state.xml").write_text("<State/>")
+        state = MagicMock()
+        state.getPositions.return_value = "positions"
+        state.getVelocities.return_value = "velocities"
+        state.getPeriodicBoxVectors.return_value = "box"
+        state.getStepCount.return_value = 1234
+        state.getTime.return_value = "time"
+        runner = SimulationRunner.__new__(SimulationRunner)
+        runner._working_dir = tmp_path
+        serializer = MagicMock()
+        serializer.deserialize.return_value = state
+
+        with patch("polyzymd.simulation.runner.XmlSerializer", serializer):
+            runner._load_eq_stage_state(0, "heating")
+
+        assert runner._current_positions == "positions"
+        assert runner._current_velocities == "velocities"
+        assert runner._current_box_vectors == "box"
+        assert runner._current_step_count == 1234
+        assert runner._current_time == "time"
+
+
+class TestEquilibrationResumeMetadata:
+    """Resume markers must match the current derived stage schedule."""
+
+    @staticmethod
+    def _stage():
+        from polyzymd.config.schema import EquilibrationStageConfig
+
+        return EquilibrationStageConfig(
+            name="heating",
+            temperature_start=60.0,
+            temperature_end=300.0,
+            temperature_increment=1.0,
+            temperature_interval_steps=500,
+            time_step=2.0,
+        )
+
+    def test_rejects_changed_total_steps(self):
+        from polyzymd.simulation.runner import SimulationRunner
+
+        stage = self._stage()
+        total_steps = int(stage.resolved_duration * 1e6 / 2.0)
+
+        with pytest.raises(RuntimeError, match="current configuration"):
+            SimulationRunner._validate_eq_resume_metadata(
+                stage,
+                resume_step=100,
+                saved_total_steps=total_steps + 1,
+                saved_temperature=stage.temperature_at_step(100, total_steps),
+                saved_temperature_start=stage.temperature_start,
+                saved_temperature_end=stage.temperature_end,
+                saved_temperature_increment=stage.temperature_increment,
+                saved_temperature_interval_steps=stage.temperature_interval_steps,
+            )
+
+    def test_rejects_changed_ramp_temperature(self):
+        from polyzymd.simulation.runner import SimulationRunner
+
+        stage = self._stage()
+        total_steps = int(stage.resolved_duration * 1e6 / 2.0)
+
+        with pytest.raises(RuntimeError, match="current schedule"):
+            SimulationRunner._validate_eq_resume_metadata(
+                stage,
+                resume_step=100,
+                saved_total_steps=total_steps,
+                saved_temperature=100.0,
+                saved_temperature_start=stage.temperature_start,
+                saved_temperature_end=stage.temperature_end,
+                saved_temperature_increment=stage.temperature_increment,
+                saved_temperature_interval_steps=stage.temperature_interval_steps,
+            )
+
+    def test_rejects_changed_increment_schedule(self):
+        from polyzymd.simulation.runner import SimulationRunner
+
+        stage = self._stage()
+        total_steps = int(stage.resolved_duration * 1e6 / 2.0)
+
+        with pytest.raises(RuntimeError, match="marker schedule"):
+            SimulationRunner._validate_eq_resume_metadata(
+                stage,
+                resume_step=100,
+                saved_total_steps=total_steps,
+                saved_temperature=stage.temperature_at_step(100, total_steps),
+                saved_temperature_start=stage.temperature_start,
+                saved_temperature_end=stage.temperature_end,
+                saved_temperature_increment=2.0,
+                saved_temperature_interval_steps=stage.temperature_interval_steps,
+            )
+
+    def test_accepts_matching_schedule(self):
+        from polyzymd.simulation.runner import SimulationRunner
+
+        stage = self._stage()
+        total_steps = int(stage.resolved_duration * 1e6 / 2.0)
+        resume_step = total_steps // 2
+
+        SimulationRunner._validate_eq_resume_metadata(
+            stage,
+            resume_step=resume_step,
+            saved_total_steps=total_steps,
+            saved_temperature=stage.temperature_at_step(resume_step, total_steps),
+            saved_temperature_start=stage.temperature_start,
+            saved_temperature_end=stage.temperature_end,
+            saved_temperature_increment=stage.temperature_increment,
+            saved_temperature_interval_steps=stage.temperature_interval_steps,
+        )
 
 
 def _write_eq_stage(
@@ -565,7 +572,7 @@ class TestFindInterruptedEqStage:
         assert info is None
 
     def test_interrupted_without_checkpoint_returns_none(self, tmp_path):
-        """EQ_INTERRUPTED marker without checkpoint can't resume."""
+        """EQ_INTERRUPTED marker without state or checkpoint can't resume."""
         stages = [self._make_stage("heating")]
         dir_name = "equilibration_0_heating"
         stage_dir = tmp_path / dir_name
@@ -578,6 +585,24 @@ class TestFindInterruptedEqStage:
         runner = self._make_runner(tmp_path)
         info = runner._find_interrupted_eq_stage(stages, completed_indices=[])
         assert info is None
+
+    def test_interrupted_with_portable_state_can_resume(self, tmp_path):
+        stages = [self._make_stage("heating")]
+        dir_name = "equilibration_0_heating"
+        stage_dir = tmp_path / dir_name
+        stage_dir.mkdir()
+        (stage_dir / "EQ_INTERRUPTED").write_text(
+            "stage_index=0\nstage_name=heating\n"
+            "steps_completed=5000\ntotal_steps=10000\n"
+            "current_temperature=200.0\nis_temperature_ramping=True\n"
+        )
+        (stage_dir / f"{dir_name}_state.xml").write_text("<State/>")
+        runner = self._make_runner(tmp_path)
+
+        info = runner._find_interrupted_eq_stage(stages, completed_indices=[])
+
+        assert info is not None
+        assert info["steps_completed"] == 5000
 
     def test_temperature_ramping_metadata(self, tmp_path):
         stages = [self._make_stage("ramp")]

--- a/tests/workflow/test_daisy_chain.py
+++ b/tests/workflow/test_daisy_chain.py
@@ -25,7 +25,6 @@ def _simulation_config_data(tmp_path: Path) -> dict:
                 "ensemble": "NPT",
                 "duration": 100.0,
                 "samples": 10,
-                "report_interval": 50000,
                 "checkpoint_interval": 60.0,
             },
         },


### PR DESCRIPTION
## Summary

- derive trajectory report cadence from the requested sample count and handle segment boundaries consistently
- replace decimal heating rates with explicit temperature increments and step intervals across validation, OpenMM, GROMACS, templates, and docs
- make OpenMM and GROMACS hold each ramp target for the same number of integration steps, with the same boundary updates
- make equilibration ramp resumes preserve state and schedule progress safely
- preserve legacy duration-based ramp configs through a targeted, one-time migration warning

## Testing

- full test suite: 2483 passed
- focused schema, GROMACS exporter, and simulation runner tests: 152 passed
- Ruff checks passed for `src/`, `tests/`, and `scripts/`
- Black check passed for `src/`, `tests/`, and `scripts/`
- Sphinx clean build passed with warnings treated as errors
- OpenMM Reference-platform interruption/resume test verifies checkpoint/state recovery and appended CSV/DCD outputs
- generated GROMACS annealing schedule matches OpenMM's target at every integration step, including a partial final increment
- validated the CALB configuration as +1 K every 600 steps for 283 updates and 0.339600 ns

The build environment does not include a `gmx` executable, so GROMACS preprocessing/runtime execution was not repeated here.
