### PR TITLE
docs(agent): formalize development workflow

### DIFF
--- a/.opencode/instructions/development-workflow.md
+++ b/.opencode/instructions/development-workflow.md
@@ -90,6 +90,25 @@ every PR manually.
 
 The GitHub connector lacked PR-write permission, so I used the authenticated gh fallback. I will not merge it.
 
+## Maintain Living Guidance
+
+At the end of each change, compare every loaded repository instruction, Skill,
+and reference against the behavior and tool access observed during the task.
+When code, scientific contracts, commands, branch names, release policy,
+documentation structure, tools, permissions, or recurring workflows change:
+
+1. Update the affected repository guidance and personal PolyzyMD Skill in the
+   same atomic task when access and scope permit.
+2. Remove or revise obsolete branch aliases, commands, limitations, and
+   workarounds instead of accumulating contradictory history.
+3. Validate edited Skills with the Skill validator and run the relevant
+   repository documentation or static gates.
+4. If the guidance cannot be updated, report the exact stale file and proposed
+   replacement text to Joe before closing the task.
+
+Only persist evidence-backed, reusable knowledge. Do not turn a one-off failure
+or system-specific tuning choice into a universal rule.
+
 ## Release Flow
 
 - `main` contains released code.

--- a/.opencode/instructions/development-workflow.md
+++ b/.opencode/instructions/development-workflow.md
@@ -1,0 +1,104 @@
+# Development Workflow
+
+## Project Priorities
+
+Optimize PolyzyMD work in this order:
+
+1. Scientific correctness and reproducibility.
+2. Low-friction user experience.
+3. OpenMM and GROMACS parity for engine-facing features.
+4. Small, reviewable, maintainable changes.
+5. Documentation that matches the code.
+
+Joe retains authority over scientific assumptions and release readiness. Pause
+and ask before choosing chemistry, topology, parameterization, force-field, or
+scientific-interpretation assumptions. Do not silently substitute agent
+judgment in these areas.
+
+## Collaboration and Progress
+
+- Use one writer per worktree. Give review, architecture, documentation, and
+  validation agents read-only roles unless they receive an explicit writing
+  handoff.
+- Use separate worktrees for parallel writing tasks.
+- Report milestone updates rather than every command. Useful milestones include
+  scope confirmation, implementation completion, focused tests, engine-specific
+  artifacts, parity checks, short dynamics, documentation, and independent
+  review.
+- Keep work steerable. When evidence changes the likely implementation path,
+  report it before expanding the scope.
+
+## Atomic Scope
+
+Start from one end-user goal and define explicit non-goals. A pull request must
+be a small, self-contained, independent change that addresses one well-defined
+goal. Multiple atomic PRs may compose a larger feature.
+
+- Below roughly 300 changed lines: normally proceed.
+- Above 300 changed lines: inspect for scope creep, generated content, and
+  excessive tests; split when independent behavior exists.
+- Above 500 changed lines: pause and explain why the change cannot be divided.
+
+Test code counts toward the review burden. Prefer the smallest test set that
+proves the behavior and protects the scientific contract. Do not add layers of
+repetitive fixtures, mocks, or abstractions without a concrete failure mode.
+
+Treat `and` in a commit or PR subject as a signal to check whether two units of
+work should be separated. It is a scope heuristic, not a grammatical ban.
+
+## Validation and Engine Parity
+
+Use a proportional validation ladder: static checks, focused tests, subsystem
+tests, representative integration, scientific acceptance, broad regression,
+and documentation. Expensive validation must follow cheaper gates.
+
+Engine-facing features require OpenMM and GROMACS coverage. Match molecular
+identity and intended mechanics: particles, masses, bonds, constraints,
+charges, parameters, exclusions/pairs, coordinates, and box. Allow justified
+numerical differences caused by engine algorithms, including small PME energy
+differences; document the tolerance and evidence.
+
+On `jlaforetlaptop`, query OpenMM's API for available platforms before choosing
+CUDA. Do not assume that a platform is available from the machine name alone.
+
+When visual molecular inspection remains necessary, hand Joe absolute paths to
+the topology and, when available, trajectory. State what automation checked and
+what still requires his PyMOL judgment.
+
+## Commits and Publication
+
+After an atomic change passes its required gates:
+
+1. Review the complete owned diff.
+2. Verify `git config user.name` and `git config user.email` identify Joe.
+3. Create an atomic conventional commit using the configured identity.
+4. Explain non-obvious decisions and scientific intent in the commit body.
+5. Do not add Codex branding, generated-by text, or co-author trailers.
+6. Push validated commits to the working branch automatically for authorized
+   development tasks.
+
+Do not commit or push incomplete, failing, or scientifically unresolved work.
+Read-only inspection does not authorize commits or pushes. Never force-push a
+published/shared branch without Joe's explicit approval; use
+`--force-with-lease` only after that approval.
+
+Do not open a pull request until Joe confirms development is complete. After
+confirmation, Codex opens the PR and reports the user goal, rationale,
+scientific assumptions, validation, documentation, artifact paths, limitations,
+linked issues, and dependencies. Codex never merges PRs; Joe reads and merges
+every PR manually.
+
+## Release Flow
+
+- `main` contains released code.
+- `release/1.3` stabilizes the v1.3 analysis release. Until migration, its
+  current branch name is `feature/v1.3.0-rc5`.
+- `release/1.4` integrates conjugation work. Until migration, its current branch
+  name is `conjugation-engine-refactor`.
+- Branch bug fixes from the current release line and merge them back through
+  atomic PRs.
+- Tag immutable beta snapshots as `vX.Y.Z-rc.N`.
+- Forward-integrate release-line fixes into the next release line regularly.
+- Run lightweight lint, import, unit, and documentation checks on ordinary PRs.
+  Reserve GPU simulations and resource-intensive scientific regression for
+  feature acceptance and major release gates.

--- a/.opencode/instructions/development-workflow.md
+++ b/.opencode/instructions/development-workflow.md
@@ -88,6 +88,8 @@ scientific assumptions, validation, documentation, artifact paths, limitations,
 linked issues, and dependencies. Codex never merges PRs; Joe reads and merges
 every PR manually.
 
+The GitHub connector lacked PR-write permission, so I used the authenticated gh fallback. I will not merge it.
+
 ## Release Flow
 
 - `main` contains released code.

--- a/.opencode/instructions/documentation.md
+++ b/.opencode/instructions/documentation.md
@@ -1,5 +1,70 @@
 # Documentation Rules
 
+## Audience and Purpose
+
+Read the Docs is the canonical interface through which humans and agents learn
+what PolyzyMD can do, how to use it, and where its implementation lives. Write
+for undergraduate learners, PhD researchers, industry users, experimentalists,
+and readers who use English as an additional language.
+
+- Keep documentation synchronized whenever code changes commands,
+  configuration, outputs, workflows, public contracts, or scientific meaning.
+- Prefer direct, concrete language, short sentences, explicit prerequisites,
+  copyable commands, expected outcomes, and clear next steps.
+- Remove repetitive summaries, generic claims, canned transitions, and vague
+  adjectives that make prose sound machine-generated.
+- Use `docs/source/get_started/quickstart.md` as the primary voice and workflow
+  reference.
+
+## Diataxis Roles
+
+Keep each page centered on one Diataxis purpose:
+
+- `get_started/` and `tutorials/`: learning-oriented guided experiences.
+- `how_to/`: task-oriented procedures for a known goal.
+- `reference/`: factual lookup, schemas, commands, compatibility, and code maps.
+- `explanation/`: concepts, design decisions, tradeoffs, and scientific context.
+
+Do not turn a tutorial into an API inventory or hide required procedure inside
+an explanation page. Link between page types instead of duplicating content.
+
+## Workflow and Usability Review
+
+Canonical workflows must show prerequisites, exact commands, expected
+artifacts, success criteria, common recovery paths, and the next likely task.
+Show OpenMM and GROMACS paths with equal visibility when both are supported.
+
+For a new or materially changed workflow page, use a fresh-context, read-only
+reviewer to follow the documented task as a novice. Give the reviewer the page
+and necessary environment, not the intended verdict. Fix factual gaps,
+ambiguous steps, hidden prerequisites, and unnecessary cognitive load before
+calling the documentation complete.
+
+Audit prose in separate passes for:
+
+1. Fidelity to current code and tested behavior.
+2. Diataxis structure and completeness.
+3. Plain English and removal of machine-like filler.
+4. Novice task completion and navigation.
+
+## Source Navigation for Agents
+
+Use stable semantic references instead of fragile line links:
+
+- Name repository paths and public symbols explicitly, for example
+  `src/polyzymd/builders/solvent.py` and `SolventBuilder.solvate_from_config()`.
+- Use MyST Python roles for rendered API links.
+- Link to packages or symbols, not exact source line numbers.
+- Avoid handwritten GitHub blob links when a repository path or Sphinx
+  cross-reference is sufficient.
+- End implementation-heavy pages with a compact `Implementation references`
+  section that routes to the CLI, configuration, public API, implementation,
+  and tests without interrupting the user workflow.
+
+Maintain a reference-oriented code map that connects user tasks to canonical
+documentation, CLI commands or public APIs, implementation packages, and test
+locations. Do not catalog every private helper.
+
 ## Stack
 
 - **Engine:** Sphinx 8.x

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,17 @@ outside the managed pixi environment.
 See `.opencode/instructions/development-workflow.md` for collaboration,
 scope, validation, authorship, push, and PR rules.
 
+## Harness Capabilities and Living Guidance
+
+The GitHub connector lacked PR-write permission, so I used the authenticated gh fallback. I will not merge it.
+
+Treat `AGENTS.md`, `.opencode/instructions/`, and the personal PolyzyMD Skills
+as living guidance. When repository behavior, scientific contracts, branch
+names, tools, permissions, or recurring workflows change, update the affected
+guidance in the same atomic task so future agents do not follow stale rules.
+Validate edited Skills and run the relevant repository documentation or static
+checks before committing.
+
 ## Architecture Quick Reference
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,23 @@ outside the managed pixi environment.
 
 ## Git Workflow
 
-- **Branches:** `main` (stable), `dev` (integration), `feature/*` (work)
-- Currently on `feature/mda-analysis-migration`
-- Commit messages: imperative mood, 50-char subject, reference issues (`#20`)
+- **Branches:** `main` (released), `release/*` (release integration), short-lived
+  `fix/*` and `feature/*` branches (atomic work)
+- Until the branch migration is complete, treat `feature/v1.3.0-rc5` as
+  `release/1.3` and `conjugation-engine-refactor` as `release/1.4`.
+- Mark beta snapshots with immutable SemVer prerelease tags such as
+  `v1.3.0-rc.1`; do not create a new mutable branch for each snapshot.
+- Forward-integrate stabilized v1.3 fixes into the v1.4 integration branch so
+  conjugation work does not drift. Prefer merges for published/shared stacks
+  and rebases for unpublished local work.
+- Use conventional commits with an imperative subject near 50 characters.
+  Keep each commit atomic and explain important reasoning in the body.
 - Run `ruff check` and `black --check` before committing
-- Never force-push to `main` or `dev`
+- Never force-push to `main`, `dev`, or `release/*`.
+- Never merge a pull request. Joe reviews every PR and merges it manually.
+
+See `.opencode/instructions/development-workflow.md` for collaboration,
+scope, validation, authorship, push, and PR rules.
 
 ## Architecture Quick Reference
 
@@ -204,6 +216,8 @@ See `.opencode/instructions/` for detailed rules on specific topics:
 - `architecture.md` — module structure, design patterns, extension points
 - `environment.md` — pixi environment setup, dependency management, CI
 - `testing.md` — test infrastructure, running tests, writing new tests
+- `development-workflow.md` — release flow, atomic scope, agent
+  collaboration, commits, pushes, and PR handoff
 - `analysis-module.md` — analysis plugin system patterns and contracts
 - `documentation.md` — Sphinx/MyST conventions, API docs, zero-warning build gate, `:no-index:` rules
 - `openff-pdb-ingestion.md` — OpenFF protein/PDB ingestion troubleshooting and living error-log rules


### PR DESCRIPTION
## Summary

- codify PolyzyMD's single-writer, milestone-based agent collaboration model
- define atomic scope gates, scientific escalation points, validation tiers, and OpenMM/GROMACS parity expectations
- document the release-candidate, commit, push, PR, and human-only merge workflow
- establish Read the Docs as the canonical human and agent interface using Diataxis, plain-language review, and stable implementation references

## Why

PolyzyMD is developed through long-running agent-assisted workflows across multiple release lines and worktrees. These rules preserve scientific authority, keep changes reviewable, prevent branch drift, and make future Codex sessions follow the same development and documentation practices without repeating project onboarding.

## Validation

- `python3 .../quick_validate.py .../polyzymd-development`
- `python3 .../quick_validate.py .../polyzymd-md-validation`
- `pixi run -e build make -C docs clean html` — succeeded with zero Sphinx warnings
- `pixi run -e build ruff check src/` — passed
- `pixi run -e build black src/ --check` — 177 files unchanged

## Scope

This PR changes agent and documentation policy only. It does not change PolyzyMD runtime behavior.
